### PR TITLE
HACK: Make the namespace controller multi-cluster-aware

### DIFF
--- a/cmd/kube-controller-manager/app/core.go
+++ b/cmd/kube-controller-manager/app/core.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/klog/v2"
 
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/quota/v1/generic"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
@@ -493,7 +494,9 @@ func startModifiedNamespaceController(ctx ControllerContext, namespaceKubeClient
 		return nil, true, err
 	}
 
-	discoverResourcesFn := namespaceKubeClient.Discovery().ServerPreferredNamespacedResources
+	discoverResourcesFn := func(clusterName string) ([]*metav1.APIResourceList, error) {
+		return namespaceKubeClient.Discovery().ServerPreferredNamespacedResources()
+	}
 
 	namespaceController := namespacecontroller.NewNamespaceController(
 		namespaceKubeClient,

--- a/pkg/controller/namespace/deletion/namespaced_resources_deleter_test.go
+++ b/pkg/controller/namespace/deletion/namespaced_resources_deleter_test.go
@@ -198,11 +198,11 @@ func testSyncNamespaceThatIsTerminating(t *testing.T, versions *metav1.APIVersio
 				t.Fatal(err)
 			}
 
-			fn := func() ([]*metav1.APIResourceList, error) {
+			fn := func(clusterName string) ([]*metav1.APIResourceList, error) {
 				return resources, testInput.gvrError
 			}
 			d := NewNamespacedResourcesDeleter(mockClient.CoreV1().Namespaces(), metadataClient, mockClient.CoreV1(), fn, v1.FinalizerKubernetes)
-			if err := d.Delete(testInput.testNamespace.Name); !matchErrors(err, testInput.expectErrorOnDelete) {
+			if err := d.Delete("", testInput.testNamespace.Name); !matchErrors(err, testInput.expectErrorOnDelete) {
 				t.Errorf("expected error %q when syncing namespace, got %q, %v", testInput.expectErrorOnDelete, err, testInput.expectErrorOnDelete == err)
 			}
 
@@ -295,12 +295,12 @@ func TestSyncNamespaceThatIsActive(t *testing.T) {
 			Phase: v1.NamespaceActive,
 		},
 	}
-	fn := func() ([]*metav1.APIResourceList, error) {
+	fn := func(clusterName string) ([]*metav1.APIResourceList, error) {
 		return testResources(), nil
 	}
 	d := NewNamespacedResourcesDeleter(mockClient.CoreV1().Namespaces(), nil, mockClient.CoreV1(),
 		fn, v1.FinalizerKubernetes)
-	err := d.Delete(testNamespace.Name)
+	err := d.Delete("", testNamespace.Name)
 	if err != nil {
 		t.Errorf("Unexpected error when synching namespace %v", err)
 	}
@@ -424,7 +424,7 @@ func TestDeleteEncounters404(t *testing.T) {
 	mockMetadataClient.PrependReactor("delete-collection", "flakes", ns1FlakesNotFound)
 	mockMetadataClient.PrependReactor("list", "flakes", ns1FlakesNotFound)
 
-	resourcesFn := func() ([]*metav1.APIResourceList, error) {
+	resourcesFn := func(clusterName string) ([]*metav1.APIResourceList, error) {
 		return []*metav1.APIResourceList{{
 			GroupVersion: "example.com/v1",
 			APIResources: []metav1.APIResource{{Name: "flakes", Namespaced: true, Kind: "Flake", Verbs: []string{"get", "list", "delete", "deletecollection", "create", "update"}}},
@@ -435,7 +435,7 @@ func TestDeleteEncounters404(t *testing.T) {
 
 	// Delete ns1 and get NotFound errors for the flakes resource
 	mockMetadataClient.ClearActions()
-	if err := d.Delete(ns1.Name); err != nil {
+	if err := d.Delete("", ns1.Name); err != nil {
 		t.Fatal(err)
 	}
 	if len(mockMetadataClient.Actions()) != 3 ||
@@ -450,7 +450,7 @@ func TestDeleteEncounters404(t *testing.T) {
 
 	// Delete ns2
 	mockMetadataClient.ClearActions()
-	if err := d.Delete(ns2.Name); err != nil {
+	if err := d.Delete("", ns2.Name); err != nil {
 		t.Fatal(err)
 	}
 	if len(mockMetadataClient.Actions()) != 2 ||

--- a/pkg/controller/namespace/namespace_controller.go
+++ b/pkg/controller/namespace/namespace_controller.go
@@ -66,7 +66,7 @@ type NamespaceController struct {
 func NewNamespaceController(
 	kubeClient clientset.Interface,
 	metadataClient metadata.Interface,
-	discoverResourcesFn func() ([]*metav1.APIResourceList, error),
+	discoverResourcesFn func(clusterName string) ([]*metav1.APIResourceList, error),
 	namespaceInformer coreinformers.NamespaceInformer,
 	resyncPeriod time.Duration,
 	finalizerToken v1.FinalizerName) *NamespaceController {
@@ -189,7 +189,7 @@ func (nm *NamespaceController) syncNamespaceFromKey(key string) (err error) {
 		utilruntime.HandleError(fmt.Errorf("Unable to retrieve namespace %v from store: %v", key, err))
 		return err
 	}
-	return nm.namespacedResourcesDeleter.Delete(namespace.Name)
+	return nm.namespacedResourcesDeleter.Delete(namespace.ClusterName, namespace.Name)
 }
 
 // Run starts observing the system with the specified number of workers.

--- a/pkg/genericcontrolplane/clientutils/multiclusterconfig.go
+++ b/pkg/genericcontrolplane/clientutils/multiclusterconfig.go
@@ -90,9 +90,9 @@ func (mcrt *multiClusterClientConfigRoundTripper) RoundTrip(req *http.Request) (
 	if err != nil {
 		return nil, err
 	}
+	contextCluster := genericapirequest.ClusterFrom(req.Context())
 	if requestInfo != nil &&
 		mcrt.enabledOn.Has(requestInfo.Resource) {
-		contextCluster := genericapirequest.ClusterFrom(req.Context())
 		resourceClusterName := ""
 		headerCluster := ""
 		switch requestInfo.Verb {
@@ -152,6 +152,10 @@ func (mcrt *multiClusterClientConfigRoundTripper) RoundTrip(req *http.Request) (
 			return nil, fmt.Errorf("Cluster should not be empty for request '%s' on resource '%s' (%s)", requestInfo.Verb, requestInfo.Resource, requestInfo.Path)
 		}
 		req.Header.Add("X-Kubernetes-Cluster", headerCluster)
+	} else {
+		if contextCluster != nil && contextCluster.Name != "" {
+			req.Header.Add("X-Kubernetes-Cluster", contextCluster.Name)
+		}
 	}
 	return mcrt.rt.RoundTrip(req)
 }

--- a/pkg/registry/rbac/rest/storage_rbac.go
+++ b/pkg/registry/rbac/rest/storage_rbac.go
@@ -39,6 +39,7 @@ import (
 	serverstorage "k8s.io/apiserver/pkg/server/storage"
 	clientset "k8s.io/client-go/kubernetes"
 	rbacv1client "k8s.io/client-go/kubernetes/typed/rbac/v1"
+	clientgorest "k8s.io/client-go/rest"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/component-helpers/auth/rbac/reconciliation"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
@@ -174,7 +175,9 @@ func (p *PolicyData) EnsureRBACPolicy() genericapiserver.PostStartHookFunc {
 		// initializing roles is really important.  On some e2e runs, we've seen cases where etcd is down when the server
 		// starts, the roles don't initialize, and nothing works.
 		err := wait.Poll(1*time.Second, 30*time.Second, func() (done bool, err error) {
-			client, err := clientset.NewForConfig(hookContext.LoopbackClientConfig)
+			adminLogicalClusterConfig := clientgorest.CopyConfig(hookContext.LoopbackClientConfig)
+			adminLogicalClusterConfig.Host += "/clusters/admin"
+			client, err := clientset.NewForConfig(adminLogicalClusterConfig)
 			if err != nil {
 				utilruntime.HandleError(fmt.Errorf("unable to initialize client set: %v", err))
 				return false, nil

--- a/test/e2e_node/services/namespace_controller.go
+++ b/test/e2e_node/services/namespace_controller.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/informers"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/metadata"
@@ -70,7 +71,9 @@ func (n *NamespaceController) Start() error {
 	if err != nil {
 		return err
 	}
-	discoverResourcesFn := client.Discovery().ServerPreferredNamespacedResources
+	discoverResourcesFn := func(clusterName string) ([]*metav1.APIResourceList, error) {
+		return client.Discovery().ServerPreferredNamespacedResources()
+	}
 	informerFactory := informers.NewSharedInformerFactory(client, ncResyncPeriod)
 	nc := namespacecontroller.NewNamespaceController(
 		client,

--- a/test/integration/namespace/ns_conditions_test.go
+++ b/test/integration/namespace/ns_conditions_test.go
@@ -183,8 +183,9 @@ func namespaceLifecycleSetup(t *testing.T) (framework.CloseFunc, *namespace.Name
 		panic(err)
 	}
 
-	discoverResourcesFn := clientSet.Discovery().ServerPreferredNamespacedResources
-
+	discoverResourcesFn := func(clusterName string) ([]*metav1.APIResourceList, error) {
+		return clientSet.Discovery().ServerPreferredNamespacedResources()
+	}
 	controller := namespace.NewNamespaceController(
 		clientSet,
 		metadataClient,


### PR DESCRIPTION
The namespace controller should be made multi-cluster-aware, exactly like the CRD controllers have been when working on CRD tenancy (cf. commit 84c07cb)