### PR TITLE
HACK: Ensure the `clusterName` is managed consistently...

### DIFF
--- a/pkg/controlplane/clientutils/multiclusterconfig.go
+++ b/pkg/controlplane/clientutils/multiclusterconfig.go
@@ -22,6 +22,7 @@ package clientutils
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -147,9 +148,10 @@ func (mcrt *multiClusterClientConfigRoundTripper) RoundTrip(req *http.Request) (
 				}
 			}
 		}
-		if headerCluster != "" {
-			req.Header.Add("X-Kubernetes-Cluster", headerCluster)
+		if headerCluster == "" {
+			return nil, fmt.Errorf("Cluster should not be empty for request '%s' on resource '%s' (%s)", requestInfo.Verb, requestInfo.Resource, requestInfo.Path)
 		}
+		req.Header.Add("X-Kubernetes-Cluster", headerCluster)
 	}
 	return mcrt.rt.RoundTrip(req)
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_discovery.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_discovery.go
@@ -42,10 +42,10 @@ func (r *versionDiscoveryHandler) ServeHTTP(w http.ResponseWriter, req *http.Req
 		return
 	}
 
-	clusterName := ""
-	cluster := genericapirequest.ClusterFrom(req.Context())
-	if cluster != nil {
-		clusterName = cluster.Name
+	clusterName, err := genericapirequest.ClusterNameFrom(req.Context())
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
 	}
 
 	discovery, ok := r.getDiscovery(clusterName, schema.GroupVersion{Group: pathParts[1], Version: pathParts[2]})
@@ -109,10 +109,10 @@ func (r *groupDiscoveryHandler) ServeHTTP(w http.ResponseWriter, req *http.Reque
 		return
 	}
 
-	clusterName := ""
-	cluster := genericapirequest.ClusterFrom(req.Context())
-	if cluster != nil {
-		clusterName = cluster.Name
+	clusterName, err := genericapirequest.ClusterNameFrom(req.Context())
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
 	}
 
 	discovery, ok := r.getDiscovery(clusterName, pathParts[1])

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go
@@ -267,10 +267,12 @@ func (r *crdHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	}
 
 	crdKey := crdName
-	clusterName := ""
-	cluster := genericapirequest.ClusterFrom(ctx)
-	if cluster != nil {
-		clusterName = cluster.Name
+	clusterName, err := genericapirequest.ClusterNameFrom(ctx)
+	if err != nil {
+		responsewriters.ErrorNegotiated(
+			apierrors.NewInternalError(fmt.Errorf("error resolving resource: %v", err)),
+			Codecs, schema.GroupVersion{Group: requestInfo.APIGroup, Version: requestInfo.APIVersion}, w, req,
+		)
 	}
 	crdKey = clusters.ToClusterAwareKey(clusterName, crdKey)
 	crd, err := r.crdLister.Get(crdKey)

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/discovery/version_hack.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/discovery/version_hack.go
@@ -79,7 +79,10 @@ func withContributedResources(groupVersion schema.GroupVersion, apiResourceListe
 			result := []metav1.APIResource{}
 			result = append(result, apiResourceLister.ListAPIResources()...)
 			if cluster != nil {
-				if additionalResources := ContributedResources[ClusterGroupVersion{cluster.Name, groupVersion.Group, groupVersion.Version}]; additionalResources != nil {
+				if additionalResources := ContributedResources[ClusterGroupVersion{
+					ClusterName: cluster.Name,
+					Group:       groupVersion.Group,
+					Version:     groupVersion.Version}]; additionalResources != nil {
 					result = append(result, additionalResources.ListAPIResources()...)
 				}
 				sort.Slice(result, func(i, j int) bool {

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/request/context_cluster.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/request/context_cluster.go
@@ -18,6 +18,8 @@ package request
 
 import (
 	"context"
+	"errors"
+	"fmt"
 )
 
 type clusterKey int
@@ -51,4 +53,39 @@ func ClusterFrom(ctx context.Context) *Cluster {
 		return nil
 	}
 	return &cluster
+}
+
+func buildClusterError(message string, ctx context.Context) error {
+	if ri, ok := RequestInfoFrom(ctx); ok {
+		message = message + fmt.Sprintf(" - RequestInfo: %#v", ri)
+	}
+	return errors.New(message)
+}
+
+// ValidClusterFrom returns the value of the cluster key on the ctx.
+// If there's no cluster key, or if the cluster name is empty
+// and it's not a wildcard context, then return an error.
+func ValidClusterFrom(ctx context.Context) (*Cluster, error) {
+	cluster := ClusterFrom(ctx)
+	if cluster == nil {
+		return nil, buildClusterError("no cluster in the request context", ctx)
+	}
+	if cluster.Name == "" && !cluster.Wildcard {
+		return nil, buildClusterError("cluster name is empty in the request context", ctx)
+	}
+	return cluster, nil
+}
+
+// ClusterNameFrom returns the cluster name from the value of the cluster
+// key on the ctx.
+// If the cluster name is empty, then return an error.
+func ClusterNameFrom(ctx context.Context) (string, error) {
+	cluster, err := ValidClusterFrom(ctx)
+	if err != nil {
+		return "", err
+	}
+	if cluster.Name == "" {
+		return "", buildClusterError("cluster name is empty in the request context", ctx)
+	}
+	return cluster.Name, nil
 }

--- a/staging/src/k8s.io/apiserver/pkg/server/routes/index.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/routes/index.go
@@ -66,10 +66,10 @@ type IndexLister struct {
 
 // ServeHTTP serves the available paths.
 func (i IndexLister) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	cluster := genericapirequest.ClusterFrom(r.Context())
-	clusterName := ""
-	if cluster != nil {
-		clusterName = cluster.Name
+	clusterName, err := genericapirequest.ClusterNameFrom(r.Context())
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
 	}
 	responsewriters.WriteRawJSON(i.StatusCode, metav1.RootPaths{Paths: i.PathProvider.ListedPaths(clusterName)}, w)
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher.go
@@ -389,8 +389,8 @@ func (wc *watchChan) prepareObjs(e *event) (curObj runtime.Object, oldObj runtim
 		if err != nil {
 			return nil, nil, err
 		}
-		clusterName := ""
-		if wc.clusterName == "*" {
+		clusterName := wc.clusterName
+		if clusterName == "*" {
 			sub := strings.TrimPrefix(e.key, wc.key)
 			if i := strings.Index(sub, "/"); i != -1 {
 				sub = sub[:i]
@@ -415,6 +415,8 @@ func (wc *watchChan) prepareObjs(e *event) (curObj runtime.Object, oldObj runtim
 			} else {
 				klog.Infof("NO SUB: %T %s", curObj, clusterName)
 			}
+		} else {
+			klog.Errorf("Cluster should not be unknown")
 		}
 	}
 	// We need to decode prevValue, only if this is deletion event or
@@ -433,8 +435,8 @@ func (wc *watchChan) prepareObjs(e *event) (curObj runtime.Object, oldObj runtim
 		if err != nil {
 			return nil, nil, err
 		}
-		clusterName := ""
-		if wc.clusterName == "*" {
+		clusterName := wc.clusterName
+		if clusterName == "*" {
 			sub := strings.TrimPrefix(e.key, wc.key)
 			if i := strings.Index(sub, "/"); i != -1 {
 				sub = sub[:i]
@@ -459,8 +461,9 @@ func (wc *watchChan) prepareObjs(e *event) (curObj runtime.Object, oldObj runtim
 			} else {
 				klog.Infof("NO SUB: %T %s", oldObj, clusterName)
 			}
+		} else {
+			klog.Errorf("Cluster should not be unknown")
 		}
-
 	}
 	return curObj, oldObj, nil
 }

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_apis.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_apis.go
@@ -77,10 +77,10 @@ func (r *apisHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		Groups: []metav1.APIGroup{r.discoveryGroup},
 	}
 
-	clusterName := ""
-	cluster := genericapirequest.ClusterFrom(req.Context())
-	if cluster != nil {
-		clusterName = cluster.Name
+	clusterName, err := genericapirequest.ClusterNameFrom(req.Context())
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
 	}
 
 	apiServices, err := r.lister.List(labels.Everything())
@@ -161,10 +161,10 @@ type apiGroupHandler struct {
 }
 
 func (r *apiGroupHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	clusterName := ""
-	cluster := genericapirequest.ClusterFrom(req.Context())
-	if cluster != nil {
-		clusterName = cluster.Name
+	clusterName, err := genericapirequest.ClusterNameFrom(req.Context())
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
 	}
 
 	apiServices, err := r.lister.List(labels.Everything())


### PR DESCRIPTION
We should not allow any operation that results in an object having an empty `clusterName`.
