### PR TITLE
HACK: Make the Namespace admission multi-cluster-aware

### DIFF
--- a/pkg/genericcontrolplane/server.go
+++ b/pkg/genericcontrolplane/server.go
@@ -36,8 +36,8 @@ import (
 	"k8s.io/apiserver/pkg/authorization/union"
 	"k8s.io/apiserver/pkg/endpoints/discovery"
 	openapinamer "k8s.io/apiserver/pkg/endpoints/openapi"
-	genericfeatures "k8s.io/apiserver/pkg/features"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	genericfeatures "k8s.io/apiserver/pkg/features"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/apiserver/pkg/server/filters"
 	serverstorage "k8s.io/apiserver/pkg/server/storage"
@@ -362,7 +362,7 @@ func BuildGenericConfig(
 
 	kubeClientConfig := genericConfig.LoopbackClientConfig
 
-	clientutils.EnableMultiCluster(genericConfig.LoopbackClientConfig, genericConfig, "apiservices", "customresourcedefinitions")
+	clientutils.EnableMultiCluster(genericConfig.LoopbackClientConfig, genericConfig, "namespaces", "apiservices", "customresourcedefinitions")
 
 	clientgoExternalClient, err := clientgoclientset.NewForConfig(kubeClientConfig)
 	if err != nil {
@@ -378,8 +378,8 @@ func BuildGenericConfig(
 
 	genericConfig.Authorization.Authorizer, genericConfig.RuleResolver, err = BuildAuthorizer(s, versionedInformers)
 	if err != nil {
-	    lastErr = fmt.Errorf("invalid authorization config: %v", err)
-	    return
+		lastErr = fmt.Errorf("invalid authorization config: %v", err)
+		return
 	}
 
 	// if !sets.NewString(s.Authorization.Modes...).Has(modes.ModeRBAC) {

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/namespace/lifecycle/admission.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/namespace/lifecycle/admission.go
@@ -33,9 +33,11 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apiserver/pkg/admission"
 	"k8s.io/apiserver/pkg/admission/initializer"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	corelisters "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/clusters"
 )
 
 const (
@@ -85,13 +87,18 @@ func (l *Lifecycle) Admit(ctx context.Context, a admission.Attributes, o admissi
 		return nil
 	}
 
+	clusterName, err := genericapirequest.ClusterNameFrom(ctx)
+	if err != nil {
+		return errors.NewInternalError(err)
+	}
+
 	if a.GetKind().GroupKind() == v1.SchemeGroupVersion.WithKind("Namespace").GroupKind() {
 		// if a namespace is deleted, we want to prevent all further creates into it
 		// while it is undergoing termination.  to reduce incidences where the cache
 		// is slow to update, we add the namespace into a force live lookup list to ensure
 		// we are not looking at stale state.
 		if a.GetOperation() == admission.Delete {
-			l.forceLiveLookupCache.Add(a.GetName(), true, forceLiveLookupTTL)
+			l.forceLiveLookupCache.Add(clusters.ToClusterAwareKey(clusterName, a.GetName()), true, forceLiveLookupTTL)
 		}
 		// allow all operations to namespaces
 		return nil
@@ -114,10 +121,12 @@ func (l *Lifecycle) Admit(ctx context.Context, a admission.Attributes, o admissi
 
 	var (
 		exists bool
-		err    error
 	)
 
-	namespace, err := l.namespaceLister.Get(a.GetNamespace())
+	namespaceKey := a.GetNamespace()
+	namespaceKey = clusters.ToClusterAwareKey(clusterName, namespaceKey)
+
+	namespace, err := l.namespaceLister.Get(namespaceKey)
 	if err != nil {
 		if !errors.IsNotFound(err) {
 			return errors.NewInternalError(err)
@@ -130,7 +139,7 @@ func (l *Lifecycle) Admit(ctx context.Context, a admission.Attributes, o admissi
 		// give the cache time to observe the namespace before rejecting a create.
 		// this helps when creating a namespace and immediately creating objects within it.
 		time.Sleep(missingNamespaceWait)
-		namespace, err = l.namespaceLister.Get(a.GetNamespace())
+		namespace, err = l.namespaceLister.Get(namespaceKey)
 		switch {
 		case errors.IsNotFound(err):
 			// no-op
@@ -146,7 +155,7 @@ func (l *Lifecycle) Admit(ctx context.Context, a admission.Attributes, o admissi
 
 	// forceLiveLookup if true will skip looking at local cache state and instead always make a live call to server.
 	forceLiveLookup := false
-	if _, ok := l.forceLiveLookupCache.Get(a.GetNamespace()); ok {
+	if _, ok := l.forceLiveLookupCache.Get(namespaceKey); ok {
 		// we think the namespace was marked for deletion, but our current local cache says otherwise, we will force a live lookup.
 		forceLiveLookup = exists && namespace.Status.Phase == v1.NamespaceActive
 	}
@@ -154,7 +163,7 @@ func (l *Lifecycle) Admit(ctx context.Context, a admission.Attributes, o admissi
 	// refuse to operate on non-existent namespaces
 	if !exists || forceLiveLookup {
 		// as a last resort, make a call directly to storage
-		namespace, err = l.client.CoreV1().Namespaces().Get(context.TODO(), a.GetNamespace(), metav1.GetOptions{})
+		namespace, err = l.client.CoreV1().Namespaces().Get(genericapirequest.WithCluster(context.TODO(), genericapirequest.Cluster{Name: clusterName}), a.GetNamespace(), metav1.GetOptions{})
 		switch {
 		case errors.IsNotFound(err):
 			return err


### PR DESCRIPTION
The namespace lifecycle admission controller should be made multi-cluster-aware, exactly like the CRD controllers have been when working on CRD tenancy (cf. commit 84c07cbd39b412de7355c3a9cf5eec0cc78c5b15)