### PR TITLE
HACK: negotiation: tell the user what they did wrong

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/negotiation/errors.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/negotiation/errors.go
@@ -77,16 +77,17 @@ func (e errNotAcceptableConversion) Status() metav1.Status {
 
 // errUnsupportedMediaType indicates Content-Type is not recognized
 type errUnsupportedMediaType struct {
+	requested string
 	accepted []string
 }
 
 // NewUnsupportedMediaTypeError returns an error of UnsupportedMediaType which contains specified string
-func NewUnsupportedMediaTypeError(accepted []string) error {
-	return errUnsupportedMediaType{accepted}
+func NewUnsupportedMediaTypeError(requested string, accepted []string) error {
+	return errUnsupportedMediaType{requested: requested, accepted: accepted}
 }
 
 func (e errUnsupportedMediaType) Error() string {
-	return fmt.Sprintf("the body of the request was in an unknown format - accepted media types include: %v", strings.Join(e.accepted, ", "))
+	return fmt.Sprintf("the body of the request was in an unknown format (%s) - accepted media types include: %v", e.requested, strings.Join(e.accepted, ", "))
 }
 
 func (e errUnsupportedMediaType) Status() metav1.Status {

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/negotiation/negotiate.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/negotiation/negotiate.go
@@ -86,9 +86,9 @@ func NegotiateInputSerializerForMediaType(mediaType string, streaming bool, ns r
 
 	supported, streamingSupported := MediaTypesForSerializer(ns)
 	if streaming {
-		return runtime.SerializerInfo{}, NewUnsupportedMediaTypeError(streamingSupported)
+		return runtime.SerializerInfo{}, NewUnsupportedMediaTypeError(mediaType, streamingSupported)
 	}
-	return runtime.SerializerInfo{}, NewUnsupportedMediaTypeError(supported)
+	return runtime.SerializerInfo{}, NewUnsupportedMediaTypeError(mediaType, supported)
 }
 
 // isPrettyPrint returns true if the "pretty" query parameter is true or if the User-Agent

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/patch.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/patch.go
@@ -82,7 +82,7 @@ func PatchResource(r rest.Patcher, scope *RequestScope, admit admission.Interfac
 
 		// Ensure the patchType is one we support
 		if !sets.NewString(patchTypes...).Has(contentType) {
-			scope.err(negotiation.NewUnsupportedMediaTypeError(patchTypes), w, req)
+			scope.err(negotiation.NewUnsupportedMediaTypeError(contentType, patchTypes), w, req)
 			return
 		}
 


### PR DESCRIPTION
The error messages previously did not show the requested content type,
which is not useful for the user.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>