### PR TITLE
genericcontrolplane: split generic config construction from kube-apiserver and apiextensions

### DIFF
--- a/pkg/genericcontrolplane/admission/initializer.go
+++ b/pkg/genericcontrolplane/admission/initializer.go
@@ -23,13 +23,6 @@ import (
 	quota "k8s.io/apiserver/pkg/quota/v1"
 )
 
-// TODO add a `WantsToRun` which takes a stopCh.  Might make it generic.
-
-// WantsCloudConfig defines a function which sets CloudConfig for admission plugins that need it.
-type WantsCloudConfig interface {
-	SetCloudConfig([]byte)
-}
-
 // WantsRESTMapper defines a function which sets RESTMapper for admission plugins that need it.
 type WantsRESTMapper interface {
 	SetRESTMapper(meta.RESTMapper)

--- a/pkg/genericcontrolplane/apiextensions.go
+++ b/pkg/genericcontrolplane/apiextensions.go
@@ -14,9 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package app does all of the work necessary to create a Kubernetes
-// APIServer by binding together the API, master and APIServer infrastructure.
-// It can be configured and called directly or via the hyperkube framework.
 package genericcontrolplane
 
 import (
@@ -34,6 +31,7 @@ import (
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/apiserver/pkg/util/webhook"
 	kubeexternalinformers "k8s.io/client-go/informers"
+
 	"k8s.io/kubernetes/pkg/genericcontrolplane/options"
 )
 
@@ -41,7 +39,7 @@ func CreateAPIExtensionsConfig(
 	kubeAPIServerConfig genericapiserver.Config,
 	externalInformers kubeexternalinformers.SharedInformerFactory,
 	pluginInitializers []admission.PluginInitializer,
-	commandOptions *options.ServerRunOptions,
+	commandOptions options.CompletedServerRunOptions,
 	serviceResolver webhook.ServiceResolver,
 	authResolverWrapper webhook.AuthenticationInfoResolverWrapper,
 ) (*apiextensionsapiserver.Config, error) {

--- a/pkg/genericcontrolplane/options/flags.go
+++ b/pkg/genericcontrolplane/options/flags.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+import (
+	cliflag "k8s.io/component-base/cli/flag"
+)
+
+// Flags returns flags for a specific APIServer by section name
+func (s *ServerRunOptions) Flags() (fss cliflag.NamedFlagSets) {
+	s.GenericServerRunOptions.AddUniversalFlags(fss.FlagSet("generic"))
+	s.Etcd.AddFlags(fss.FlagSet("etcd"))
+	s.SecureServing.AddFlags(fss.FlagSet("secure serving"))
+	s.Audit.AddFlags(fss.FlagSet("auditing"))
+	s.Features.AddFlags(fss.FlagSet("features"))
+	s.Authentication.AddFlags(fss.FlagSet("authentication"))
+
+	s.APIEnablement.AddFlags(fss.FlagSet("API enablement"))
+	s.EgressSelector.AddFlags(fss.FlagSet("egress selector"))
+	s.Admission.AddFlags(fss.FlagSet("admission"))
+
+	s.Metrics.AddFlags(fss.FlagSet("metrics"))
+	s.Logs.AddFlags(fss.FlagSet("logs"))
+	s.Traces.AddFlags(fss.FlagSet("traces"))
+
+	fs := fss.FlagSet("misc")
+	fs.DurationVar(&s.EventTTL, "event-ttl", s.EventTTL,
+		"Amount of time to retain events.")
+
+	fs.BoolVar(&s.EnableLogsHandler, "enable-logs-handler", s.EnableLogsHandler,
+		"If true, install a /logs handler for the apiserver logs.")
+	fs.MarkDeprecated("enable-logs-handler", "This flag will be removed in v1.19") //nolint:golint,errcheck
+
+	fs.Int64Var(&s.MaxConnectionBytesPerSec, "max-connection-bytes-per-sec", s.MaxConnectionBytesPerSec, ""+
+		"If non-zero, throttle each user connection to this number of bytes/sec. "+
+		"Currently only applies to long-running requests.")
+
+	fs.IntVar(&s.IdentityLeaseDurationSeconds, "identity-lease-duration-seconds", s.IdentityLeaseDurationSeconds,
+		"The duration of kube-apiserver lease in seconds, must be a positive number. (In use when the APIServerIdentity feature gate is enabled.)")
+
+	fs.IntVar(&s.IdentityLeaseRenewIntervalSeconds, "identity-lease-renew-interval-seconds", s.IdentityLeaseRenewIntervalSeconds,
+		"The interval of kube-apiserver renewing its lease in seconds, must be a positive number. (In use when the APIServerIdentity feature gate is enabled.)")
+
+	fs.StringVar(&s.ProxyClientCertFile, "proxy-client-cert-file", s.ProxyClientCertFile, ""+
+		"Client certificate used to prove the identity of the aggregator or kube-apiserver "+
+		"when it must call out during a request. This includes proxying requests to a user "+
+		"api-server and calling out to webhook admission plugins. It is expected that this "+
+		"cert includes a signature from the CA in the --requestheader-client-ca-file flag. "+
+		"That CA is published in the 'extension-apiserver-authentication' configmap in "+
+		"the kube-system namespace. Components receiving calls from kube-aggregator should "+
+		"use that CA to perform their half of the mutual TLS verification.")
+	fs.StringVar(&s.ProxyClientKeyFile, "proxy-client-key-file", s.ProxyClientKeyFile, ""+
+		"Private key for the client certificate used to prove the identity of the aggregator or kube-apiserver "+
+		"when it must call out during a request. This includes proxying requests to a user "+
+		"api-server and calling out to webhook admission plugins.")
+
+	return fss
+}

--- a/pkg/genericcontrolplane/options/validation.go
+++ b/pkg/genericcontrolplane/options/validation.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+import (
+	"fmt"
+
+	apiextensionsapiserver "k8s.io/apiextensions-apiserver/pkg/apiserver"
+
+	"k8s.io/kubernetes/pkg/api/genericcontrolplanescheme"
+)
+
+func validateAPIServerIdentity(options *CompletedServerRunOptions) []error {
+	var errs []error
+	if options.IdentityLeaseDurationSeconds <= 0 {
+		errs = append(errs, fmt.Errorf("--identity-lease-duration-seconds should be a positive number, but value '%d' provided", options.IdentityLeaseDurationSeconds))
+	}
+	if options.IdentityLeaseRenewIntervalSeconds <= 0 {
+		errs = append(errs, fmt.Errorf("--identity-lease-renew-interval-seconds should be a positive number, but value '%d' provided", options.IdentityLeaseRenewIntervalSeconds))
+	}
+	return errs
+}
+
+// Validate checks Options and return a slice of found errs.
+func (s *CompletedServerRunOptions) Validate() []error {
+	var errs []error
+	errs = append(errs, s.Etcd.Validate()...)
+	errs = append(errs, s.SecureServing.Validate()...)
+	errs = append(errs, s.Authentication.Validate()...)
+	errs = append(errs, s.Audit.Validate()...)
+	errs = append(errs, s.Admission.Validate()...)
+	errs = append(errs, s.APIEnablement.Validate(genericcontrolplanescheme.Scheme, apiextensionsapiserver.Scheme)...)
+	errs = append(errs, s.Metrics.Validate()...)
+	errs = append(errs, s.Logs.Validate()...)
+	errs = append(errs, validateAPIServerIdentity(s)...)
+
+	return errs
+}

--- a/pkg/genericcontrolplane/server.go
+++ b/pkg/genericcontrolplane/server.go
@@ -91,7 +91,7 @@ func Run(options options.CompletedServerRunOptions, stopCh <-chan struct{}) erro
 	apiExtensionsConfig, err := CreateAPIExtensionsConfig(
 		*config.GenericConfig,
 		config.ExtraConfig.VersionedInformers,
-		nil,
+		nil, // pluginInitializer
 		options,
 		&unimplementedServiceResolver{},
 		webhook.NewDefaultAuthenticationInfoResolverWrapper(
@@ -205,7 +205,7 @@ func CreateKubeAPIServerConfig(
 		return nil, err
 	}
 
-	// // Load the public keys.g
+	// // Load the public keys.
 	// var pubKeys []interface{}
 	// for _, f := range s.Authentication.ServiceAccounts.KeyFiles {
 	// 	keys, err := keyutil.PublicKeysFromFile(f)
@@ -317,9 +317,10 @@ func BuildGenericConfig(
 		return
 	}
 
-	//if utilfeature.DefaultFeatureGate.Enabled(genericfeatures.APIPriorityAndFairness) && s.GenericServerRunOptions.EnablePriorityAndFairness {
-	//	genericConfig.FlowControl, lastErr = BuildPriorityAndFairness(s, clientgoExternalClient, versionedInformers)
-	//}
+	if utilfeature.DefaultFeatureGate.Enabled(genericfeatures.APIPriorityAndFairness) && o.GenericServerRunOptions.EnablePriorityAndFairness {
+		// TODO(sttts): make BuildPriorityAndFairness take the completed options
+		genericConfig.FlowControl, lastErr = BuildPriorityAndFairness(&o.ServerRunOptions, clientgoExternalClient, versionedInformers)
+	}
 
 	return
 }

--- a/pkg/genericcontrolplane/server.go
+++ b/pkg/genericcontrolplane/server.go
@@ -23,8 +23,6 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"os"
-	"strings"
 	"time"
 
 	apiextensionsapiserver "k8s.io/apiextensions-apiserver/pkg/apiserver"
@@ -69,11 +67,11 @@ const (
 )
 
 // Run runs the specified APIServer.  This should never exit.
-func Run(completedOptions completedServerRunOptions, stopCh <-chan struct{}) error {
+func Run(options options.CompletedServerRunOptions, stopCh <-chan struct{}) error {
 	// To help debugging, immediately log version
 	klog.Infof("Version: %+v", version.Get())
 
-	genericConfig, storageFactory, err := BuildGenericConfig(completedOptions.ServerRunOptions)
+	genericConfig, storageFactory, err := BuildGenericConfig(options)
 	if err != nil {
 		return err
 	}
@@ -84,7 +82,7 @@ func Run(completedOptions completedServerRunOptions, stopCh <-chan struct{}) err
 	}
 	versionedInformers := clientgoinformers.NewSharedInformerFactory(client, 10*time.Minute)
 
-	config, err := CreateKubeAPIServerConfig(genericConfig, completedOptions, versionedInformers, nil, storageFactory)
+	config, err := CreateKubeAPIServerConfig(genericConfig, options, versionedInformers, nil, storageFactory)
 	if err != nil {
 		return err
 	}
@@ -94,7 +92,7 @@ func Run(completedOptions completedServerRunOptions, stopCh <-chan struct{}) err
 		*config.GenericConfig,
 		config.ExtraConfig.VersionedInformers,
 		nil,
-		completedOptions.ServerRunOptions,
+		options,
 		&unimplementedServiceResolver{},
 		webhook.NewDefaultAuthenticationInfoResolverWrapper(
 			nil,
@@ -152,7 +150,7 @@ func CreateServerChain(config apis.CompletedConfig, apiExtensionConfig apiextens
 // CreateKubeAPIServerConfig creates all the resources for running the API server, but runs none of them
 func CreateKubeAPIServerConfig(
 	genericConfig *genericapiserver.Config,
-	s completedServerRunOptions,
+	o options.CompletedServerRunOptions,
 	versionedInformers kubeexternalinformers.SharedInformerFactory,
 	additionalPluginInitializers []admission.PluginInitializer,
 	storageFactory *serverstorage.DefaultStorageFactory,
@@ -160,33 +158,33 @@ func CreateKubeAPIServerConfig(
 	*apis.Config,
 	error,
 ) {
-	s.Metrics.Apply()
+	o.Metrics.Apply()
 	serviceaccount.RegisterMetrics()
 
-	s.Logs.Apply()
+	o.Logs.Apply()
 
 	config := &apis.Config{
 		GenericConfig: genericConfig,
 		ExtraConfig: apis.ExtraConfig{
 			APIResourceConfigSource: storageFactory.APIResourceConfigSource,
 			StorageFactory:          storageFactory,
-			EventTTL:                s.EventTTL,
-			EnableLogsSupport:       s.EnableLogsHandler,
+			EventTTL:                o.EventTTL,
+			EnableLogsSupport:       o.EnableLogsHandler,
 
 			VersionedInformers: versionedInformers,
 
-			IdentityLeaseDurationSeconds:      s.IdentityLeaseDurationSeconds,
-			IdentityLeaseRenewIntervalSeconds: s.IdentityLeaseRenewIntervalSeconds,
+			IdentityLeaseDurationSeconds:      o.IdentityLeaseDurationSeconds,
+			IdentityLeaseRenewIntervalSeconds: o.IdentityLeaseRenewIntervalSeconds,
 		},
 	}
 
-	clientCAProvider, err := s.Authentication.ClientCert.GetClientCAContentProvider()
+	clientCAProvider, err := o.Authentication.ClientCert.GetClientCAContentProvider()
 	if err != nil {
 		return nil, err
 	}
 	config.ExtraConfig.ClusterAuthenticationInfo.ClientCA = clientCAProvider
 
-	requestHeaderConfig, err := s.Authentication.RequestHeader.ToAuthenticationRequestHeaderConfig()
+	requestHeaderConfig, err := o.Authentication.RequestHeader.ToAuthenticationRequestHeaderConfig()
 	if err != nil {
 		return nil, err
 	}
@@ -198,7 +196,7 @@ func CreateKubeAPIServerConfig(
 		config.ExtraConfig.ClusterAuthenticationInfo.RequestHeaderUsernameHeaders = requestHeaderConfig.UsernameHeaders
 	}
 
-	if err := s.ServerRunOptions.Admission.ApplyTo(
+	if err := o.ServerRunOptions.Admission.ApplyTo(
 		config.GenericConfig,
 		config.ExtraConfig.VersionedInformers,
 		config.GenericConfig.LoopbackClientConfig,
@@ -226,35 +224,35 @@ func CreateKubeAPIServerConfig(
 
 // BuildGenericConfig takes the master server options and produces the genericapiserver.Config associated with it
 func BuildGenericConfig(
-	s *options.ServerRunOptions,
+	o options.CompletedServerRunOptions,
 ) (
 	genericConfig *genericapiserver.Config,
 	storageFactory *serverstorage.DefaultStorageFactory,
 	lastErr error,
 ) {
 	genericConfig = genericapiserver.NewConfig(genericcontrolplanescheme.Codecs)
-	if s.BuildHandlerChainFunc != nil {
-		genericConfig.BuildHandlerChainFunc = s.BuildHandlerChainFunc
+	if o.BuildHandlerChainFunc != nil {
+		genericConfig.BuildHandlerChainFunc = o.BuildHandlerChainFunc
 	}
 
-	if lastErr = s.GenericServerRunOptions.ApplyTo(genericConfig); lastErr != nil {
+	if lastErr = o.GenericServerRunOptions.ApplyTo(genericConfig); lastErr != nil {
 		return
 	}
 
-	if lastErr = s.SecureServing.ApplyTo(&genericConfig.SecureServing, &genericConfig.LoopbackClientConfig); lastErr != nil {
+	if lastErr = o.SecureServing.ApplyTo(&genericConfig.SecureServing, &genericConfig.LoopbackClientConfig); lastErr != nil {
 		return
 	}
-	if lastErr = s.Features.ApplyTo(genericConfig); lastErr != nil {
+	if lastErr = o.Features.ApplyTo(genericConfig); lastErr != nil {
 		return
 	}
-	if lastErr = s.APIEnablement.ApplyTo(genericConfig, apis.DefaultAPIResourceConfigSource(), genericcontrolplanescheme.Scheme); lastErr != nil {
+	if lastErr = o.APIEnablement.ApplyTo(genericConfig, apis.DefaultAPIResourceConfigSource(), genericcontrolplanescheme.Scheme); lastErr != nil {
 		return
 	}
-	if lastErr = s.EgressSelector.ApplyTo(genericConfig); lastErr != nil {
+	if lastErr = o.EgressSelector.ApplyTo(genericConfig); lastErr != nil {
 		return
 	}
 	if utilfeature.DefaultFeatureGate.Enabled(genericfeatures.APIServerTracing) {
-		if lastErr = s.Traces.ApplyTo(genericConfig.EgressSelector, genericConfig); lastErr != nil {
+		if lastErr = o.Traces.ApplyTo(genericConfig.EgressSelector, genericConfig); lastErr != nil {
 			return
 		}
 	}
@@ -271,7 +269,7 @@ func BuildGenericConfig(
 
 	storageFactoryConfig := kubeapiserver.NewStorageFactoryConfig(genericcontrolplanescheme.Scheme, genericcontrolplanescheme.Codecs)
 	storageFactoryConfig.APIResourceConfig = genericConfig.MergedResourceConfig
-	completedStorageFactoryConfig, err := storageFactoryConfig.Complete(s.Etcd)
+	completedStorageFactoryConfig, err := storageFactoryConfig.Complete(o.Etcd)
 	if err != nil {
 		lastErr = err
 		return
@@ -286,7 +284,7 @@ func BuildGenericConfig(
 	if utilfeature.DefaultFeatureGate.Enabled(genericfeatures.APIServerTracing) && genericConfig.TracerProvider != nil {
 		storageFactory.StorageConfig.Transport.TracerProvider = genericConfig.TracerProvider
 	}
-	if lastErr = s.Etcd.ApplyWithStorageFactoryTo(storageFactory, genericConfig); lastErr != nil {
+	if lastErr = o.Etcd.ApplyWithStorageFactoryTo(storageFactory, genericConfig); lastErr != nil {
 		return
 	}
 
@@ -309,11 +307,11 @@ func BuildGenericConfig(
 	versionedInformers := clientgoinformers.NewSharedInformerFactory(clientgoExternalClient, 10*time.Minute)
 
 	// Authentication.ApplyTo requires already applied OpenAPIConfig and EgressSelector if present
-	if lastErr = AuthenticationApplyTo(s.Authentication, &genericConfig.Authentication, genericConfig.SecureServing, genericConfig.EgressSelector, genericConfig.OpenAPIConfig); lastErr != nil {
+	if lastErr = AuthenticationApplyTo(o.Authentication, &genericConfig.Authentication, genericConfig.SecureServing, genericConfig.EgressSelector, genericConfig.OpenAPIConfig); lastErr != nil {
 		return
 	}
 
-	genericConfig.Authorization.Authorizer, genericConfig.RuleResolver, err = BuildAuthorizer(s, versionedInformers)
+	genericConfig.Authorization.Authorizer, genericConfig.RuleResolver, err = BuildAuthorizer(&o.ServerRunOptions, versionedInformers)
 	if err != nil {
 		lastErr = fmt.Errorf("invalid authorization config: %v", err)
 		return
@@ -356,52 +354,6 @@ func BuildPriorityAndFairness(s *options.ServerRunOptions, extclient clientgocli
 		s.GenericServerRunOptions.MaxRequestsInFlight+s.GenericServerRunOptions.MaxMutatingRequestsInFlight,
 		s.GenericServerRunOptions.RequestTimeout/4,
 	), nil
-}
-
-// completedServerRunOptions is a private wrapper that enforces a call of Complete() before Run can be invoked.
-type completedServerRunOptions struct {
-	*options.ServerRunOptions
-}
-
-// Complete set default ServerRunOptions.
-// Should be called after kube-apiserver flags parsed.
-func Complete(s *options.ServerRunOptions) (completedServerRunOptions, error) {
-	var options completedServerRunOptions
-	// set defaults
-	if err := s.GenericServerRunOptions.DefaultAdvertiseAddress(s.SecureServing.SecureServingOptions); err != nil {
-		return options, err
-	}
-
-	if err := s.SecureServing.MaybeDefaultWithSelfSignedCerts(s.GenericServerRunOptions.AdvertiseAddress.String(), nil, nil); err != nil {
-		return options, fmt.Errorf("error creating self-signed certificates: %v", err)
-	}
-
-	if len(s.GenericServerRunOptions.ExternalHost) == 0 {
-		if len(s.GenericServerRunOptions.AdvertiseAddress) > 0 {
-			s.GenericServerRunOptions.ExternalHost = s.GenericServerRunOptions.AdvertiseAddress.String()
-		} else {
-			if hostname, err := os.Hostname(); err == nil {
-				s.GenericServerRunOptions.ExternalHost = hostname
-			} else {
-				return options, fmt.Errorf("error finding host name: %v", err)
-			}
-		}
-		klog.Infof("external host was not specified, using %v", s.GenericServerRunOptions.ExternalHost)
-	}
-
-	for key, value := range s.APIEnablement.RuntimeConfig {
-		if key == "v1" || strings.HasPrefix(key, "v1/") ||
-			key == "api/v1" || strings.HasPrefix(key, "api/v1/") {
-			delete(s.APIEnablement.RuntimeConfig, key)
-			s.APIEnablement.RuntimeConfig["/v1"] = value
-		}
-		if key == "api/legacy" {
-			delete(s.APIEnablement.RuntimeConfig, key)
-		}
-	}
-
-	options.ServerRunOptions = s
-	return options, nil
 }
 
 // unimplementedServiceResolver is a webhook.ServiceResolver that always returns an error.


### PR DESCRIPTION
- follow options -(fiddle)-> config -(fiddle)-> server pattern with generic apiserver config, i.e. split generation appart from apiserver creation
- restore flags and validation logic
- add CompletedServerRunOptions to make completion composable for consumers in their option structs