### PR TITLE
CRD tenancy

### DIFF
--- a/cmd/kube-apiserver/app/aggregator.go
+++ b/cmd/kube-apiserver/app/aggregator.go
@@ -297,7 +297,7 @@ var apiVersionPriorities = map[schema.GroupVersion]priority{
 func apiServicesToRegister(delegateAPIServer genericapiserver.DelegationTarget, registration autoregister.AutoAPIServiceRegistration) []*v1.APIService {
 	apiServices := []*v1.APIService{}
 
-	for _, curr := range delegateAPIServer.ListedPaths() {
+	for _, curr := range delegateAPIServer.ListedPaths("") {
 		if curr == "/api/v1" {
 			apiService := makeAPIService(schema.GroupVersion{Group: "", Version: "v1"})
 			registration.AddAPIServiceToSyncOnStart(apiService)

--- a/pkg/controlplane/aggregator.go
+++ b/pkg/controlplane/aggregator.go
@@ -183,7 +183,10 @@ func makeAPIService(gv schema.GroupVersion) *v1.APIService {
 		return nil
 	}
 	return &v1.APIService{
-		ObjectMeta: metav1.ObjectMeta{Name: gv.Version + "." + gv.Group},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        gv.Version + "." + gv.Group,
+			ClusterName: RootClusterName,
+		},
 		Spec: v1.APIServiceSpec{
 			Group:                gv.Group,
 			Version:              gv.Version,
@@ -271,7 +274,7 @@ var apiVersionPriorities = map[schema.GroupVersion]priority{
 func apiServicesToRegister(delegateAPIServer genericapiserver.DelegationTarget, registration autoregister.AutoAPIServiceRegistration) []*v1.APIService {
 	apiServices := []*v1.APIService{}
 
-	for _, curr := range delegateAPIServer.ListedPaths() {
+	for _, curr := range delegateAPIServer.ListedPaths("") {
 		if curr == "/api/v1" {
 			apiService := makeAPIService(schema.GroupVersion{Group: "", Version: "v1"})
 			registration.AddAPIServiceToSyncOnStart(apiService)

--- a/pkg/controlplane/clientutils/multiclusterconfig.go
+++ b/pkg/controlplane/clientutils/multiclusterconfig.go
@@ -1,0 +1,155 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package app does all of the work necessary to create a Kubernetes
+// APIServer by binding together the API, master and APIServer infrastructure.
+// It can be configured and called directly or via the hyperkube framework.
+package clientutils
+
+import (
+	"bytes"
+	"errors"
+	"net/http"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	utilnet "k8s.io/apimachinery/pkg/util/net"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apiserver/pkg/endpoints/request"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/apiserver/pkg/server"
+	genericapiserver "k8s.io/apiserver/pkg/server"
+	"k8s.io/client-go/rest"
+	_ "k8s.io/component-base/metrics/prometheus/workqueue" // for workqueue metric registration
+	"k8s.io/klog"
+)
+
+type multiClusterClientConfigRoundTripper struct {
+	rt                  http.RoundTripper
+	requestInfoResolver func() genericapirequest.RequestInfoResolver
+	enabledOn           sets.String
+}
+
+// EnableMultiCluster allows uses a rountripper to hack the rest.Config used by
+// client-go APIs, in order to add support for logical clusters for a given list of resources.
+// - By default it enables "wildcard" cluster in list and watch request to enable searchng in all logical clusters
+// - For other types of requests, tries to guess the logical cluster where the operation should occur
+// - It finally sets the "X-Kubernetes-Cluster" header accordingly.
+//
+// This is a temporary hack and should be replaced by thoughtful and real support of logical clusters
+// in the client-go layer
+func EnableMultiCluster(config *rest.Config, apiServerConfig *genericapiserver.Config, enabledOnResources ...string) {
+	config.ContentConfig.ContentType = "application/json"
+
+	config.Wrap(func(rt http.RoundTripper) http.RoundTripper {
+		defaultResolver := defaultRequestInfoResolver()
+		return &multiClusterClientConfigRoundTripper{
+			rt: rt,
+			requestInfoResolver: func() genericapirequest.RequestInfoResolver {
+				if apiServerConfig != nil {
+					return apiServerConfig.RequestInfoResolver
+				} else {
+					return defaultResolver
+				}
+			},
+			enabledOn: sets.NewString(enabledOnResources...),
+		}
+	})
+}
+
+func defaultRequestInfoResolver() genericapirequest.RequestInfoResolver {
+	apiPrefixes := sets.NewString(strings.Trim(server.APIGroupPrefix, "/")) // all possible API prefixes
+	legacyAPIPrefixes := sets.String{}                                      // APIPrefixes that won't have groups (legacy)
+	apiPrefixes.Insert(strings.Trim(server.DefaultLegacyAPIPrefix, "/"))
+	legacyAPIPrefixes.Insert(strings.Trim(server.DefaultLegacyAPIPrefix, "/"))
+
+	return &request.RequestInfoFactory{
+		APIPrefixes:          apiPrefixes,
+		GrouplessAPIPrefixes: legacyAPIPrefixes,
+	}
+}
+
+func (mcrt *multiClusterClientConfigRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	req = utilnet.CloneRequest(req)
+	requestInfo, err := mcrt.requestInfoResolver().NewRequestInfo(req)
+	if err != nil {
+		return nil, err
+	}
+	if requestInfo != nil &&
+		mcrt.enabledOn.Has(requestInfo.Resource) {
+		contextCluster := genericapirequest.ClusterFrom(req.Context())
+		resourceClusterName := ""
+		headerCluster := ""
+		switch requestInfo.Verb {
+		case "list", "watch":
+			if contextCluster != nil && !contextCluster.Wildcard {
+				headerCluster = contextCluster.Name
+			} else {
+				headerCluster = "*"
+			}
+		case "create", "update":
+			err := func() error {
+				// We dn't try to mutate the object here. Just guessing the ClusterName field from the body,
+				// in order to set the header accordingly
+				reader, err := req.GetBody()
+				if err != nil {
+					klog.Infof("DEBUG: Error when trying to read the request body from the multicluster client config roundtripper: %v", err)
+					return err
+				}
+				defer reader.Close()
+				buf := new(bytes.Buffer)
+				_, err = buf.ReadFrom(reader)
+				if err != nil {
+					klog.Infof("DEBUG: Error when trying to read the request body from the multicluster client config roundtripper: %v", err)
+					return err
+				}
+				bytes := buf.Bytes()
+				obj, _, err := unstructured.UnstructuredJSONScheme.Decode(bytes, nil, nil)
+				if err != nil {
+					klog.Infof("DEBUG: Error when trying to read the request body from the multicluster client config roundtripper: %v", err)
+					return err
+				}
+				if s, ok := obj.(metav1.Object); ok {
+					resourceClusterName = s.GetClusterName()
+				}
+				return nil
+			}()
+			if err != nil {
+				return nil, err
+			}
+			fallthrough
+		default:
+			if resourceClusterName != "" {
+				if contextCluster != nil && contextCluster.Name != resourceClusterName {
+					return nil, errors.New("Resource cluster name " + resourceClusterName + " incompatible with context cluster name " + contextCluster.Name)
+				}
+				headerCluster = resourceClusterName
+			} else {
+				if contextCluster != nil { //
+					if contextCluster.Wildcard {
+						return nil, errors.New("Cluster should be set for request " + requestInfo.Verb + ", but instead wildcards were provided.")
+					}
+					headerCluster = contextCluster.Name
+				}
+			}
+		}
+		if headerCluster != "" {
+			req.Header.Add("X-Kubernetes-Cluster", headerCluster)
+		}
+	}
+	return mcrt.rt.RoundTrip(req)
+}

--- a/pkg/controlplane/server.go
+++ b/pkg/controlplane/server.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/emicklei/go-restful"
 	extensionsapiserver "k8s.io/apiextensions-apiserver/pkg/apiserver"
+	"k8s.io/apiextensions-apiserver/pkg/controller/openapi/builder"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apiserver/pkg/admission"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
@@ -48,8 +49,11 @@ import (
 	"k8s.io/component-base/version"
 	"k8s.io/klog"
 	aggregatorapiserver "k8s.io/kube-aggregator/pkg/apiserver"
+	"k8s.io/kube-aggregator/pkg/controllers/openapi/aggregator"
+	"k8s.io/kube-openapi/pkg/handler"
 	"k8s.io/kubernetes/pkg/api/controlplanescheme"
 	"k8s.io/kubernetes/pkg/controlplane/apis"
+	"k8s.io/kubernetes/pkg/controlplane/clientutils"
 	"k8s.io/kubernetes/pkg/controlplane/options"
 	generatedopenapi "k8s.io/kubernetes/pkg/generated/openapi"
 	"k8s.io/kubernetes/pkg/kubeapiserver"
@@ -61,6 +65,7 @@ const Include = "kube-control-plane"
 const (
 	etcdRetryLimit    = 60
 	etcdRetryInterval = 1 * time.Second
+	RootClusterName   = "admin"
 )
 
 // Run runs the specified APIServer.  This should never exit.
@@ -73,15 +78,12 @@ func Run(completeOptions completedServerRunOptions, stopCh <-chan struct{}) erro
 		return err
 	}
 
-	prepared, err := server.PrepareRun()
-	if err != nil {
-		return err
-	}
+	prepared := server.PrepareRun()
 	return prepared.Run(stopCh)
 }
 
 // CreateServerChain creates the apiservers connected via delegation.
-func CreateServerChain(completedOptions completedServerRunOptions, stopCh <-chan struct{}) (*aggregatorapiserver.APIAggregator, error) {
+func CreateServerChain(completedOptions completedServerRunOptions, stopCh <-chan struct{}) (*genericapiserver.GenericAPIServer, error) {
 	kubeAPIServerConfig, _, serviceResolver, pluginInitializer, err := CreateKubeAPIServerConfig(completedOptions)
 	if err != nil {
 		return nil, err
@@ -126,7 +128,71 @@ func CreateServerChain(completedOptions completedServerRunOptions, stopCh <-chan
 		}
 	})
 
-	return aggregatorServer, nil
+	// HACK: we don't use the OpenAPI Aggregator of the aggretorServer anymore (only the agregator generic server is prepared)
+	// because the openAPI Agregator isn't compatible with CRD tenancy.
+	// So instead, at the same path, we register our own handler that mainly returns the right merged openAPI schema
+	// based on the logical cluster based on the incoming request.
+	downloader := aggregator.NewDownloader()
+	aggregatorServer.GenericAPIServer.Handler.NonGoRestfulMux.HandleFunc("/openapi/v2", func(res http.ResponseWriter, req *http.Request) {
+		req = req.Clone(req.Context())
+		req.URL.Path = "/openapi/v2"
+		req.URL.RawPath = req.URL.Path
+
+		cluster := genericapirequest.ClusterFrom(req.Context())
+
+		withCluster := func(handler http.Handler) http.HandlerFunc {
+			return func(res http.ResponseWriter, req *http.Request) {
+				if cluster != nil {
+					req = req.Clone(genericapirequest.WithCluster(req.Context(), *cluster))
+				}
+				handler.ServeHTTP(res, req)
+			}
+		}
+
+		// DAVID TODO: try to understand why adding the cluster returns nil here. The default openAPIService should work
+		controlPlaneSpec, etag, httpStatus, err := downloader.Download(kubeAPIServer.GenericAPIServer.Handler.Director, "")
+		klog.Infof(etag, httpStatus)
+
+		crdSpecs, etag, httpStatus, err := downloader.Download(withCluster(apiExtensionsServer.GenericAPIServer.Handler.Director), "")
+		klog.Infof(etag, httpStatus)
+
+		mergedSpecs, err := builder.MergeSpecs(controlPlaneSpec, crdSpecs)
+
+		openAPIVersionedService, err := handler.NewOpenAPIService(mergedSpecs)
+		if err != nil {
+			klog.Errorf("Error while building OpenAPI schema: %v", err)
+		}
+
+		handler := &singlePathHandler{}
+
+		// In order to reuse the kube-openapi API as much as possible, we
+		// register the OpenAPI service in the singlePathHandler
+		err = openAPIVersionedService.RegisterOpenAPIVersionedService("/openapi/v2", handler)
+		if err != nil {
+			klog.Errorf("Error while building OpenAPI schema: %v", err)
+		}
+
+		handler.ServeHTTP(res, req)
+	})
+
+	return aggregatorServer.GenericAPIServer, nil
+}
+
+// singlePathHandler is a dummy PathHandler that mainly allows grabbing a http.Handler
+// from a PathHandler consumer and then being able to use the http.Handler
+// to serve a request.
+type singlePathHandler struct {
+	handler [1]http.Handler
+}
+
+func (sph *singlePathHandler) Handle(path string, handler http.Handler) {
+	sph.handler[0] = handler
+}
+func (sph *singlePathHandler) ServeHTTP(res http.ResponseWriter, req *http.Request) {
+	if sph.handler[0] == nil {
+		res.WriteHeader(404)
+	}
+	sph.handler[0].ServeHTTP(res, req)
 }
 
 // CreateKubeAPIServer creates and wires a workable kube-apiserver
@@ -290,6 +356,9 @@ func BuildGenericConfig(
 	genericConfig.LoopbackClientConfig.DisableCompression = true
 
 	kubeClientConfig := genericConfig.LoopbackClientConfig
+
+	clientutils.EnableMultiCluster(genericConfig.LoopbackClientConfig, genericConfig, "apiservices", "customresourcedefinitions")
+
 	clientgoExternalClient, err := clientgoclientset.NewForConfig(kubeClientConfig)
 	if err != nil {
 		lastErr = fmt.Errorf("failed to create real external clientset: %v", err)
@@ -342,7 +411,7 @@ func BuildGenericConfig(
 				cluster.Wildcard = true
 				fallthrough
 			case "":
-				cluster.Name = "admin"
+				cluster.Name = RootClusterName
 			default:
 				if !reClusterName.MatchString(clusterName) {
 					http.Error(w, "Unknown cluster", http.StatusNotFound)

--- a/pkg/master/controller/crdregistration/crdregistration_controller.go
+++ b/pkg/master/controller/crdregistration/crdregistration_controller.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"time"
 
+	"k8s.io/apiserver/pkg/endpoints/discovery"
 	"k8s.io/klog"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -27,10 +28,10 @@ import (
 	crdlisters "k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/clusters"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 )
@@ -41,7 +42,7 @@ type AutoAPIServiceRegistration interface {
 	// AddAPIServiceToSync adds an API service to auto-register.
 	AddAPIServiceToSync(in *v1.APIService)
 	// RemoveAPIServiceToSync removes an API service to auto-register.
-	RemoveAPIServiceToSync(name string)
+	RemoveAPIServiceToSync(clusterAndName string)
 }
 
 type crdRegistrationController struct {
@@ -50,7 +51,7 @@ type crdRegistrationController struct {
 
 	apiServiceRegistration AutoAPIServiceRegistration
 
-	syncHandler func(groupVersion schema.GroupVersion) error
+	syncHandler func(clusterGroupVersion discovery.ClusterGroupVersion) error
 
 	syncedInitialSet chan struct{}
 
@@ -122,7 +123,11 @@ func (c *crdRegistrationController) Run(threadiness int, stopCh <-chan struct{})
 	} else {
 		for _, crd := range crds {
 			for _, version := range crd.Spec.Versions {
-				if err := c.syncHandler(schema.GroupVersion{Group: crd.Spec.Group, Version: version.Name}); err != nil {
+				if err := c.syncHandler(discovery.ClusterGroupVersion{
+					ClusterName: crd.GetClusterName(),
+					Group:       crd.Spec.Group,
+					Version:     version.Name,
+				}); err != nil {
 					utilruntime.HandleError(err)
 				}
 			}
@@ -164,7 +169,7 @@ func (c *crdRegistrationController) processNextWorkItem() bool {
 	defer c.queue.Done(key)
 
 	// do your work on the key.  This method will contains your "do stuff" logic
-	err := c.syncHandler(key.(schema.GroupVersion))
+	err := c.syncHandler(key.(discovery.ClusterGroupVersion))
 	if err == nil {
 		// if you had no error, tell the queue to stop tracking history for your key.  This will
 		// reset things like failure counts for per-item rate limiting
@@ -186,12 +191,16 @@ func (c *crdRegistrationController) processNextWorkItem() bool {
 
 func (c *crdRegistrationController) enqueueCRD(crd *apiextensionsv1.CustomResourceDefinition) {
 	for _, version := range crd.Spec.Versions {
-		c.queue.Add(schema.GroupVersion{Group: crd.Spec.Group, Version: version.Name})
+		c.queue.Add(discovery.ClusterGroupVersion{
+			ClusterName: crd.GetClusterName(),
+			Group:       crd.Spec.Group,
+			Version:     version.Name,
+		})
 	}
 }
 
-func (c *crdRegistrationController) handleVersionUpdate(groupVersion schema.GroupVersion) error {
-	apiServiceName := groupVersion.Version + "." + groupVersion.Group
+func (c *crdRegistrationController) handleVersionUpdate(clusterGroupVersion discovery.ClusterGroupVersion) error {
+	apiServiceName := clusterGroupVersion.Version + "." + clusterGroupVersion.Group
 
 	// check all CRDs.  There shouldn't that many, but if we have problems later we can index them
 	crds, err := c.crdLister.List(labels.Everything())
@@ -199,19 +208,25 @@ func (c *crdRegistrationController) handleVersionUpdate(groupVersion schema.Grou
 		return err
 	}
 	for _, crd := range crds {
-		if crd.Spec.Group != groupVersion.Group {
+		if crd.GetClusterName() != clusterGroupVersion.ClusterName {
+			continue
+		}
+		if crd.Spec.Group != clusterGroupVersion.Group {
 			continue
 		}
 		for _, version := range crd.Spec.Versions {
-			if version.Name != groupVersion.Version || !version.Served {
+			if version.Name != clusterGroupVersion.Version || !version.Served {
 				continue
 			}
 
 			c.apiServiceRegistration.AddAPIServiceToSync(&v1.APIService{
-				ObjectMeta: metav1.ObjectMeta{Name: apiServiceName},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        apiServiceName,
+					ClusterName: clusterGroupVersion.ClusterName,
+				},
 				Spec: v1.APIServiceSpec{
-					Group:                groupVersion.Group,
-					Version:              groupVersion.Version,
+					Group:                clusterGroupVersion.Group,
+					Version:              clusterGroupVersion.Version,
 					GroupPriorityMinimum: 1000, // CRDs should have relatively low priority
 					VersionPriority:      100,  // CRDs will be sorted by kube-like versions like any other APIService with the same VersionPriority
 				},
@@ -220,6 +235,6 @@ func (c *crdRegistrationController) handleVersionUpdate(groupVersion schema.Grou
 		}
 	}
 
-	c.apiServiceRegistration.RemoveAPIServiceToSync(apiServiceName)
+	c.apiServiceRegistration.RemoveAPIServiceToSync(clusters.ToClusterAwareKey(clusterGroupVersion.ClusterName, apiServiceName))
 	return nil
 }

--- a/pkg/master/controller/crdregistration/crdregistration_controller_test.go
+++ b/pkg/master/controller/crdregistration/crdregistration_controller_test.go
@@ -24,6 +24,7 @@ import (
 	crdlisters "k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/endpoints/discovery"
 	"k8s.io/client-go/tools/cache"
 	apiregistration "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 )
@@ -104,7 +105,11 @@ func TestHandleVersionUpdate(t *testing.T) {
 				crdCache.Add(test.startingCRDs[i])
 			}
 
-			c.handleVersionUpdate(test.version)
+			c.handleVersionUpdate(discovery.ClusterGroupVersion{
+				ClusterName: "",
+				Group:       test.version.Group,
+				Version:     test.version.Version,
+			})
 
 			if !reflect.DeepEqual(test.expectedAdded, registration.added) {
 				t.Errorf("%s expected %v, got %v", test.name, test.expectedAdded, registration.added)

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/apiserver.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/apiserver.go
@@ -176,11 +176,11 @@ func (c completedConfig) New(delegationTarget genericapiserver.DelegationTarget)
 	}
 
 	versionDiscoveryHandler := &versionDiscoveryHandler{
-		discovery: map[schema.GroupVersion]*discovery.APIVersionHandler{},
+		discovery: map[string]map[schema.GroupVersion]*discovery.APIVersionHandler{},
 		delegate:  delegateHandler,
 	}
 	groupDiscoveryHandler := &groupDiscoveryHandler{
-		discovery: map[string]*discovery.APIGroupHandler{},
+		discovery: map[string]map[string]*discovery.APIGroupHandler{},
 		delegate:  delegateHandler,
 	}
 	establishingController := establish.NewEstablishingController(s.Informers.Apiextensions().V1().CustomResourceDefinitions(), crdClient.ApiextensionsV1())
@@ -207,7 +207,7 @@ func (c completedConfig) New(delegationTarget genericapiserver.DelegationTarget)
 	s.GenericAPIServer.Handler.NonGoRestfulMux.Handle("/apis", crdHandler)
 	s.GenericAPIServer.Handler.NonGoRestfulMux.HandlePrefix("/apis/", crdHandler)
 	// HACK: Added to allow serving core resources registered through CRDs (for the KCP scenario)
-	s.GenericAPIServer.Handler.NonGoRestfulMux.HandlePrefix("/api/v1/", crdHandler)
+	s.GenericAPIServer.Handler.NonGoRestfulMux.UnlistedHandlePrefix("/api/v1/", crdHandler)
 
 	crdController := NewDiscoveryController(s.Informers.Apiextensions().V1().CustomResourceDefinitions(), versionDiscoveryHandler, groupDiscoveryHandler)
 	namingController := status.NewNamingConditionController(s.Informers.Apiextensions().V1().CustomResourceDefinitions(), crdClient.ApiextensionsV1())

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_discovery.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_discovery.go
@@ -23,12 +23,13 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/endpoints/discovery"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 )
 
 type versionDiscoveryHandler struct {
 	// TODO, writing is infrequent, optimize this
 	discoveryLock sync.RWMutex
-	discovery     map[schema.GroupVersion]*discovery.APIVersionHandler
+	discovery     map[string]map[schema.GroupVersion]*discovery.APIVersionHandler
 
 	delegate http.Handler
 }
@@ -40,7 +41,14 @@ func (r *versionDiscoveryHandler) ServeHTTP(w http.ResponseWriter, req *http.Req
 		r.delegate.ServeHTTP(w, req)
 		return
 	}
-	discovery, ok := r.getDiscovery(schema.GroupVersion{Group: pathParts[1], Version: pathParts[2]})
+
+	clusterName := ""
+	cluster := genericapirequest.ClusterFrom(req.Context())
+	if cluster != nil {
+		clusterName = cluster.Name
+	}
+
+	discovery, ok := r.getDiscovery(clusterName, schema.GroupVersion{Group: pathParts[1], Version: pathParts[2]})
 	if !ok {
 		r.delegate.ServeHTTP(w, req)
 		return
@@ -49,32 +57,46 @@ func (r *versionDiscoveryHandler) ServeHTTP(w http.ResponseWriter, req *http.Req
 	discovery.ServeHTTP(w, req)
 }
 
-func (r *versionDiscoveryHandler) getDiscovery(gv schema.GroupVersion) (*discovery.APIVersionHandler, bool) {
+func (r *versionDiscoveryHandler) getDiscovery(clusterName string, gv schema.GroupVersion) (*discovery.APIVersionHandler, bool) {
 	r.discoveryLock.RLock()
 	defer r.discoveryLock.RUnlock()
 
-	ret, ok := r.discovery[gv]
+	clusterDiscovery, clusterExists := r.discovery[clusterName]
+	if !clusterExists {
+		return nil, false
+	}
+	ret, ok := clusterDiscovery[gv]
 	return ret, ok
 }
 
-func (r *versionDiscoveryHandler) setDiscovery(gv schema.GroupVersion, discovery *discovery.APIVersionHandler) {
+func (r *versionDiscoveryHandler) setDiscovery(clusterName string, gv schema.GroupVersion, discoveryHandler *discovery.APIVersionHandler) {
 	r.discoveryLock.Lock()
 	defer r.discoveryLock.Unlock()
 
-	r.discovery[gv] = discovery
+	if _, clusterExists := r.discovery[clusterName]; !clusterExists {
+		r.discovery[clusterName] = map[schema.GroupVersion]*discovery.APIVersionHandler{}
+	}
+	r.discovery[clusterName][gv] = discoveryHandler
 }
 
-func (r *versionDiscoveryHandler) unsetDiscovery(gv schema.GroupVersion) {
+func (r *versionDiscoveryHandler) unsetDiscovery(clusterName string, gv schema.GroupVersion) {
 	r.discoveryLock.Lock()
 	defer r.discoveryLock.Unlock()
 
-	delete(r.discovery, gv)
+	if _, clusterExists := r.discovery[clusterName]; !clusterExists {
+		return
+	}
+
+	delete(r.discovery[clusterName], gv)
+	if len(r.discovery[clusterName]) == 0 {
+		delete(r.discovery, clusterName)
+	}
 }
 
 type groupDiscoveryHandler struct {
 	// TODO, writing is infrequent, optimize this
 	discoveryLock sync.RWMutex
-	discovery     map[string]*discovery.APIGroupHandler
+	discovery     map[string]map[string]*discovery.APIGroupHandler
 
 	delegate http.Handler
 }
@@ -86,7 +108,14 @@ func (r *groupDiscoveryHandler) ServeHTTP(w http.ResponseWriter, req *http.Reque
 		r.delegate.ServeHTTP(w, req)
 		return
 	}
-	discovery, ok := r.getDiscovery(pathParts[1])
+
+	clusterName := ""
+	cluster := genericapirequest.ClusterFrom(req.Context())
+	if cluster != nil {
+		clusterName = cluster.Name
+	}
+
+	discovery, ok := r.getDiscovery(clusterName, pathParts[1])
 	if !ok {
 		r.delegate.ServeHTTP(w, req)
 		return
@@ -95,26 +124,40 @@ func (r *groupDiscoveryHandler) ServeHTTP(w http.ResponseWriter, req *http.Reque
 	discovery.ServeHTTP(w, req)
 }
 
-func (r *groupDiscoveryHandler) getDiscovery(group string) (*discovery.APIGroupHandler, bool) {
+func (r *groupDiscoveryHandler) getDiscovery(clusterName, group string) (*discovery.APIGroupHandler, bool) {
 	r.discoveryLock.RLock()
 	defer r.discoveryLock.RUnlock()
 
-	ret, ok := r.discovery[group]
+	clusterDiscovery, clusterExists := r.discovery[clusterName]
+	if !clusterExists {
+		return nil, false
+	}
+	ret, ok := clusterDiscovery[group]
 	return ret, ok
 }
 
-func (r *groupDiscoveryHandler) setDiscovery(group string, discovery *discovery.APIGroupHandler) {
+func (r *groupDiscoveryHandler) setDiscovery(clusterName, group string, discoveryHandler *discovery.APIGroupHandler) {
 	r.discoveryLock.Lock()
 	defer r.discoveryLock.Unlock()
 
-	r.discovery[group] = discovery
+	if _, clusterExists := r.discovery[clusterName]; !clusterExists {
+		r.discovery[clusterName] = map[string]*discovery.APIGroupHandler{}
+	}
+	r.discovery[clusterName][group] = discoveryHandler
 }
 
-func (r *groupDiscoveryHandler) unsetDiscovery(group string) {
+func (r *groupDiscoveryHandler) unsetDiscovery(clusterName, group string) {
 	r.discoveryLock.Lock()
 	defer r.discoveryLock.Unlock()
 
-	delete(r.discovery, group)
+	if _, clusterExists := r.discovery[clusterName]; !clusterExists {
+		return
+	}
+
+	delete(r.discovery[clusterName], group)
+	if len(r.discovery[clusterName]) == 0 {
+		delete(r.discovery, clusterName)
+	}
 }
 
 // splitPath returns the segments for a URL path.

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go
@@ -72,6 +72,7 @@ import (
 	"k8s.io/apiserver/pkg/endpoints/metrics"
 	"k8s.io/apiserver/pkg/endpoints/openapi"
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/features"
 	"k8s.io/apiserver/pkg/registry/generic"
 	genericregistry "k8s.io/apiserver/pkg/registry/generic/registry"
@@ -83,6 +84,7 @@ import (
 	"k8s.io/client-go/scale"
 	"k8s.io/client-go/scale/scheme/autoscalingv1"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/clusters"
 	"k8s.io/klog"
 	"k8s.io/kube-openapi/pkg/util/proto"
 )
@@ -263,7 +265,15 @@ func (r *crdHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	if requestInfo.APIGroup == "" {
 		crdName = crdName + "core"
 	}
-	crd, err := r.crdLister.Get(crdName)
+
+	crdKey := crdName
+	clusterName := ""
+	cluster := genericapirequest.ClusterFrom(ctx)
+	if cluster != nil {
+		clusterName = cluster.Name
+	}
+	crdKey = clusters.ToClusterAwareKey(clusterName, crdKey)
+	crd, err := r.crdLister.Get(crdKey)
 	if apierrors.IsNotFound(err) {
 		if !r.hasSynced() {
 			responsewriters.ErrorNegotiated(serverStartingError(), Codecs, schema.GroupVersion{Group: requestInfo.APIGroup, Version: requestInfo.APIVersion}, w, req)
@@ -311,7 +321,7 @@ func (r *crdHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 	terminating := apiextensionshelpers.IsCRDConditionTrue(crd, apiextensionsv1.Terminating)
 
-	crdInfo, err := r.getOrCreateServingInfoFor(crd.UID, crd.Name)
+	crdInfo, err := r.getOrCreateServingInfoFor(crd.UID, crd.Name, clusterName)
 	if apierrors.IsNotFound(err) {
 		r.delegate.ServeHTTP(w, req)
 		return
@@ -480,9 +490,9 @@ func (r *crdHandler) updateCustomResourceDefinition(oldObj, newObj interface{}) 
 	if !apiextensionshelpers.IsCRDConditionTrue(newCRD, apiextensionsv1.Established) &&
 		apiextensionshelpers.IsCRDConditionTrue(newCRD, apiextensionsv1.NamesAccepted) {
 		if r.masterCount > 1 {
-			r.establishingController.QueueCRD(newCRD.Name, 5*time.Second)
+			r.establishingController.QueueCRD(newCRD.Name, newCRD.GetClusterName(), 5*time.Second)
 		} else {
-			r.establishingController.QueueCRD(newCRD.Name, 0)
+			r.establishingController.QueueCRD(newCRD.Name, newCRD.GetClusterName(), 0)
 		}
 	}
 
@@ -578,7 +588,7 @@ func (r *crdHandler) tearDown(oldInfo *crdInfo) {
 // GetCustomResourceListerCollectionDeleter returns the ListerCollectionDeleter of
 // the given crd.
 func (r *crdHandler) GetCustomResourceListerCollectionDeleter(crd *apiextensionsv1.CustomResourceDefinition) (finalizer.ListerCollectionDeleter, error) {
-	info, err := r.getOrCreateServingInfoFor(crd.UID, crd.Name)
+	info, err := r.getOrCreateServingInfoFor(crd.UID, crd.Name, crd.GetClusterName())
 	if err != nil {
 		return nil, err
 	}
@@ -587,7 +597,7 @@ func (r *crdHandler) GetCustomResourceListerCollectionDeleter(crd *apiextensions
 
 // getOrCreateServingInfoFor gets the CRD serving info for the given CRD UID if the key exists in the storage map.
 // Otherwise the function fetches the up-to-date CRD using the given CRD name and creates CRD serving info.
-func (r *crdHandler) getOrCreateServingInfoFor(uid types.UID, name string) (*crdInfo, error) {
+func (r *crdHandler) getOrCreateServingInfoFor(uid types.UID, name, clusterName string) (*crdInfo, error) {
 	storageMap := r.customStorage.Load().(crdStorageMap)
 	if ret, ok := storageMap[uid]; ok {
 		return ret, nil
@@ -600,7 +610,11 @@ func (r *crdHandler) getOrCreateServingInfoFor(uid types.UID, name string) (*crd
 	// If updateCustomResourceDefinition sees an update and happens later, the storage will be deleted and
 	// we will re-create the updated storage on demand. If updateCustomResourceDefinition happens before,
 	// we make sure that we observe the same up-to-date CRD.
-	crd, err := r.crdLister.Get(name)
+	crdKey := name
+	if clusterName != "" {
+		crdKey = clusters.ToClusterAwareKey(clusterName, crdKey)
+	}
+	crd, err := r.crdLister.Get(crdKey)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler_test.go
@@ -159,20 +159,24 @@ func TestRouting(t *testing.T) {
 		hasSynced: func() bool { return hasSynced },
 		delegate:  delegate,
 		versionDiscoveryHandler: &versionDiscoveryHandler{
-			discovery: map[schema.GroupVersion]*discovery.APIVersionHandler{
-				customV1: discovery.NewAPIVersionHandler(Codecs, customV1, discovery.APIResourceListerFunc(func() []metav1.APIResource {
-					return nil
-				})),
+			discovery: map[string]map[schema.GroupVersion]*discovery.APIVersionHandler{
+				"": {
+					customV1: discovery.NewAPIVersionHandler(Codecs, customV1, discovery.APIResourceListerFunc(func() []metav1.APIResource {
+						return nil
+					})),
+				},
 			},
 			delegate: delegate,
 		},
 		groupDiscoveryHandler: &groupDiscoveryHandler{
-			discovery: map[string]*discovery.APIGroupHandler{
-				"custom": discovery.NewAPIGroupHandler(Codecs, metav1.APIGroup{
-					Name:             customV1.Group,
-					Versions:         []metav1.GroupVersionForDiscovery{{GroupVersion: customV1.String(), Version: customV1.Version}},
-					PreferredVersion: metav1.GroupVersionForDiscovery{GroupVersion: customV1.String(), Version: customV1.Version},
-				}),
+			discovery: map[string]map[string]*discovery.APIGroupHandler{
+				"": {
+					"custom": discovery.NewAPIGroupHandler(Codecs, metav1.APIGroup{
+						Name:             customV1.Group,
+						Versions:         []metav1.GroupVersionForDiscovery{{GroupVersion: customV1.String(), Version: customV1.Version}},
+						PreferredVersion: metav1.GroupVersionForDiscovery{GroupVersion: customV1.String(), Version: customV1.Version},
+					}),
+				},
 			},
 			delegate: delegate,
 		},
@@ -494,7 +498,7 @@ func testHandlerConversion(t *testing.T, enableWatchCache bool) {
 		t.Fatal(err)
 	}
 
-	crdInfo, err := handler.getOrCreateServingInfoFor(crd.UID, crd.Name)
+	crdInfo, err := handler.getOrCreateServingInfoFor(crd.UID, crd.Name, "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/establish/establishing_controller.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/establish/establishing_controller.go
@@ -34,6 +34,7 @@ import (
 	client "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1"
 	informers "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/apiextensions/v1"
 	listers "k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/v1"
+	"k8s.io/client-go/tools/clusters"
 )
 
 // EstablishingController controls how and when CRD is established.
@@ -64,8 +65,8 @@ func NewEstablishingController(crdInformer informers.CustomResourceDefinitionInf
 }
 
 // QueueCRD adds CRD into the establishing queue.
-func (ec *EstablishingController) QueueCRD(key string, timeout time.Duration) {
-	ec.queue.AddAfter(key, timeout)
+func (ec *EstablishingController) QueueCRD(name, clusterName string, timeout time.Duration) {
+	ec.queue.AddAfter(clusters.ToClusterAwareKey(clusterName, name), timeout)
 }
 
 // Run starts the EstablishingController.

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/finalizer/crd_finalizer.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/finalizer/crd_finalizer.go
@@ -190,7 +190,10 @@ func (c *CRDFinalizer) deleteInstances(crd *apiextensionsv1.CustomResourceDefini
 		}, err
 	}
 
-	ctx := genericapirequest.NewContext()
+	ctx := genericapirequest.WithCluster(genericapirequest.NewContext(), genericapirequest.Cluster{
+		Name: crd.GetClusterName(),
+	})
+
 	allResources, err := crClient.List(ctx, nil)
 	if err != nil {
 		return apiextensionsv1.CustomResourceDefinitionCondition{

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/controller.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/controller.go
@@ -28,16 +28,17 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apiserver/pkg/server/routes"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog"
-	"k8s.io/kube-openapi/pkg/handler"
 
 	apiextensionshelpers "k8s.io/apiextensions-apiserver/pkg/apihelpers"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	informers "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/apiextensions/v1"
 	listers "k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/v1"
 	"k8s.io/apiextensions-apiserver/pkg/controller/openapi/builder"
+	"k8s.io/client-go/tools/clusters"
 )
 
 // Controller watches CustomResourceDefinitions and publishes validation schema
@@ -50,12 +51,12 @@ type Controller struct {
 
 	queue workqueue.RateLimitingInterface
 
-	staticSpec     *spec.Swagger
-	openAPIService *handler.OpenAPIService
+	staticSpec             *spec.Swagger
+	openAPIServiceProvider routes.OpenAPIServiceProvider
 
-	// specs per version and per CRD name
+	// specs per cluster and per version and per CRD name
 	lock     sync.Mutex
-	crdSpecs map[string]map[string]*spec.Swagger
+	crdSpecs map[string]map[string]map[string]*spec.Swagger
 }
 
 // NewController creates a new Controller with input CustomResourceDefinition informer
@@ -64,7 +65,7 @@ func NewController(crdInformer informers.CustomResourceDefinitionInformer) *Cont
 		crdLister:  crdInformer.Lister(),
 		crdsSynced: crdInformer.Informer().HasSynced,
 		queue:      workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "crd_openapi_controller"),
-		crdSpecs:   map[string]map[string]*spec.Swagger{},
+		crdSpecs:   map[string]map[string]map[string]*spec.Swagger{},
 	}
 
 	crdInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -77,8 +78,51 @@ func NewController(crdInformer informers.CustomResourceDefinitionInformer) *Cont
 	return c
 }
 
+// HACK:
+//  Everything regarding OpenAPI and resource discovery is managed through controllers currently
+// (a number of controllers highly coupled with the corresponding http handlers).
+// The following code is an attempt at provising CRD tenancy while accommodating the current design without being too much invasive,
+// because doing differently would have meant too much refactoring..
+// But in the long run the "do this dynamically, not as part of a controller" is probably going to be important.
+// openapi/crd generation is expensive, so doing on a controller means that CPU and memory scale O(crds),
+// when we really want them to scale O(active_clusters).
+
+func (c *Controller) setClusterCrdSpecs(clusterName, crdName string, newSpecs map[string]*spec.Swagger) {
+	_, found := c.crdSpecs[clusterName]
+	if !found {
+		c.crdSpecs[clusterName] = map[string]map[string]*spec.Swagger{}
+	}
+	c.crdSpecs[clusterName][crdName] = newSpecs
+	c.openAPIServiceProvider.AddCuster(clusterName)
+}
+
+func (c *Controller) removeClusterCrdSpecs(clusterName, crdName string) bool {
+	_, crdsForClusterFound := c.crdSpecs[clusterName]
+	if !crdsForClusterFound {
+		return false
+	}
+	if _, found := c.crdSpecs[clusterName][crdName]; !found {
+		return false
+	}
+	delete(c.crdSpecs[clusterName], crdName)
+	if len(c.crdSpecs[clusterName]) == 0 {
+		delete(c.crdSpecs, clusterName)
+		c.openAPIServiceProvider.RemoveCuster(clusterName)
+	}
+	return true
+}
+
+func (c *Controller) getClusterCrdSpecs(clusterName, crdName string) (map[string]*spec.Swagger, bool) {
+	_, specsFoundForCluster := c.crdSpecs[clusterName]
+	if !specsFoundForCluster {
+		return map[string]*spec.Swagger{}, false
+	}
+	crdSpecs, found := c.crdSpecs[clusterName][crdName]
+	return crdSpecs, found
+}
+
 // Run sets openAPIAggregationManager and starts workers
-func (c *Controller) Run(staticSpec *spec.Swagger, openAPIService *handler.OpenAPIService, stopCh <-chan struct{}) {
+func (c *Controller) Run(staticSpec *spec.Swagger, openAPIServiceProvider routes.OpenAPIServiceProvider, stopCh <-chan struct{}) {
 	defer utilruntime.HandleCrash()
 	defer c.queue.ShutDown()
 	defer klog.Infof("Shutting down OpenAPI controller")
@@ -86,7 +130,7 @@ func (c *Controller) Run(staticSpec *spec.Swagger, openAPIService *handler.OpenA
 	klog.Infof("Starting OpenAPI controller")
 
 	c.staticSpec = staticSpec
-	c.openAPIService = openAPIService
+	c.openAPIServiceProvider = openAPIServiceProvider
 
 	if !cache.WaitForCacheSync(stopCh, c.crdsSynced) {
 		utilruntime.HandleError(fmt.Errorf("timed out waiting for caches to sync"))
@@ -109,7 +153,7 @@ func (c *Controller) Run(staticSpec *spec.Swagger, openAPIService *handler.OpenA
 		} else if !changed {
 			continue
 		}
-		c.crdSpecs[crd.Name] = newSpecs
+		c.setClusterCrdSpecs(crd.GetClusterName(), crd.Name, newSpecs)
 	}
 	if err := c.updateSpecLocked(); err != nil {
 		utilruntime.HandleError(fmt.Errorf("failed to initially create OpenAPI spec for CRDs: %v", err))
@@ -154,28 +198,35 @@ func (c *Controller) processNextWorkItem() bool {
 	return true
 }
 
-func (c *Controller) sync(name string) error {
+func (c *Controller) sync(clusterAndName string) error {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
-	crd, err := c.crdLister.Get(name)
+	crd, err := c.crdLister.Get(clusterAndName)
 	if err != nil && !errors.IsNotFound(err) {
 		return err
 	}
 
 	// do we have to remove all specs of this CRD?
 	if errors.IsNotFound(err) || !apiextensionshelpers.IsCRDConditionTrue(crd, apiextensionsv1.Established) {
-		if _, found := c.crdSpecs[name]; !found {
+		clusterName := ""
+		crdName := clusterAndName
+		if crd != nil {
+			clusterName = crd.GetClusterName()
+			crdName = crd.Name
+		} else {
+			clusterName, crdName = clusters.SplitClusterAwareKey(clusterAndName)
+		}
+		if !c.removeClusterCrdSpecs(clusterName, crdName) {
 			return nil
 		}
-		delete(c.crdSpecs, name)
-		klog.V(2).Infof("Updating CRD OpenAPI spec because %s was removed", name)
-		regenerationCounter.With(map[string]string{"crd": name, "reason": "remove"})
+		klog.V(2).Infof("Updating CRD OpenAPI spec because %s was removed", crdName)
+		regenerationCounter.With(map[string]string{"crd": crdName, "reason": "remove"})
 		return c.updateSpecLocked()
 	}
 
 	// compute CRD spec and see whether it changed
-	oldSpecs, updated := c.crdSpecs[crd.Name]
+	oldSpecs, updated := c.getClusterCrdSpecs(crd.GetClusterName(), crd.Name)
 	newSpecs, changed, err := buildVersionSpecs(crd, oldSpecs)
 	if err != nil {
 		return err
@@ -185,13 +236,13 @@ func (c *Controller) sync(name string) error {
 	}
 
 	// update specs of this CRD
-	c.crdSpecs[crd.Name] = newSpecs
-	klog.V(2).Infof("Updating CRD OpenAPI spec because %s changed", name)
+	c.setClusterCrdSpecs(crd.GetClusterName(), crd.Name, newSpecs)
+	klog.V(2).Infof("Updating CRD OpenAPI spec because %s changed", crd.Name)
 	reason := "add"
 	if updated {
 		reason = "update"
 	}
-	regenerationCounter.With(map[string]string{"crd": name, "reason": reason})
+	regenerationCounter.With(map[string]string{"crd": crd.Name, "reason": reason})
 	return c.updateSpecLocked()
 }
 
@@ -222,16 +273,19 @@ func buildVersionSpecs(crd *apiextensionsv1.CustomResourceDefinition, oldSpecs m
 // It is not thread-safe. The caller is responsible to hold proper lock (Controller.lock).
 func (c *Controller) updateSpecLocked() error {
 	crdSpecs := []*spec.Swagger{}
-	for _, versionSpecs := range c.crdSpecs {
-		for _, s := range versionSpecs {
-			crdSpecs = append(crdSpecs, s)
+	for clusterName, clusterCrdSpecs := range c.crdSpecs {
+		for _, versionSpecs := range clusterCrdSpecs {
+			for _, s := range versionSpecs {
+				crdSpecs = append(crdSpecs, s)
+			}
 		}
+		mergedSpec, err := builder.MergeSpecs(c.staticSpec, crdSpecs...)
+		if err != nil {
+			return fmt.Errorf("failed to merge specs: %v", err)
+		}
+		return c.openAPIServiceProvider.ForCluster(clusterName).UpdateSpec(mergedSpec)
 	}
-	mergedSpec, err := builder.MergeSpecs(c.staticSpec, crdSpecs...)
-	if err != nil {
-		return fmt.Errorf("failed to merge specs: %v", err)
-	}
-	return c.openAPIService.UpdateSpec(mergedSpec)
+	return nil
 }
 
 func (c *Controller) addCustomResourceDefinition(obj interface{}) {
@@ -265,5 +319,6 @@ func (c *Controller) deleteCustomResourceDefinition(obj interface{}) {
 }
 
 func (c *Controller) enqueue(obj *apiextensionsv1.CustomResourceDefinition) {
-	c.queue.Add(obj.Name)
+	key, _ := cache.MetaNamespaceKeyFunc(obj)
+	c.queue.Add(key)
 }

--- a/staging/src/k8s.io/apimachinery/pkg/api/validation/objectmeta.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validation/objectmeta.go
@@ -252,7 +252,13 @@ func ValidateObjectMetaAccessorUpdate(newMeta, oldMeta metav1.Object, fldPath *f
 	allErrs = append(allErrs, ValidateImmutableField(newMeta.GetCreationTimestamp(), oldMeta.GetCreationTimestamp(), fldPath.Child("creationTimestamp"))...)
 	allErrs = append(allErrs, ValidateImmutableField(newMeta.GetDeletionTimestamp(), oldMeta.GetDeletionTimestamp(), fldPath.Child("deletionTimestamp"))...)
 	allErrs = append(allErrs, ValidateImmutableField(newMeta.GetDeletionGracePeriodSeconds(), oldMeta.GetDeletionGracePeriodSeconds(), fldPath.Child("deletionGracePeriodSeconds"))...)
-	allErrs = append(allErrs, ValidateImmutableField(newMeta.GetClusterName(), oldMeta.GetClusterName(), fldPath.Child("clusterName"))...)
+
+	// HACK: Since the ClusterName is not stored in etcd, but is set when reading from etcd based on the etcd object key,
+	// we have to disable this validation when a newObject has no `ClusterName` defined (which is completely acceptable because
+	// the logical cluster associated to an etcd object is in fact determined by the current request context)
+	if newMeta.GetClusterName() != "" {
+		allErrs = append(allErrs, ValidateImmutableField(newMeta.GetClusterName(), oldMeta.GetClusterName(), fldPath.Child("clusterName"))...)
+	}
 
 	allErrs = append(allErrs, v1validation.ValidateLabels(newMeta.GetLabels(), fldPath.Child("labels"))...)
 	allErrs = append(allErrs, ValidateAnnotations(newMeta.GetAnnotations(), fldPath.Child("annotations"))...)

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/discovery/storageversionhash.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/discovery/storageversionhash.go
@@ -25,8 +25,8 @@ import (
 // <group/version/kind> tuple.
 // WARNING: this function is subject to change. Clients shouldn't depend on
 // this function.
-func StorageVersionHash(group, version, kind string) string {
-	gvk := group + "/" + version + "/" + kind
+func StorageVersionHash(clusterName, group, version, kind string) string {
+	gvk := clusterName + "/" + group + "/" + version + "/" + kind
 	if gvk == "" {
 		return ""
 	}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/discovery/version.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/discovery/version.go
@@ -44,7 +44,7 @@ type APIVersionHandler struct {
 	serializer runtime.NegotiatedSerializer
 
 	groupVersion      schema.GroupVersion
-	apiResourceLister APIResourceLister
+	apiResourceLister func(*http.Request) APIResourceLister
 }
 
 func NewAPIVersionHandler(serializer runtime.NegotiatedSerializer, groupVersion schema.GroupVersion, apiResourceLister APIResourceLister) *APIVersionHandler {
@@ -80,5 +80,5 @@ func (s *APIVersionHandler) handle(req *restful.Request, resp *restful.Response)
 
 func (s *APIVersionHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	responsewriters.WriteObjectNegotiated(s.serializer, negotiation.DefaultEndpointRestrictions, schema.GroupVersion{}, w, req, http.StatusOK,
-		&metav1.APIResourceList{GroupVersion: s.groupVersion.String(), APIResources: s.apiResourceLister.ListAPIResources()})
+		&metav1.APIResourceList{GroupVersion: s.groupVersion.String(), APIResources: s.apiResourceLister(req).ListAPIResources()})
 }

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/discovery/version_hack.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/discovery/version_hack.go
@@ -17,29 +17,78 @@ limitations under the License.
 package discovery
 
 import (
+	"net/http"
 	"regexp"
 	"sort"
 	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 )
 
 // HACK: support the case when we can add core or other legacy scheme resources through CRDs (KCP scenario)
-var ContributedResources map[schema.GroupVersion]APIResourceLister = map[schema.GroupVersion]APIResourceLister{}
+// Possibly we wouldn't need a global variable for ContributedResources that is cluster scoped,
+// In the long run we could see the context carrying an injected interface that would let us perform
+// some of these cluster scoped behaviors (where we would call methods on it instead of having lots of little caches everywhere).
+// Finally with more refactoring we might also just want to skip having the cache and do it dynamically.
+var ContributedResources map[ClusterGroupVersion]APIResourceLister = map[ClusterGroupVersion]APIResourceLister{}
 
-func withContributedResources(groupVersion schema.GroupVersion, apiResourceLister APIResourceLister) APIResourceLister {
-	return APIResourceListerFunc(func() []metav1.APIResource {
-		result := apiResourceLister.ListAPIResources()
-		if additionalResources := ContributedResources[groupVersion]; additionalResources != nil {
-			result = append(result, additionalResources.ListAPIResources()...)
-		}
-		sort.Slice(result, func(i, j int) bool {
-			return result[i].Name < result[j].Name
+type ClusterGroupVersion struct {
+	ClusterName string
+	Group       string
+	Version     string
+}
+
+// Empty returns true if group and version are empty
+func (cgv ClusterGroupVersion) Empty() bool {
+	return len(cgv.Group) == 0 && len(cgv.Version) == 0
+}
+
+// String puts "group" and "version" into a single "group/version" string. For the legacy v1
+// it returns "v1".
+func (cgv ClusterGroupVersion) String() string {
+	// special case the internal apiVersion for the legacy kube types
+	if cgv.Empty() {
+		return ""
+	}
+
+	gv := cgv.Group + "/" + cgv.Version
+	// special case of "v1" for backward compatibility
+	if len(cgv.Group) == 0 && cgv.Version == "v1" {
+		gv = cgv.Version
+	}
+	result := gv
+	if cgv.ClusterName != "" {
+		result = cgv.ClusterName + "/" + gv
+	}
+	return result
+}
+
+func (cgv ClusterGroupVersion) GroupVersion() schema.GroupVersion {
+	return schema.GroupVersion{
+		Group:   cgv.Group,
+		Version: cgv.Version,
+	}
+}
+
+func withContributedResources(groupVersion schema.GroupVersion, apiResourceLister APIResourceLister) func(*http.Request) APIResourceLister {
+	return func(req *http.Request) APIResourceLister {
+		cluster := genericapirequest.ClusterFrom(req.Context())
+		return APIResourceListerFunc(func() []metav1.APIResource {
+			result := []metav1.APIResource{}
+			result = append(result, apiResourceLister.ListAPIResources()...)
+			if cluster != nil {
+				if additionalResources := ContributedResources[ClusterGroupVersion{cluster.Name, groupVersion.Group, groupVersion.Version}]; additionalResources != nil {
+					result = append(result, additionalResources.ListAPIResources()...)
+				}
+				sort.Slice(result, func(i, j int) bool {
+					return result[i].Name < result[j].Name
+				})
+			}
+			return result
 		})
-
-		return result
-	})
+	}
 }
 
 // IsAPIContributed returns `true` is the path corresponds to a resource that

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/installer.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/installer.go
@@ -392,7 +392,7 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 		if err != nil {
 			return nil, err
 		}
-		apiResource.StorageVersionHash = discovery.StorageVersionHash(gvk.Group, gvk.Version, gvk.Kind)
+		apiResource.StorageVersionHash = discovery.StorageVersionHash("", gvk.Group, gvk.Version, gvk.Kind)
 	}
 
 	// Get the list of actions for the given scope.

--- a/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
@@ -48,7 +48,6 @@ import (
 	"k8s.io/klog"
 	openapibuilder "k8s.io/kube-openapi/pkg/builder"
 	openapicommon "k8s.io/kube-openapi/pkg/common"
-	"k8s.io/kube-openapi/pkg/handler"
 	openapiutil "k8s.io/kube-openapi/pkg/util"
 	openapiproto "k8s.io/kube-openapi/pkg/util/proto"
 )
@@ -131,7 +130,7 @@ type GenericAPIServer struct {
 
 	// OpenAPIVersionedService controls the /openapi/v2 endpoint, and can be used to update the served spec.
 	// It is set during PrepareRun.
-	OpenAPIVersionedService *handler.OpenAPIService
+	OpenAPIVersionedService routes.OpenAPIServiceProvider
 
 	// StaticOpenAPISpec is the spec derived from the restful container endpoints.
 	// It is set during PrepareRun.
@@ -215,7 +214,7 @@ type DelegationTarget interface {
 	HealthzChecks() []healthz.HealthChecker
 
 	// ListedPaths returns the paths for supporting an index
-	ListedPaths() []string
+	ListedPaths(clusterName string) []string
 
 	// NextDelegate returns the next delegationTarget in the chain of delegations
 	NextDelegate() DelegationTarget
@@ -237,8 +236,8 @@ func (s *GenericAPIServer) PreShutdownHooks() map[string]preShutdownHookEntry {
 func (s *GenericAPIServer) HealthzChecks() []healthz.HealthChecker {
 	return s.healthzChecks
 }
-func (s *GenericAPIServer) ListedPaths() []string {
-	return s.listedPathProvider.ListedPaths()
+func (s *GenericAPIServer) ListedPaths(clusterName string) []string {
+	return s.listedPathProvider.ListedPaths(clusterName)
 }
 
 func (s *GenericAPIServer) NextDelegate() DelegationTarget {
@@ -264,7 +263,7 @@ func (s emptyDelegate) PreShutdownHooks() map[string]preShutdownHookEntry {
 func (s emptyDelegate) HealthzChecks() []healthz.HealthChecker {
 	return []healthz.HealthChecker{}
 }
-func (s emptyDelegate) ListedPaths() []string {
+func (s emptyDelegate) ListedPaths(clusterName string) []string {
 	return []string{}
 }
 func (s emptyDelegate) NextDelegate() DelegationTarget {

--- a/staging/src/k8s.io/apiserver/pkg/server/mux/pathrecorder.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/mux/pathrecorder.go
@@ -95,7 +95,7 @@ func NewPathRecorderMux(name string) *PathRecorderMux {
 }
 
 // ListedPaths returns the registered handler exposedPaths.
-func (m *PathRecorderMux) ListedPaths() []string {
+func (m *PathRecorderMux) ListedPaths(clusterName string) []string {
 	handledPaths := append([]string{}, m.exposedPaths...)
 	sort.Strings(handledPaths)
 

--- a/staging/src/k8s.io/apiserver/pkg/server/routes/index.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/routes/index.go
@@ -22,23 +22,24 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apiserver/pkg/endpoints/handlers/responsewriters"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/server/mux"
 )
 
 // ListedPathProvider is an interface for providing paths that should be reported at /.
 type ListedPathProvider interface {
 	// ListedPaths is an alphabetically sorted list of paths to be reported at /.
-	ListedPaths() []string
+	ListedPaths(clusterName string) []string
 }
 
 // ListedPathProviders is a convenient way to combine multiple ListedPathProviders
 type ListedPathProviders []ListedPathProvider
 
 // ListedPaths unions and sorts the included paths.
-func (p ListedPathProviders) ListedPaths() []string {
+func (p ListedPathProviders) ListedPaths(clusterName string) []string {
 	ret := sets.String{}
 	for _, provider := range p {
-		for _, path := range provider.ListedPaths() {
+		for _, path := range provider.ListedPaths(clusterName) {
 			ret.Insert(path)
 		}
 	}
@@ -65,5 +66,10 @@ type IndexLister struct {
 
 // ServeHTTP serves the available paths.
 func (i IndexLister) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	responsewriters.WriteRawJSON(i.StatusCode, metav1.RootPaths{Paths: i.PathProvider.ListedPaths()}, w)
+	cluster := genericapirequest.ClusterFrom(r.Context())
+	clusterName := ""
+	if cluster != nil {
+		clusterName = cluster.Name
+	}
+	responsewriters.WriteRawJSON(i.StatusCode, metav1.RootPaths{Paths: i.PathProvider.ListedPaths(clusterName)}, w)
 }

--- a/staging/src/k8s.io/apiserver/pkg/server/routes/openapi.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/routes/openapi.go
@@ -17,10 +17,13 @@ limitations under the License.
 package routes
 
 import (
+	"net/http"
+
 	restful "github.com/emicklei/go-restful"
 	"github.com/go-openapi/spec"
 	"k8s.io/klog"
 
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/server/mux"
 	"k8s.io/kube-openapi/pkg/builder"
 	"k8s.io/kube-openapi/pkg/common"
@@ -32,15 +35,127 @@ type OpenAPI struct {
 	Config *common.Config
 }
 
+// OpenAPIServiceProvider is a hacky way to
+// replace a single OpenAPIService by a provider which will
+// provide an distinct openAPIService per logical cluster.
+// This is required to implement CRD tenancy and have the openAPI
+// models be conistent with the current logical cluster.
+//
+// However this is just a first step, since a better way
+// would be to completly avoid the need of registering a OpenAPIService
+// for each logical cluster. See the addition comments below.
+type OpenAPIServiceProvider interface {
+	ForCluster(clusterName string) *handler.OpenAPIService
+	AddCuster(clusterName string)
+	RemoveCuster(clusterName string)
+	UpdateSpec(openapiSpec *spec.Swagger) error
+}
+
+type clusterAwarePathHandler struct {
+	clusterName          string
+	addHandlerForCluster func(clusterName string, handler http.Handler)
+}
+
+func (c *clusterAwarePathHandler) Handle(path string, handler http.Handler) {
+	c.addHandlerForCluster(c.clusterName, handler)
+}
+
+// HACK: This is the implementation of OpenAPIServiceProvider
+// that allows supporting several logical clusters for CRD tenancy.
+//
+// However this should be conisdered a temporary step, to cope with the
+// current design of OpenAPI publishing. But having to register every logical
+// cluster creates more cost on creating logical clusters.
+// Instead, we'd expect us to slowly refactor the openapi generation code so
+// that it can be used dynamically, and time limited or size limited openapi caches
+// would be used to serve the calculated version.
+// Finally a development princple for the logical cluster prototype would be
+// - don't do static registration of logical clusters
+// - do lazy instantiation wherever possible so that starting a new logical cluster remains as cheap as possible
+type openAPIServiceProvider struct {
+	staticSpec                   *spec.Swagger
+	defaultOpenAPIServiceHandler http.Handler
+	defaultOpenAPIService        *handler.OpenAPIService
+	openAPIServices              map[string]*handler.OpenAPIService
+	handlers                     map[string]http.Handler
+	path                         string
+	mux                          *mux.PathRecorderMux
+}
+
+var _ OpenAPIServiceProvider = (*openAPIServiceProvider)(nil)
+
+func (p *openAPIServiceProvider) ForCluster(clusterName string) *handler.OpenAPIService {
+	return p.openAPIServices[clusterName]
+}
+
+func (p *openAPIServiceProvider) AddCuster(clusterName string) {
+	if _, found := p.openAPIServices[clusterName]; !found {
+		openAPIVersionedService, err := handler.RegisterOpenAPIVersionedService(p.staticSpec, p.path, &clusterAwarePathHandler{
+			clusterName: clusterName,
+			addHandlerForCluster: func(clusterName string, handler http.Handler) {
+				p.handlers[clusterName] = handler
+			},
+		})
+		if err != nil {
+			klog.Fatalf("Failed to register versioned open api spec for root: %v", err)
+		}
+		p.openAPIServices[clusterName] = openAPIVersionedService
+	}
+}
+
+func (p *openAPIServiceProvider) RemoveCuster(clusterName string) {
+	delete(p.openAPIServices, clusterName)
+	delete(p.handlers, clusterName)
+}
+
+func (p *openAPIServiceProvider) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
+	cluster := genericapirequest.ClusterFrom(req.Context())
+	if cluster == nil {
+		p.defaultOpenAPIServiceHandler.ServeHTTP(resp, req)
+		return
+	}
+	handler, found := p.handlers[cluster.Name]
+	if !found {
+		resp.WriteHeader(404)
+		return
+	}
+	handler.ServeHTTP(resp, req)
+}
+
+func (o *openAPIServiceProvider) UpdateSpec(openapiSpec *spec.Swagger) (err error) {
+	return o.defaultOpenAPIService.UpdateSpec(openapiSpec)
+}
+
+func (p *openAPIServiceProvider) Register() {
+	defaultOpenAPIService, err := handler.RegisterOpenAPIVersionedService(p.staticSpec, p.path, &clusterAwarePathHandler{
+		clusterName: "",
+		addHandlerForCluster: func(clusterName string, handler http.Handler) {
+			p.defaultOpenAPIServiceHandler = handler
+		},
+	})
+	if err != nil {
+		klog.Fatalf("Failed to register versioned open api spec for root: %v", err)
+	}
+	p.defaultOpenAPIService = defaultOpenAPIService
+	p.mux.Handle(p.path, p)
+}
+
 // Install adds the SwaggerUI webservice to the given mux.
-func (oa OpenAPI) Install(c *restful.Container, mux *mux.PathRecorderMux) (*handler.OpenAPIService, *spec.Swagger) {
+func (oa OpenAPI) Install(c *restful.Container, mux *mux.PathRecorderMux) (OpenAPIServiceProvider, *spec.Swagger) {
 	spec, err := builder.BuildOpenAPISpec(c.RegisteredWebServices(), oa.Config)
 	if err != nil {
 		klog.Fatalf("Failed to build open api spec for root: %v", err)
 	}
-	openAPIVersionedService, err := handler.RegisterOpenAPIVersionedService(spec, "/openapi/v2", mux)
-	if err != nil {
-		klog.Fatalf("Failed to register versioned open api spec for root: %v", err)
+
+	provider := &openAPIServiceProvider{
+		mux:             mux,
+		staticSpec:      spec,
+		openAPIServices: map[string]*handler.OpenAPIService{},
+		handlers:        map[string]http.Handler{},
+		path:            "/openapi/v2",
 	}
-	return openAPIVersionedService, spec
+
+	provider.Register()
+
+	return provider, spec
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
@@ -32,6 +32,7 @@ import (
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/conversion"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -114,6 +115,15 @@ func (s *store) Versioner() storage.Versioner {
 
 // Get implements storage.Interface.Get.
 func (s *store) Get(ctx context.Context, key string, resourceVersion string, out runtime.Object, ignoreNotFound bool) error {
+	clusterName := ""
+	cluster := genericapirequest.ClusterFrom(ctx)
+	if cluster != nil {
+		if cluster.Wildcard {
+			return storage.NewInternalError("Cluster wildcards cannot be used for Get actions: key = " + key)
+		}
+		clusterName = cluster.Name
+	}
+
 	key = path.Join(s.pathPrefix, key)
 	startTime := time.Now()
 	getResp, err := s.client.KV.Get(ctx, key, s.getOps...)
@@ -138,11 +148,20 @@ func (s *store) Get(ctx context.Context, key string, resourceVersion string, out
 		return storage.NewInternalError(err.Error())
 	}
 
-	return decode(s.codec, s.versioner, data, out, kv.ModRevision)
+	return decode(s.codec, s.versioner, data, out, kv.ModRevision, clusterName)
 }
 
 // Create implements storage.Interface.Create.
 func (s *store) Create(ctx context.Context, key string, obj, out runtime.Object, ttl uint64) error {
+	var clusterName string
+	cluster := genericapirequest.ClusterFrom(ctx)
+	if cluster != nil {
+		if cluster.Wildcard {
+			return storage.NewInternalError("Cluster wildcards cannot be used for Create actions: key = " + key)
+		}
+		clusterName = cluster.Name
+	}
+
 	if version, err := s.versioner.ObjectResourceVersion(obj); err == nil && version != 0 {
 		return errors.New("resourceVersion should not be set on objects to be created")
 	}
@@ -181,7 +200,7 @@ func (s *store) Create(ctx context.Context, key string, obj, out runtime.Object,
 
 	if out != nil {
 		putResp := txnResp.Responses[0].GetResponsePut()
-		return decode(s.codec, s.versioner, data, out, putResp.Header.Revision)
+		return decode(s.codec, s.versioner, data, out, putResp.Header.Revision, clusterName)
 	}
 	return nil
 }
@@ -197,6 +216,15 @@ func (s *store) Delete(ctx context.Context, key string, out runtime.Object, prec
 }
 
 func (s *store) conditionalDelete(ctx context.Context, key string, out runtime.Object, v reflect.Value, preconditions *storage.Preconditions, validateDeletion storage.ValidateObjectFunc) error {
+	clusterName := ""
+	cluster := genericapirequest.ClusterFrom(ctx)
+	if cluster != nil {
+		if cluster.Wildcard {
+			return storage.NewInternalError("Cluster wildcards cannot be used for conditionalDelete actions: key = " + key)
+		}
+		clusterName = cluster.Name
+	}
+
 	startTime := time.Now()
 	getResp, err := s.client.KV.Get(ctx, key)
 	metrics.RecordEtcdRequestLatency("get", getTypeName(out), startTime)
@@ -204,7 +232,7 @@ func (s *store) conditionalDelete(ctx context.Context, key string, out runtime.O
 		return err
 	}
 	for {
-		origState, err := s.getState(getResp, key, v, false)
+		origState, err := s.getState(getResp, key, v, false, clusterName)
 		if err != nil {
 			return err
 		}
@@ -233,7 +261,7 @@ func (s *store) conditionalDelete(ctx context.Context, key string, out runtime.O
 			klog.V(4).Infof("deletion of %s failed because of a conflict, going to retry", key)
 			continue
 		}
-		return decode(s.codec, s.versioner, origState.data, out, origState.rev)
+		return decode(s.codec, s.versioner, origState.data, out, origState.rev, clusterName)
 	}
 }
 
@@ -243,6 +271,15 @@ func (s *store) GuaranteedUpdate(
 	preconditions *storage.Preconditions, tryUpdate storage.UpdateFunc, suggestion ...runtime.Object) error {
 	trace := utiltrace.New("GuaranteedUpdate etcd3", utiltrace.Field{"type", getTypeName(out)})
 	defer trace.LogIfLong(500 * time.Millisecond)
+
+	clusterName := ""
+	cluster := genericapirequest.ClusterFrom(ctx)
+	if cluster != nil {
+		if cluster.Wildcard {
+			return storage.NewInternalError("Cluster wildcards cannot be used for GuaranteedUpdate actions: key = " + key)
+		}
+		clusterName = cluster.Name
+	}
 
 	v, err := conversion.EnforcePtr(out)
 	if err != nil {
@@ -257,7 +294,7 @@ func (s *store) GuaranteedUpdate(
 		if err != nil {
 			return nil, err
 		}
-		return s.getState(getResp, key, v, ignoreNotFound)
+		return s.getState(getResp, key, v, ignoreNotFound, clusterName)
 	}
 
 	var origState *objState
@@ -334,7 +371,7 @@ func (s *store) GuaranteedUpdate(
 			}
 			// recheck that the data from etcd is not stale before short-circuiting a write
 			if !origState.stale {
-				return decode(s.codec, s.versioner, origState.data, out, origState.rev)
+				return decode(s.codec, s.versioner, origState.data, out, origState.rev, clusterName)
 			}
 		}
 
@@ -365,7 +402,7 @@ func (s *store) GuaranteedUpdate(
 		if !txnResp.Succeeded {
 			getResp := (*clientv3.GetResponse)(txnResp.Responses[0].GetResponseRange())
 			klog.V(4).Infof("GuaranteedUpdate of %s failed because of a conflict, going to retry", key)
-			origState, err = s.getState(getResp, key, v, ignoreNotFound)
+			origState, err = s.getState(getResp, key, v, ignoreNotFound, clusterName)
 			if err != nil {
 				return err
 			}
@@ -375,7 +412,7 @@ func (s *store) GuaranteedUpdate(
 		}
 		putResp := txnResp.Responses[0].GetResponsePut()
 
-		return decode(s.codec, s.versioner, data, out, putResp.Header.Revision)
+		return decode(s.codec, s.versioner, data, out, putResp.Header.Revision, clusterName)
 	}
 }
 
@@ -414,7 +451,7 @@ func (s *store) GetToList(ctx context.Context, key string, resourceVersion strin
 		if err != nil {
 			return storage.NewInternalError(err.Error())
 		}
-		if err := appendListItem(v, data, uint64(getResp.Kvs[0].ModRevision), pred, s.codec, s.versioner, newItemFunc); err != nil {
+		if err := appendListItem(v, data, uint64(getResp.Kvs[0].ModRevision), pred, s.codec, s.versioner, newItemFunc, ""); err != nil {
 			return err
 		}
 	}
@@ -632,7 +669,18 @@ func (s *store) List(ctx context.Context, key, resourceVersion string, pred stor
 				return storage.NewInternalErrorf("unable to transform key %q: %v", kv.Key, err)
 			}
 
-			if err := appendListItem(v, data, uint64(kv.ModRevision), pred, s.codec, s.versioner, newItemFunc); err != nil {
+			cluster := genericapirequest.ClusterFrom(ctx)
+			clusterName := ""
+			if cluster != nil {
+				clusterName = cluster.Name
+				if cluster.Wildcard {
+					sub := strings.TrimPrefix(string(kv.Key), keyPrefix)
+					if i := strings.Index(sub, "/"); i != -1 {
+						clusterName = sub[:i]
+					}
+				}
+			}
+			if err := appendListItem(v, data, uint64(kv.ModRevision), pred, s.codec, s.versioner, newItemFunc, clusterName); err != nil {
 				return err
 			}
 		}
@@ -727,12 +775,21 @@ func (s *store) watch(ctx context.Context, key string, rv string, pred storage.S
 	key = path.Join(s.pathPrefix, key)
 	// HACK: would need to be an argument to storage (or a change to how decoding works for key structure)
 	cluster := genericapirequest.ClusterFrom(ctx)
-	extractClusterSegmentFromKey := cluster != nil && cluster.Wildcard
+	extractClusterSegmentFromKey := false
+	clusterName := ""
+	if cluster != nil {
+		clusterName = cluster.Name
+		if cluster.Wildcard {
+			clusterName = "*"
+			extractClusterSegmentFromKey = true
+		}
+	}
+
 	klog.Infof("DEBUG: key=%s willExtractCluster=%t", key, extractClusterSegmentFromKey)
-	return s.watcher.Watch(ctx, key, int64(rev), recursive, extractClusterSegmentFromKey, pred)
+	return s.watcher.Watch(ctx, key, int64(rev), recursive, clusterName, pred)
 }
 
-func (s *store) getState(getResp *clientv3.GetResponse, key string, v reflect.Value, ignoreNotFound bool) (*objState, error) {
+func (s *store) getState(getResp *clientv3.GetResponse, key string, v reflect.Value, ignoreNotFound bool, clusterName string) (*objState, error) {
 	state := &objState{
 		meta: &storage.ResponseMeta{},
 	}
@@ -759,7 +816,7 @@ func (s *store) getState(getResp *clientv3.GetResponse, key string, v reflect.Va
 		state.meta.ResourceVersion = uint64(state.rev)
 		state.data = data
 		state.stale = stale
-		if err := decode(s.codec, s.versioner, state.data, state.obj, state.rev); err != nil {
+		if err := decode(s.codec, s.versioner, state.data, state.obj, state.rev, clusterName); err != nil {
 			return nil, err
 		}
 	}
@@ -843,7 +900,7 @@ func (s *store) ensureMinimumResourceVersion(minimumResourceVersion string, actu
 
 // decode decodes value of bytes into object. It will also set the object resource version to rev.
 // On success, objPtr would be set to the object.
-func decode(codec runtime.Codec, versioner storage.Versioner, value []byte, objPtr runtime.Object, rev int64) error {
+func decode(codec runtime.Codec, versioner storage.Versioner, value []byte, objPtr runtime.Object, rev int64, clusterName string) error {
 	if _, err := conversion.EnforcePtr(objPtr); err != nil {
 		return fmt.Errorf("unable to convert output object to pointer: %v", err)
 	}
@@ -855,11 +912,31 @@ func decode(codec runtime.Codec, versioner storage.Versioner, value []byte, objP
 	if err := versioner.UpdateObject(objPtr, uint64(rev)); err != nil {
 		klog.Errorf("failed to update object version: %v", err)
 	}
+	// HACK: in order to support CRD tenancy, the clusterName, which is extracted from the object etcd key,
+	// should be set on the decoded object.
+	// This is done here since we want to set the logical cluster the object is part of,
+	// without storing the clusterName inside the etcd object itself (as it has been until now).
+	// The etcd key is ultimately the only thing that links us to a cluster
+	if clusterName != "" {
+		if s, ok := objPtr.(metav1.ObjectMetaAccessor); ok {
+			klog.Infof("Setting ClusterName %s in appendListItem", clusterName)
+			s.GetObjectMeta().SetClusterName(clusterName)
+		} else if s, ok := objPtr.(metav1.Object); ok {
+			klog.Infof("Setting ClusterName %s in appendListItem", clusterName)
+			s.SetClusterName(clusterName)
+		} else if s, ok := objPtr.(*unstructured.Unstructured); ok {
+			klog.Infof("SUB: %s", clusterName)
+			s.SetClusterName(clusterName)
+		} else {
+			klog.Infof("Could not set ClusterName %s in appendListItem on object: %T", clusterName, objPtr)
+		}
+	}
+
 	return nil
 }
 
 // appendListItem decodes and appends the object (if it passes filter) to v, which must be a slice.
-func appendListItem(v reflect.Value, data []byte, rev uint64, pred storage.SelectionPredicate, codec runtime.Codec, versioner storage.Versioner, newItemFunc func() runtime.Object) error {
+func appendListItem(v reflect.Value, data []byte, rev uint64, pred storage.SelectionPredicate, codec runtime.Codec, versioner storage.Versioner, newItemFunc func() runtime.Object, clusterName string) error {
 	obj, _, err := codec.Decode(data, nil, newItemFunc())
 	if err != nil {
 		return err
@@ -868,6 +945,27 @@ func appendListItem(v reflect.Value, data []byte, rev uint64, pred storage.Selec
 	if err := versioner.UpdateObject(obj, rev); err != nil {
 		klog.Errorf("failed to update object version: %v", err)
 	}
+
+	// HACK: in order to support CRD tenancy, the clusterName, which is extracted from the object etcd key,
+	// should be set on the decoded object.
+	// This is done here since we want to set the logical cluster the object is part of,
+	// without storing the clusterName inside the etcd object itself (as it has been until now).
+	// The etcd key is ultimately the only thing that links us to a cluster
+	if clusterName != "" {
+		if s, ok := obj.(metav1.ObjectMetaAccessor); ok {
+			klog.Infof("Setting ClusterName %s in appendListItem", clusterName)
+			s.GetObjectMeta().SetClusterName(clusterName)
+		} else if s, ok := obj.(metav1.Object); ok {
+			klog.Infof("Setting ClusterName %s in appendListItem", clusterName)
+			s.SetClusterName(clusterName)
+		} else if s, ok := obj.(*unstructured.Unstructured); ok {
+			klog.Infof("SUB: %s", clusterName)
+			s.SetClusterName(clusterName)
+		} else {
+			klog.Infof("Could not set ClusterName %s in appendListItem on object: %T", clusterName, obj)
+		}
+	}
+
 	if matched, err := pred.Matches(obj); err == nil && matched {
 		v.Set(reflect.Append(v, reflect.ValueOf(obj).Elem()))
 	}

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apiserver/pkg/storage/value"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"go.etcd.io/etcd/clientv3"
 	"k8s.io/klog"
@@ -88,7 +89,7 @@ type watchChan struct {
 	errChan           chan error
 
 	// HACK: testing watch across multiple prefixes
-	extractCluster bool
+	clusterName string
 }
 
 func newWatcher(client *clientv3.Client, codec runtime.Codec, versioner storage.Versioner, transformer value.Transformer) *watcher {
@@ -107,16 +108,16 @@ func newWatcher(client *clientv3.Client, codec runtime.Codec, versioner storage.
 // If recursive is false, it watches on given key.
 // If recursive is true, it watches any children and directories under the key, excluding the root key itself.
 // pred must be non-nil. Only if pred matches the change, it will be returned.
-func (w *watcher) Watch(ctx context.Context, key string, rev int64, recursive, clusterAsFirstSegment bool, pred storage.SelectionPredicate) (watch.Interface, error) {
+func (w *watcher) Watch(ctx context.Context, key string, rev int64, recursive bool, clusterName string, pred storage.SelectionPredicate) (watch.Interface, error) {
 	if recursive && !strings.HasSuffix(key, "/") {
 		key += "/"
 	}
-	wc := w.createWatchChan(ctx, key, rev, recursive, clusterAsFirstSegment, pred)
+	wc := w.createWatchChan(ctx, key, rev, recursive, clusterName, pred)
 	go wc.run()
 	return wc, nil
 }
 
-func (w *watcher) createWatchChan(ctx context.Context, key string, rev int64, recursive, clusterAsFirstSegment bool, pred storage.SelectionPredicate) *watchChan {
+func (w *watcher) createWatchChan(ctx context.Context, key string, rev int64, recursive bool, clusterName string, pred storage.SelectionPredicate) *watchChan {
 	wc := &watchChan{
 		watcher:           w,
 		key:               key,
@@ -128,7 +129,7 @@ func (w *watcher) createWatchChan(ctx context.Context, key string, rev int64, re
 		errChan:           make(chan error, 1),
 
 		// HACK: assume structure of key is <prefix><cluster>/...
-		extractCluster: clusterAsFirstSegment,
+		clusterName: clusterName,
 	}
 	if pred.Empty() {
 		// The filter doesn't filter out any object.
@@ -388,16 +389,31 @@ func (wc *watchChan) prepareObjs(e *event) (curObj runtime.Object, oldObj runtim
 		if err != nil {
 			return nil, nil, err
 		}
-		if wc.extractCluster {
+		clusterName := ""
+		if wc.clusterName == "*" {
 			sub := strings.TrimPrefix(e.key, wc.key)
 			if i := strings.Index(sub, "/"); i != -1 {
 				sub = sub[:i]
 			}
+			clusterName = sub
+		}
+		// HACK: in order to support CRD tenancy, the clusterName, which is extracted from the object etcd key,
+		// should be set on the decoded object.
+		// This is done here since we want to set the logical cluster the object is part of,
+		// without storing the clusterName inside the etcd object itself (as it has been until now).
+		// The etcd key is ultimately the only thing that links us to a cluster
+		if clusterName != "" {
 			if s, ok := curObj.(metav1.ObjectMetaAccessor); ok {
-				klog.Infof("SUB: %s", sub)
-				s.GetObjectMeta().SetClusterName(sub)
+				klog.Infof("SUB: %s", clusterName)
+				s.GetObjectMeta().SetClusterName(clusterName)
+			} else if s, ok := curObj.(metav1.Object); ok {
+				klog.Infof("SUB: %s", clusterName)
+				s.SetClusterName(clusterName)
+			} else if s, ok := curObj.(*unstructured.Unstructured); ok {
+				klog.Infof("SUB: %s", clusterName)
+				s.SetClusterName(clusterName)
 			} else {
-				klog.Infof("NO SUB: %T %s", curObj, sub)
+				klog.Infof("NO SUB: %T %s", curObj, clusterName)
 			}
 		}
 	}
@@ -417,16 +433,31 @@ func (wc *watchChan) prepareObjs(e *event) (curObj runtime.Object, oldObj runtim
 		if err != nil {
 			return nil, nil, err
 		}
-		if wc.extractCluster {
+		clusterName := ""
+		if wc.clusterName == "*" {
 			sub := strings.TrimPrefix(e.key, wc.key)
 			if i := strings.Index(sub, "/"); i != -1 {
 				sub = sub[:i]
 			}
+			clusterName = sub
+		}
+		// HACK: in order to support CRD tenancy, the clusterName, which is extracted from the object etcd key,
+		// should be set on the decoded object.
+		// This is done here since we want to set the logical cluster the object is part of,
+		// without storing the clusterName inside the etcd object itself (as it has been until now).
+		// The etcd key is ultimately the only thing that links us to a cluster
+		if clusterName != "" {
 			if s, ok := oldObj.(metav1.ObjectMetaAccessor); ok {
-				klog.Infof("SUB: %s", sub)
-				s.GetObjectMeta().SetClusterName(sub)
+				klog.Infof("SUB: %s", clusterName)
+				s.GetObjectMeta().SetClusterName(clusterName)
+			} else if s, ok := oldObj.(metav1.Object); ok {
+				klog.Infof("SUB: %s", clusterName)
+				s.SetClusterName(clusterName)
+			} else if s, ok := oldObj.(*unstructured.Unstructured); ok {
+				klog.Infof("SUB: %s", clusterName)
+				s.SetClusterName(clusterName)
 			} else {
-				klog.Infof("NO SUB: %T %s", oldObj, sub)
+				klog.Infof("NO SUB: %T %s", oldObj, clusterName)
 			}
 		}
 

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher_test.go
@@ -246,7 +246,7 @@ func TestWatchContextCancel(t *testing.T) {
 	cancel()
 	// When we watch with a canceled context, we should detect that it's context canceled.
 	// We won't take it as error and also close the watcher.
-	w, err := store.watcher.Watch(canceledCtx, "/abc", 0, false, storage.Everything)
+	w, err := store.watcher.Watch(canceledCtx, "/abc", 0, false, "", storage.Everything)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -265,7 +265,7 @@ func TestWatchErrResultNotBlockAfterCancel(t *testing.T) {
 	origCtx, store, cluster := testSetup(t)
 	defer cluster.Terminate(t)
 	ctx, cancel := context.WithCancel(origCtx)
-	w := store.watcher.createWatchChan(ctx, "/abc", 0, false, storage.Everything)
+	w := store.watcher.createWatchChan(ctx, "/abc", 0, false, "", storage.Everything)
 	// make resutlChan and errChan blocking to ensure ordering.
 	w.resultChan = make(chan watch.Event)
 	w.errChan = make(chan error)

--- a/staging/src/k8s.io/client-go/tools/cache/store.go
+++ b/staging/src/k8s.io/client-go/tools/cache/store.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/client-go/tools/clusters"
 )
 
 // Store is a generic object storage and processing interface.  A
@@ -100,14 +101,16 @@ func MetaNamespaceKeyFunc(obj interface{}) (string, error) {
 	if key, ok := obj.(ExplicitKey); ok {
 		return string(key), nil
 	}
-	meta, err := meta.Accessor(obj)
+	metaObj, err := meta.Accessor(obj)
 	if err != nil {
 		return "", fmt.Errorf("object has no meta: %v", err)
 	}
-	if len(meta.GetNamespace()) > 0 {
-		return meta.GetNamespace() + "/" + meta.GetName(), nil
+
+	name := clusters.ToClusterAwareKey(metaObj.GetClusterName(), metaObj.GetName())
+	if len(metaObj.GetNamespace()) > 0 {
+		return metaObj.GetNamespace() + "/" + name, nil
 	}
-	return meta.GetName(), nil
+	return name, nil
 }
 
 // SplitMetaNamespaceKey returns the namespace and name that

--- a/staging/src/k8s.io/client-go/tools/clusters/cache.go
+++ b/staging/src/k8s.io/client-go/tools/clusters/cache.go
@@ -1,0 +1,30 @@
+package clusters
+
+import "strings"
+
+// ToClusterAwareKey allows combining the object name and
+// the object cluster in a single key that can be used by informers.
+// This is KCP-related hack useful when watching across several
+// logical clusters using a wildcard context cluster
+//
+// This is a temporary hack and should be replaced by thoughtful
+// and real support of logical cluster in the client-go layer
+func ToClusterAwareKey(clusterName, name string) string {
+	if clusterName != "" {
+		return clusterName + "#$#" + name
+	}
+
+	return name
+}
+
+// ToClusterAwareKey just allows extract the name and clusterName
+// from a Key initially created with ToClusterAwareKey
+func SplitClusterAwareKey(clusterAwareKey string) (clusterName, name string) {
+	parts := strings.SplitN(clusterAwareKey, "#$#", 2)
+	if len(parts) == 1 {
+		// name only, no cluster
+		return "", parts[0]
+	}
+	// clusterName and name
+	return parts[0], parts[1]
+}

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/apiserver.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/apiserver.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/client-go/pkg/version"
 	openapicommon "k8s.io/kube-openapi/pkg/common"
 
+	"k8s.io/client-go/tools/clusters"
 	v1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 	v1helper "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1/helper"
 	"k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1"
@@ -119,6 +120,9 @@ type APIAggregator struct {
 	// handledGroups are the groups that already have routes
 	handledGroups sets.String
 
+	// pathToClusters is a map that provids a list of clusters for which a given path is to be visible
+	pathToClusters map[string][]string
+
 	// lister is used to add group handling for /apis/<group> aggregator lookups based on
 	// controller state
 	lister listers.APIServiceLister
@@ -184,12 +188,28 @@ func (c completedConfig) NewWithDelegate(delegationTarget genericapiserver.Deleg
 		proxyClientKey:           c.ExtraConfig.ProxyClientKey,
 		proxyTransport:           c.ExtraConfig.ProxyTransport,
 		proxyHandlers:            map[string]*proxyHandler{},
+		pathToClusters:           map[string][]string{},
 		handledGroups:            sets.String{},
 		lister:                   informerFactory.Apiregistration().V1().APIServices().Lister(),
 		APIRegistrationInformers: informerFactory,
 		serviceResolver:          c.ExtraConfig.ServiceResolver,
 		openAPIConfig:            openAPIConfig,
 		egressSelector:           c.GenericConfig.EgressSelector,
+	}
+
+	s.GenericAPIServer.Handler.PathValidForCluster = func(path, clusterName string) bool {
+		clusters, found := s.pathToClusters[path]
+		if !found {
+			return true
+		}
+
+		for _, cluster := range clusters {
+			if cluster == clusterName {
+				return true
+			}
+		}
+
+		return false
 	}
 
 	apiGroupInfo := apiservicerest.NewRESTStorage(c.GenericConfig.MergedResourceConfig, c.GenericConfig.RESTOptionsGetter)
@@ -315,6 +335,12 @@ func (s *APIAggregator) AddAPIService(apiService *v1.APIService) error {
 		s.openAPIAggregationController.AddAPIService(proxyHandler, apiService)
 	}
 	s.proxyHandlers[apiService.Name] = proxyHandler
+
+	if !IsVersionForAllClusters(apiService.Spec) {
+		s.pathToClusters[proxyPath] = append(s.pathToClusters[proxyPath], apiService.GetClusterName())
+		s.pathToClusters[proxyPath+"/"] = append(s.pathToClusters[proxyPath+"/"], apiService.GetClusterName())
+	}
+
 	s.GenericAPIServer.Handler.NonGoRestfulMux.Handle(proxyPath, proxyHandler)
 	s.GenericAPIServer.Handler.NonGoRestfulMux.UnlistedHandlePrefix(proxyPath+"/", proxyHandler)
 
@@ -337,6 +363,11 @@ func (s *APIAggregator) AddAPIService(apiService *v1.APIService) error {
 		delegate:  s.delegateHandler,
 	}
 	// aggregation is protected
+
+	if !IsGroupForAllClusters(apiService.Spec.Group) {
+		s.pathToClusters[groupPath] = append(s.pathToClusters[groupPath], apiService.GetClusterName())
+		s.pathToClusters[groupPath+"/"] = s.pathToClusters[groupPath]
+	}
 	s.GenericAPIServer.Handler.NonGoRestfulMux.Handle(groupPath, groupDiscoveryHandler)
 	s.GenericAPIServer.Handler.NonGoRestfulMux.UnlistedHandle(groupPath+"/", groupDiscoveryHandler)
 	s.handledGroups.Insert(apiService.Spec.Group)
@@ -345,7 +376,8 @@ func (s *APIAggregator) AddAPIService(apiService *v1.APIService) error {
 
 // RemoveAPIService removes the APIService from being handled.  It is not thread-safe, so only call it on one thread at a time please.
 // It's a slow moving API, so it's ok to run the controller on a single thread.
-func (s *APIAggregator) RemoveAPIService(apiServiceName string) {
+func (s *APIAggregator) RemoveAPIService(clusterAndApiServiceName string) {
+	clusterName, apiServiceName := clusters.SplitClusterAwareKey(clusterAndApiServiceName)
 	version := v1helper.APIServiceNameToGroupVersion(apiServiceName)
 
 	proxyPath := "/apis/" + version.Group + "/" + version.Version
@@ -353,15 +385,29 @@ func (s *APIAggregator) RemoveAPIService(apiServiceName string) {
 	if apiServiceName == legacyAPIServiceName {
 		proxyPath = "/api"
 	}
-	s.GenericAPIServer.Handler.NonGoRestfulMux.Unregister(proxyPath)
-	s.GenericAPIServer.Handler.NonGoRestfulMux.Unregister(proxyPath + "/")
-	if s.openAPIAggregationController != nil {
-		s.openAPIAggregationController.RemoveAPIService(apiServiceName)
-	}
-	delete(s.proxyHandlers, apiServiceName)
 
-	// TODO unregister group level discovery when there are no more versions for the group
-	// We don't need this right away because the handler properly delegates when no versions are present
+	if clusterName != "" {
+		newPathToClusters := sets.NewString(s.pathToClusters[proxyPath]...).Delete(clusterName).List()
+
+		if len(newPathToClusters) > 0 {
+			s.pathToClusters[proxyPath] = newPathToClusters
+			s.pathToClusters[proxyPath+"/"] = s.pathToClusters[proxyPath]
+		} else {
+			s.GenericAPIServer.Handler.NonGoRestfulMux.Unregister(proxyPath)
+			s.GenericAPIServer.Handler.NonGoRestfulMux.Unregister(proxyPath + "/")
+			if s.openAPIAggregationController != nil {
+				s.openAPIAggregationController.RemoveAPIService(apiServiceName)
+			}
+			delete(s.proxyHandlers, apiServiceName)
+
+			// TODO unregister group level discovery when there are no more versions for the group
+			// We don't need this right away because the handler properly delegates when no versions are present
+
+			delete(s.pathToClusters, proxyPath)
+			delete(s.pathToClusters, proxyPath+"/")
+		}
+
+	}
 }
 
 // DefaultAPIResourceConfigSource returns default configuration for an APIResource.

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/apiservice_controller.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/apiservice_controller.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 
-	"k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
+	v1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 	informers "k8s.io/kube-aggregator/pkg/client/informers/externalversions/apiregistration/v1"
 	listers "k8s.io/kube-aggregator/pkg/client/listers/apiregistration/v1"
 	"k8s.io/kube-aggregator/pkg/controllers"
@@ -37,7 +37,7 @@ import (
 // APIHandlerManager defines the behaviour that an API handler should have.
 type APIHandlerManager interface {
 	AddAPIService(apiService *v1.APIService) error
-	RemoveAPIService(apiServiceName string)
+	RemoveAPIService(clusterAndApiServiceName string)
 }
 
 // APIServiceRegistrationController is responsible for registering and removing API services.

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_apis.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_apis.go
@@ -28,10 +28,13 @@ import (
 	"k8s.io/apiserver/pkg/endpoints/handlers/negotiation"
 	"k8s.io/apiserver/pkg/endpoints/handlers/responsewriters"
 
+	extensionsapiserver "k8s.io/apiextensions-apiserver/pkg/apiserver"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	apiregistrationv1api "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 	apiregistrationv1apihelper "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1/helper"
 	apiregistrationv1beta1api "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1"
 	listers "k8s.io/kube-aggregator/pkg/client/listers/apiregistration/v1"
+	"k8s.io/kubernetes/pkg/api/controlplanescheme"
 )
 
 // apisHandler serves the `/apis` endpoint.
@@ -74,6 +77,12 @@ func (r *apisHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		Groups: []metav1.APIGroup{r.discoveryGroup},
 	}
 
+	clusterName := ""
+	cluster := genericapirequest.ClusterFrom(req.Context())
+	if cluster != nil {
+		clusterName = cluster.Name
+	}
+
 	apiServices, err := r.lister.List(labels.Everything())
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -85,7 +94,7 @@ func (r *apisHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		if len(apiGroupServers[0].Spec.Group) == 0 {
 			continue
 		}
-		discoveryGroup := convertToDiscoveryAPIGroup(apiGroupServers)
+		discoveryGroup := convertToDiscoveryAPIGroup(clusterName, apiGroupServers)
 		if discoveryGroup != nil {
 			discoveryGroupList.Groups = append(discoveryGroupList.Groups, *discoveryGroup)
 		}
@@ -94,14 +103,31 @@ func (r *apisHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	responsewriters.WriteObjectNegotiated(r.codecs, negotiation.DefaultEndpointRestrictions, schema.GroupVersion{}, w, req, http.StatusOK, discoveryGroupList)
 }
 
+func IsVersionForAllClusters(serviceSpec apiregistrationv1api.APIServiceSpec) bool {
+	return controlplanescheme.Scheme.IsVersionRegistered(schema.GroupVersion{
+		Group:   serviceSpec.Group,
+		Version: serviceSpec.Version,
+	}) || extensionsapiserver.Scheme.IsVersionRegistered(schema.GroupVersion{
+		Group:   serviceSpec.Group,
+		Version: serviceSpec.Version,
+	})
+}
+
+func IsGroupForAllClusters(group string) bool {
+	return controlplanescheme.Scheme.IsGroupRegistered(group) || extensionsapiserver.Scheme.IsGroupRegistered(group)
+}
+
 // convertToDiscoveryAPIGroup takes apiservices in a single group and returns a discovery compatible object.
 // if none of the services are available, it will return nil.
-func convertToDiscoveryAPIGroup(apiServices []*apiregistrationv1api.APIService) *metav1.APIGroup {
+func convertToDiscoveryAPIGroup(clusterName string, apiServices []*apiregistrationv1api.APIService) *metav1.APIGroup {
 	apiServicesByGroup := apiregistrationv1apihelper.SortedByGroupAndVersion(apiServices)[0]
 
 	var discoveryGroup *metav1.APIGroup
-
 	for _, apiService := range apiServicesByGroup {
+
+		if !IsVersionForAllClusters(apiService.Spec) && apiService.GetClusterName() != clusterName {
+			continue
+		}
 		// the first APIService which is valid becomes the default
 		if discoveryGroup == nil {
 			discoveryGroup = &metav1.APIGroup{
@@ -135,6 +161,12 @@ type apiGroupHandler struct {
 }
 
 func (r *apiGroupHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	clusterName := ""
+	cluster := genericapirequest.ClusterFrom(req.Context())
+	if cluster != nil {
+		clusterName = cluster.Name
+	}
+
 	apiServices, err := r.lister.List(labels.Everything())
 	if statusErr, ok := err.(*apierrors.StatusError); ok && err != nil {
 		responsewriters.WriteRawJSON(int(statusErr.Status().Code), statusErr.Status(), w)
@@ -147,7 +179,7 @@ func (r *apiGroupHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 	apiServicesForGroup := []*apiregistrationv1api.APIService{}
 	for _, apiService := range apiServices {
-		if apiService.Spec.Group == r.groupName {
+		if apiService.Spec.Group == r.groupName && apiService.GetClusterName() == clusterName {
 			apiServicesForGroup = append(apiServicesForGroup, apiService)
 		}
 	}
@@ -157,7 +189,7 @@ func (r *apiGroupHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	discoveryGroup := convertToDiscoveryAPIGroup(apiServicesForGroup)
+	discoveryGroup := convertToDiscoveryAPIGroup(clusterName, apiServicesForGroup)
 	if discoveryGroup == nil {
 		http.Error(w, "", http.StatusNotFound)
 		return

--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/autoregister/autoregister_controller.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/autoregister/autoregister_controller.go
@@ -33,6 +33,8 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/client-go/tools/clusters"
 	"k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 	apiregistrationclient "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1"
 	informers "k8s.io/kube-aggregator/pkg/client/informers/externalversions/apiregistration/v1"
@@ -58,7 +60,7 @@ type AutoAPIServiceRegistration interface {
 	// AddAPIServiceToSync adds an API service to sync continuously.
 	AddAPIServiceToSync(in *v1.APIService)
 	// RemoveAPIServiceToSync removes an API service to auto-register.
-	RemoveAPIServiceToSync(name string)
+	RemoveAPIServiceToSync(clusterAndName string)
 }
 
 // autoRegisterController is used to keep a particular set of APIServices present in the API.  It is useful
@@ -71,7 +73,7 @@ type autoRegisterController struct {
 	apiServicesToSyncLock sync.RWMutex
 	apiServicesToSync     map[string]*v1.APIService
 
-	syncHandler func(apiServiceName string) error
+	syncHandler func(clusterAndApiServiceName string) error
 
 	// track which services we have synced
 	syncedSuccessfullyLock *sync.RWMutex
@@ -104,11 +106,11 @@ func NewAutoRegisterController(apiServiceInformer informers.APIServiceInformer, 
 	apiServiceInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			cast := obj.(*v1.APIService)
-			c.queue.Add(cast.Name)
+			c.queue.Add(clusters.ToClusterAwareKey(cast.GetClusterName(), cast.Name))
 		},
 		UpdateFunc: func(_, obj interface{}) {
 			cast := obj.(*v1.APIService)
-			c.queue.Add(cast.Name)
+			c.queue.Add(clusters.ToClusterAwareKey(cast.GetClusterName(), cast.Name))
 		},
 		DeleteFunc: func(obj interface{}) {
 			cast, ok := obj.(*v1.APIService)
@@ -124,7 +126,7 @@ func NewAutoRegisterController(apiServiceInformer informers.APIServiceInformer, 
 					return
 				}
 			}
-			c.queue.Add(cast.Name)
+			c.queue.Add(clusters.ToClusterAwareKey(cast.GetClusterName(), cast.Name))
 		},
 	})
 
@@ -149,7 +151,7 @@ func (c *autoRegisterController) Run(threadiness int, stopCh <-chan struct{}) {
 	// record APIService objects that existed when we started
 	if services, err := c.apiServiceLister.List(labels.Everything()); err == nil {
 		for _, service := range services {
-			c.apiServicesAtStart[service.Name] = true
+			c.apiServicesAtStart[clusters.ToClusterAwareKey(service.GetClusterName(), service.Name)] = true
 		}
 	}
 
@@ -212,16 +214,16 @@ func (c *autoRegisterController) processNextWorkItem() bool {
 // 4. current: sync on start, not present at start | -                     | -                         | -
 // 5. current: sync on start, present at start     | delete once           | update once               | update once
 // 6. current: sync always                         | delete                | update once               | update
-func (c *autoRegisterController) checkAPIService(name string) (err error) {
-	desired := c.GetAPIServiceToSync(name)
-	curr, err := c.apiServiceLister.Get(name)
+func (c *autoRegisterController) checkAPIService(clusterAndName string) (err error) {
+	desired := c.GetAPIServiceToSync(clusterAndName)
+	curr, err := c.apiServiceLister.Get(clusterAndName)
 
 	// if we've never synced this service successfully, record a successful sync.
-	hasSynced := c.hasSyncedSuccessfully(name)
+	hasSynced := c.hasSyncedSuccessfully(clusterAndName)
 	if !hasSynced {
 		defer func() {
 			if err == nil {
-				c.setSyncedSuccessfully(name)
+				c.setSyncedSuccessfully(clusterAndName)
 			}
 		}()
 	}
@@ -241,7 +243,10 @@ func (c *autoRegisterController) checkAPIService(name string) (err error) {
 
 	// we don't have an entry and we do want one (2B,2C)
 	case apierrors.IsNotFound(err) && desired != nil:
-		_, err := c.apiServiceClient.APIServices().Create(context.TODO(), desired, metav1.CreateOptions{})
+		context := genericapirequest.WithCluster(context.TODO(), genericapirequest.Cluster{
+			Name: desired.GetClusterName(),
+		})
+		_, err := c.apiServiceClient.APIServices().Create(context, desired, metav1.CreateOptions{})
 		if apierrors.IsAlreadyExists(err) {
 			// created in the meantime, we'll get called again
 			return nil
@@ -253,7 +258,7 @@ func (c *autoRegisterController) checkAPIService(name string) (err error) {
 		return nil
 
 	// the remote object only wants to sync on start, but was added after we started (4A,4B,4C)
-	case isAutomanagedOnStart(curr) && !c.apiServicesAtStart[name]:
+	case isAutomanagedOnStart(curr) && !c.apiServicesAtStart[clusterAndName]:
 		return nil
 
 	// the remote object only wants to sync on start and has already synced (5A,5B,5C "once" enforcement)
@@ -263,7 +268,10 @@ func (c *autoRegisterController) checkAPIService(name string) (err error) {
 	// we have a spurious APIService that we're managing, delete it (5A,6A)
 	case desired == nil:
 		opts := metav1.DeleteOptions{Preconditions: metav1.NewUIDPreconditions(string(curr.UID))}
-		err := c.apiServiceClient.APIServices().Delete(context.TODO(), curr.Name, opts)
+		context := genericapirequest.WithCluster(context.TODO(), genericapirequest.Cluster{
+			Name: curr.GetClusterName(),
+		})
+		err := c.apiServiceClient.APIServices().Delete(context, curr.Name, opts)
 		if apierrors.IsNotFound(err) || apierrors.IsConflict(err) {
 			// deleted or changed in the meantime, we'll get called again
 			return nil
@@ -287,11 +295,11 @@ func (c *autoRegisterController) checkAPIService(name string) (err error) {
 }
 
 // GetAPIServiceToSync gets a single API service to sync.
-func (c *autoRegisterController) GetAPIServiceToSync(name string) *v1.APIService {
+func (c *autoRegisterController) GetAPIServiceToSync(clusterAndName string) *v1.APIService {
 	c.apiServicesToSyncLock.RLock()
 	defer c.apiServicesToSyncLock.RUnlock()
 
-	return c.apiServicesToSync[name]
+	return c.apiServicesToSync[clusterAndName]
 }
 
 // AddAPIServiceToSyncOnStart registers an API service to sync only when the controller starts.
@@ -314,29 +322,30 @@ func (c *autoRegisterController) addAPIServiceToSync(in *v1.APIService, syncType
 	}
 	apiService.Labels[AutoRegisterManagedLabel] = syncType
 
-	c.apiServicesToSync[apiService.Name] = apiService
-	c.queue.Add(apiService.Name)
+	clusterAndName := clusters.ToClusterAwareKey(apiService.GetClusterName(), apiService.Name)
+	c.apiServicesToSync[clusterAndName] = apiService
+	c.queue.Add(clusterAndName)
 }
 
 // RemoveAPIServiceToSync deletes a registered APIService.
-func (c *autoRegisterController) RemoveAPIServiceToSync(name string) {
+func (c *autoRegisterController) RemoveAPIServiceToSync(clusterAndName string) {
 	c.apiServicesToSyncLock.Lock()
 	defer c.apiServicesToSyncLock.Unlock()
 
-	delete(c.apiServicesToSync, name)
-	c.queue.Add(name)
+	delete(c.apiServicesToSync, clusterAndName)
+	c.queue.Add(clusterAndName)
 }
 
-func (c *autoRegisterController) hasSyncedSuccessfully(name string) bool {
+func (c *autoRegisterController) hasSyncedSuccessfully(clusterAndName string) bool {
 	c.syncedSuccessfullyLock.RLock()
 	defer c.syncedSuccessfullyLock.RUnlock()
-	return c.syncedSuccessfully[name]
+	return c.syncedSuccessfully[clusterAndName]
 }
 
-func (c *autoRegisterController) setSyncedSuccessfully(name string) {
+func (c *autoRegisterController) setSyncedSuccessfully(clusterAndName string) {
 	c.syncedSuccessfullyLock.Lock()
 	defer c.syncedSuccessfullyLock.Unlock()
-	c.syncedSuccessfully[name] = true
+	c.syncedSuccessfully[clusterAndName] = true
 }
 
 func automanagedType(service *v1.APIService) string {

--- a/test/e2e/apimachinery/discovery.go
+++ b/test/e2e/apimachinery/discovery.go
@@ -63,7 +63,7 @@ var _ = SIGDescribe("Discovery", func() {
 		// is an implementation detail, which shouldn't be relied on by
 		// the clients. The following calculation is for test purpose
 		// only.
-		expected := discovery.StorageVersionHash(spec.Group, storageVersion, spec.Names.Kind)
+		expected := discovery.StorageVersionHash(testcrd.Crd.GetClusterName(), spec.Group, storageVersion, spec.Names.Kind)
 
 		for _, r := range resources.APIResources {
 			if r.Name == spec.Names.Plural {


### PR DESCRIPTION
This PR adds CRD tenancy by ensuring that logical clusters are taken in account in:
- CRD-related controllers
- APIServices-related controllers
- Discovery + OpenAPI endpoints

Main changes:
- At the client-go level:
    - introduce a roundtripper in the lookpack config, to correctly set the cluster name (or wildcards) in the request header according to the type, and verb of the K8S request (only for CRD and APIService resource types)
    - Update the default informer `KeyFunc` (`MetaNamespaceKeyFunc`) to take the resource `ClusterName` into account in the created key, to ensure we can distinguish resources from different clusters with the same name when listing or watching with client-go using cluster wildcards
- At the `etcd` storage level:
    - extend / complete the changes made by Clayton (for watches) to extend multi-cluster searches to LIST requests, and set the `ClusterName` correctly in the resulting object of  all types of REST requests.
- At the controller level:
  - In both `CRD`-related controllers and `APIService`-related controllers, ensure that they take the clustername everywhere in the code, and don't mix objects from different clusters but with the same name,
- At the generic API server level :
    - Add a `clusterName` parameter to the `ListedPathProvider.ListedPath()` interface function to allow filtering the listed paths per `clusterName`
    - Implement this filtering mechanism in several places
    - Replace the `GenericApiServer.openAPIServices` by an `OpenAPIServiceProvider` that allows managing openAPIServices and associated http handlers per clusterName.
    
... probably some other changes I don't think of now.   
 