### PR TITLE
Fixes on the CRD support

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go
@@ -657,11 +657,18 @@ func (r *crdHandler) getOrCreateServingInfoFor(uid types.UID, name string) (*crd
 	}
 
 	openAPIModels, err := buildOpenAPIModelsForApply(r.staticOpenAPISpec, crd)
+	var modelsByGKV openapi.ModelsByGKV
+
 	if err != nil {
 		utilruntime.HandleError(fmt.Errorf("error building openapi models for %s: %v", crd.Name, err))
 		openAPIModels = nil
+	} else {
+		modelsByGKV, err = openapi.GetModelsByGKV(openAPIModels)
+		if err != nil {
+			utilruntime.HandleError(fmt.Errorf("error gathering openapi models by GKV for %s: %v", crd.Name, err))
+			modelsByGKV = nil
+		}
 	}
-
 	safeConverter, unsafeConverter, err := r.converterFactory.NewConverter(crd)
 	if err != nil {
 		return nil, err
@@ -804,10 +811,6 @@ func (r *crdHandler) getOrCreateServingInfoFor(uid types.UID, name string) (*crd
 			standardSerializers = append(standardSerializers, s)
 		}
 
-		modelsByGKV, err := openapi.GetModelsByGKV(openAPIModels)
-		if err != nil {
-			klog.V(2).Infof("The CRD cannot gather openapi models by GKV: %v", err)
-		}
 		requestScopes[v.Name] = &handlers.RequestScope{
 			Namer: handlers.ContextBasedNaming{
 				SelfLinker:         meta.NewAccessor(),

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/builder/builder.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/builder/builder.go
@@ -509,11 +509,6 @@ func (b *builder) getOpenAPIConfig() *common.Config {
 		GetOperationIDAndTags: openapi.GetOperationIDAndTags,
 		GetDefinitionName: func(name string) (string, spec.Extensions) {
 			buildDefinitions.Do(buildDefinitionsFunc)
-			// HACK: support the case when we add core or other legacy scheme resources through CRDs (KCP scenario)
-			parts := strings.Split(name, "/")
-			if len(parts) == 2 {
-				name = packagePrefix(parts[0])
-			}
 			return namer.GetDefinitionName(name)
 		},
 		GetDefinitions: func(ref common.ReferenceCallback) map[string]common.OpenAPIDefinition {


### PR DESCRIPTION
This PR contains 2 fixes on the CRD support that prevented working with non-legacy-scheme CRDs.

See the commit description for more details.