### PR TITLE
HACK: hard-code the number of servers again

### DIFF
--- a/pkg/genericcontrolplane/apiextensions.go
+++ b/pkg/genericcontrolplane/apiextensions.go
@@ -87,7 +87,7 @@ func createAPIExtensionsConfig(
 		},
 		ExtraConfig: apiextensionsapiserver.ExtraConfig{
 			CRDRESTOptionsGetter: apiextensionsoptions.NewCRDRESTOptionsGetter(etcdOptions),
-			MasterCount:          3,
+			MasterCount:          1, // TODO: pass this in correctly
 			AuthResolverWrapper:  authResolverWrapper,
 			ServiceResolver:      serviceResolver,
 		},


### PR DESCRIPTION
We're not really sure why the previous hacks stopped passing this value
in and instead hard-coded it to 3, but the result is that registering
CRDs takes 5s at minimum. When our tests register dozens of CRDs and not
always in parallel, this is annoying. Hard-code it to 1 for now and
re-visit later.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>
