### PR TITLE
genericcontrolplane: make config plumbing composable

### DIFF
--- a/pkg/genericcontrolplane/apiextensions.go
+++ b/pkg/genericcontrolplane/apiextensions.go
@@ -37,7 +37,7 @@ import (
 	"k8s.io/kubernetes/pkg/genericcontrolplane/options"
 )
 
-func createAPIExtensionsConfig(
+func CreateAPIExtensionsConfig(
 	kubeAPIServerConfig genericapiserver.Config,
 	externalInformers kubeexternalinformers.SharedInformerFactory,
 	pluginInitializers []admission.PluginInitializer,
@@ -86,12 +86,10 @@ func createAPIExtensionsConfig(
 			SharedInformerFactory: externalInformers,
 		},
 		ExtraConfig: apiextensionsapiserver.ExtraConfig{
-			CRDRESTOptionsGetter:   apiextensionsoptions.NewCRDRESTOptionsGetter(etcdOptions),
-			MasterCount:            1, // TODO: pass this in correctly
-			AuthResolverWrapper:    authResolverWrapper,
-			ServiceResolver:        serviceResolver,
-			NewClientFunc:          commandOptions.APIExtensionsNewClientFunc,
-			NewInformerFactoryFunc: commandOptions.APIExtensionsNewSharedInformerFactoryFunc,
+			CRDRESTOptionsGetter: apiextensionsoptions.NewCRDRESTOptionsGetter(etcdOptions),
+			MasterCount:          1, // TODO: pass this in correctly
+			AuthResolverWrapper:  authResolverWrapper,
+			ServiceResolver:      serviceResolver,
 		},
 	}
 
@@ -99,8 +97,4 @@ func createAPIExtensionsConfig(
 	apiextensionsConfig.GenericConfig.PostStartHooks = map[string]genericapiserver.PostStartHookConfigEntry{}
 
 	return apiextensionsConfig, nil
-}
-
-func createAPIExtensionsServer(apiextensionsConfig *apiextensionsapiserver.Config, delegateAPIServer genericapiserver.DelegationTarget) (*apiextensionsapiserver.CustomResourceDefinitions, error) {
-	return apiextensionsConfig.Complete().New(delegateAPIServer)
 }

--- a/pkg/genericcontrolplane/options/options.go
+++ b/pkg/genericcontrolplane/options/options.go
@@ -20,14 +20,11 @@ import (
 	"net/http"
 	"time"
 
-	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
-	apiextensionsinformers "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions"
 	"k8s.io/apiserver/pkg/admission/plugin/webhook/mutating"
 	"k8s.io/apiserver/pkg/admission/plugin/webhook/validating"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	genericoptions "k8s.io/apiserver/pkg/server/options"
 	"k8s.io/apiserver/pkg/storage/storagebackend"
-	"k8s.io/client-go/rest"
 	"k8s.io/component-base/logs"
 	"k8s.io/component-base/metrics"
 
@@ -74,10 +71,6 @@ type ServerRunOptions struct {
 
 	// BuildHandlerChainFunc allows you to build custom handler chains by decorating the apiHandler.
 	BuildHandlerChainFunc func(apiHandler http.Handler, c *genericapiserver.Config) (secure http.Handler)
-
-	// TODO consider either moving into an apiextensions-specific struct, or maybe reuse apiextensions-apiserver/pkg/cmd/options?
-	APIExtensionsNewClientFunc                func(config *rest.Config) (apiextensionsclient.Interface, error)
-	APIExtensionsNewSharedInformerFactoryFunc func(client apiextensionsclient.Interface, resyncPeriod time.Duration) apiextensionsinformers.SharedInformerFactory
 }
 
 // NewServerRunOptions creates a new ServerRunOptions object with default parameters

--- a/pkg/genericcontrolplane/server.go
+++ b/pkg/genericcontrolplane/server.go
@@ -70,14 +70,35 @@ func Run(completeOptions completedServerRunOptions, stopCh <-chan struct{}) erro
 	// To help debugging, immediately log version
 	klog.Infof("Version: %+v", version.Get())
 
-	serverChain, err := CreateServerChain(completeOptions, stopCh)
+	config, serviceResolver, pluginInitializer, err := CreateKubeAPIServerConfig(completeOptions)
 	if err != nil {
 		return err
 	}
-	server := serverChain.MiniAggregator.GenericAPIServer
 
-	prepared := server.PrepareRun()
-	return prepared.Run(stopCh)
+	// If additional API servers are added, they should be gated.
+	apiExtensionsConfig, err := CreateAPIExtensionsConfig(
+		*config.GenericConfig,
+		config.ExtraConfig.VersionedInformers,
+		pluginInitializer,
+		completeOptions.ServerRunOptions,
+		serviceResolver,
+		webhook.NewDefaultAuthenticationInfoResolverWrapper(
+			nil,
+			config.GenericConfig.EgressSelector,
+			config.GenericConfig.LoopbackClientConfig,
+			config.GenericConfig.TracerProvider,
+		),
+	)
+	if err != nil {
+		return fmt.Errorf("configure api extensions: %v", err)
+	}
+
+	serverChain, err := CreateServerChain(config.Complete(), apiExtensionsConfig.Complete())
+	if err != nil {
+		return err
+	}
+
+	return serverChain.MiniAggregator.GenericAPIServer.PrepareRun().Run(stopCh)
 }
 
 type ServerChain struct {
@@ -87,53 +108,22 @@ type ServerChain struct {
 }
 
 // CreateServerChain creates the apiservers connected via delegation.
-func CreateServerChain(completedOptions completedServerRunOptions, stopCh <-chan struct{}) (*ServerChain, error) {
-	kubeAPIServerConfig, serviceResolver, pluginInitializer, err := CreateKubeAPIServerConfig(completedOptions)
-	if err != nil {
-		return nil, err
-	}
-
-	// If additional API servers are added, they should be gated.
-	apiExtensionsConfig, err := createAPIExtensionsConfig(
-		*kubeAPIServerConfig.GenericConfig,
-		kubeAPIServerConfig.ExtraConfig.VersionedInformers,
-		pluginInitializer,
-		completedOptions.ServerRunOptions,
-		serviceResolver,
-		webhook.NewDefaultAuthenticationInfoResolverWrapper(
-			nil,
-			kubeAPIServerConfig.GenericConfig.EgressSelector,
-			kubeAPIServerConfig.GenericConfig.LoopbackClientConfig,
-			kubeAPIServerConfig.GenericConfig.TracerProvider,
-		),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("configure api extensions: %v", err)
-	}
-	apiExtensionsServer, err := createAPIExtensionsServer(apiExtensionsConfig, genericapiserver.NewEmptyDelegate())
+func CreateServerChain(config apis.CompletedConfig, apiExtensionConfig apiextensionsapiserver.CompletedConfig) (*ServerChain, error) {
+	apiExtensionsServer, err := apiExtensionConfig.New(genericapiserver.NewEmptyDelegate())
 	if err != nil {
 		return nil, fmt.Errorf("create api extensions: %v", err)
 	}
 
-	kubeAPIServer, err := CreateKubeAPIServer(kubeAPIServerConfig, apiExtensionsServer.GenericAPIServer)
+	kubeAPIServer, err := config.New(apiExtensionsServer.GenericAPIServer)
 	if err != nil {
 		return nil, err
 	}
 
 	miniAggregatorConfig := &aggregator.MiniAggregatorConfig{
-		GenericConfig: kubeAPIServerConfig.GenericConfig,
+		GenericConfig: config.GenericConfig.Config,
 	}
 
-	if err := completedOptions.ServerRunOptions.Admission.ApplyTo(
-		kubeAPIServerConfig.GenericConfig,
-		kubeAPIServerConfig.ExtraConfig.VersionedInformers,
-		kubeAPIServerConfig.GenericConfig.LoopbackClientConfig,
-		feature.DefaultFeatureGate,
-		pluginInitializer...); err != nil {
-		return nil, err
-	}
-
-	miniAggregatorServer, err := miniAggregatorConfig.Complete(kubeAPIServerConfig.ExtraConfig.VersionedInformers).New(kubeAPIServer.GenericAPIServer, kubeAPIServer, apiExtensionsServer)
+	miniAggregatorServer, err := miniAggregatorConfig.Complete(config.ExtraConfig.VersionedInformers).New(kubeAPIServer.GenericAPIServer, kubeAPIServer, apiExtensionsServer)
 	if err != nil {
 		return nil, err
 	}
@@ -143,16 +133,6 @@ func CreateServerChain(completedOptions completedServerRunOptions, stopCh <-chan
 		GenericControlPlane:       kubeAPIServer,
 		MiniAggregator:            miniAggregatorServer,
 	}, nil
-}
-
-// CreateKubeAPIServer creates and wires a workable kube-apiserver
-func CreateKubeAPIServer(kubeAPIServerConfig *apis.Config, delegateAPIServer genericapiserver.DelegationTarget) (*apis.GenericControlPlane, error) {
-	kubeAPIServer, err := kubeAPIServerConfig.Complete().New(delegateAPIServer)
-	if err != nil {
-		return nil, err
-	}
-
-	return kubeAPIServer, nil
 }
 
 // CreateKubeAPIServerConfig creates all the resources for running the API server, but runs none of them
@@ -210,6 +190,15 @@ func CreateKubeAPIServerConfig(s completedServerRunOptions) (
 		config.ExtraConfig.ClusterAuthenticationInfo.RequestHeaderExtraHeaderPrefixes = requestHeaderConfig.ExtraHeaderPrefixes
 		config.ExtraConfig.ClusterAuthenticationInfo.RequestHeaderGroupHeaders = requestHeaderConfig.GroupHeaders
 		config.ExtraConfig.ClusterAuthenticationInfo.RequestHeaderUsernameHeaders = requestHeaderConfig.UsernameHeaders
+	}
+
+	if err := s.ServerRunOptions.Admission.ApplyTo(
+		config.GenericConfig,
+		config.ExtraConfig.VersionedInformers,
+		config.GenericConfig.LoopbackClientConfig,
+		feature.DefaultFeatureGate,
+		pluginInitializers...); err != nil {
+		return nil, nil, nil, err
 	}
 
 	// if err := config.GenericConfig.AddPostStartHook("start-kube-apiserver-admission-initializer", admissionPostStartHook); err != nil {


### PR DESCRIPTION
Before this PR, the create chain method took options and produced the server. That's not the intention of the options-config-server plumbing model. This PR split the chain creation method appart to make third-party plumbing possible.