### PR TITLE
Additional checks to avoid panic due to a non-existant CRD.

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go
@@ -51,7 +51,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/equality"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
-	"k8s.io/apimachinery/pkg/api/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -284,6 +283,22 @@ func (r *crdHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	var crdClusterName string
 	var crd *apiextensionsv1.CustomResourceDefinition
 	var err error
+	handleErrorFunc := func(err error) {
+		if apierrors.IsNotFound(err) {
+			if !r.hasSynced() {
+				responsewriters.ErrorNegotiated(serverStartingError(), Codecs, schema.GroupVersion{Group: requestInfo.APIGroup, Version: requestInfo.APIVersion}, w, req)
+				return
+			}
+			r.delegate.ServeHTTP(w, req)
+		}
+		if err != nil {
+			utilruntime.HandleError(err)
+			responsewriters.ErrorNegotiated(
+				apierrors.NewInternalError(fmt.Errorf("error resolving resource: %v", err)),
+				Codecs, schema.GroupVersion{Group: requestInfo.APIGroup, Version: requestInfo.APIVersion}, w, req,
+			)
+		}
+	}
 
 	cluster, err := genericapirequest.ValidClusterFrom(ctx)
 	if err != nil {
@@ -302,50 +317,32 @@ func (r *crdHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		// with non-equal specs (especially non-equal schemas).
 		var crds []*apiextensionsv1.CustomResourceDefinition
 		crds, err = r.crdLister.List(labels.Everything())
-		if err == nil {
-			if len(crds) == 0 {
-				err = errors.NewNotFound(schema.GroupResource{Group: apiextensionsv1.SchemeGroupVersion.Group, Resource: "customresourcedefinitions"}, "")
-			} else {
-				for _, aCRD := range crds {
-					if aCRD.Name != crdName {
-						continue
-					}
-					if crd == nil {
-						crd = aCRD
-						crdClusterName = aCRD.GetClusterName()
-					} else {
-						if !equality.Semantic.DeepEqual(crd.Spec, aCRD.Spec) {
-							responsewriters.ErrorNegotiated(
-								apierrors.NewInternalError(fmt.Errorf("error resolving resource: cannot watch across logical clusters for a resource type with several distinct schemas")),
-								Codecs, schema.GroupVersion{Group: requestInfo.APIGroup, Version: requestInfo.APIVersion}, w, req,
-							)
-							return
-						}
-					}
-				}
-			}
+		if err != nil {
+			handleErrorFunc(err)
+			return
 		}
+		var equal bool // true if all the found CRDs have the same spec
+		crd, equal = findCRD(crdName, crds)
+		if !equal {
+			err = apierrors.NewInternalError(fmt.Errorf("error resolving resource: cannot watch across logical clusters for a resource type with several distinct schemas"))
+			responsewriters.ErrorNegotiated(err, Codecs, schema.GroupVersion{Group: requestInfo.APIGroup, Version: requestInfo.APIVersion}, w, req)
+			return
+		}
+
+		if crd == nil {
+			handleErrorFunc(apierrors.NewNotFound(schema.GroupResource{Group: apiextensionsv1.SchemeGroupVersion.Group, Resource: "customresourcedefinitions"}, ""))
+			return
+		}
+		crdClusterName = crd.GetClusterName()
+
 	} else {
 		crdClusterName = cluster.Name
 		crdKey := clusters.ToClusterAwareKey(crdClusterName, crdName)
 		crd, err = r.crdLister.Get(crdKey)
-	}
-	if apierrors.IsNotFound(err) {
-		if !r.hasSynced() {
-			responsewriters.ErrorNegotiated(serverStartingError(), Codecs, schema.GroupVersion{Group: requestInfo.APIGroup, Version: requestInfo.APIVersion}, w, req)
+		if err != nil {
+			handleErrorFunc(err)
 			return
 		}
-
-		r.delegate.ServeHTTP(w, req)
-		return
-	}
-	if err != nil {
-		utilruntime.HandleError(err)
-		responsewriters.ErrorNegotiated(
-			apierrors.NewInternalError(fmt.Errorf("error resolving resource")),
-			Codecs, schema.GroupVersion{Group: requestInfo.APIGroup, Version: requestInfo.APIVersion}, w, req,
-		)
-		return
 	}
 
 	// if the scope in the CRD and the scope in request differ (with exception of the verbs in possiblyAcrossAllNamespacesVerbs
@@ -1571,4 +1568,22 @@ func buildOpenAPIModelsForApply(staticOpenAPISpec *spec.Swagger, crd *apiextensi
 		return nil, err
 	}
 	return models, nil
+}
+func findCRD(crdName string, crds []*apiextensionsv1.CustomResourceDefinition) (*apiextensionsv1.CustomResourceDefinition, bool) {
+	var crd *apiextensionsv1.CustomResourceDefinition
+
+	for _, aCRD := range crds {
+		if aCRD.Name != crdName {
+			continue
+		}
+		if crd == nil {
+			crd = aCRD
+		} else {
+			if !equality.Semantic.DeepEqual(crd.Spec, aCRD.Spec) {
+				return crd, false
+			}
+		}
+	}
+
+	return crd, true
 }


### PR DESCRIPTION
A wildcard cluster operation against a CRD that doesn't exist caused a panic.

Fixes https://github.com/kcp-dev/kcp/issues/220

Signed-off-by: Joaquim Moreno <joaquim@redhat.com>