### PR TITLE
1.23: genericcontrolplane: split generic config construction from kube-apiserver and apiextensions

### DIFF
--- a/pkg/genericcontrolplane/admission/initializer.go
+++ b/pkg/genericcontrolplane/admission/initializer.go
@@ -23,13 +23,6 @@ import (
 	quota "k8s.io/apiserver/pkg/quota/v1"
 )
 
-// TODO add a `WantsToRun` which takes a stopCh.  Might make it generic.
-
-// WantsCloudConfig defines a function which sets CloudConfig for admission plugins that need it.
-type WantsCloudConfig interface {
-	SetCloudConfig([]byte)
-}
-
 // WantsRESTMapper defines a function which sets RESTMapper for admission plugins that need it.
 type WantsRESTMapper interface {
 	SetRESTMapper(meta.RESTMapper)

--- a/pkg/genericcontrolplane/apiextensions.go
+++ b/pkg/genericcontrolplane/apiextensions.go
@@ -14,9 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package app does all of the work necessary to create a Kubernetes
-// APIServer by binding together the API, master and APIServer infrastructure.
-// It can be configured and called directly or via the hyperkube framework.
 package genericcontrolplane
 
 import (
@@ -34,6 +31,7 @@ import (
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/apiserver/pkg/util/webhook"
 	kubeexternalinformers "k8s.io/client-go/informers"
+
 	"k8s.io/kubernetes/pkg/genericcontrolplane/options"
 )
 
@@ -41,7 +39,7 @@ func CreateAPIExtensionsConfig(
 	kubeAPIServerConfig genericapiserver.Config,
 	externalInformers kubeexternalinformers.SharedInformerFactory,
 	pluginInitializers []admission.PluginInitializer,
-	commandOptions *options.ServerRunOptions,
+	commandOptions options.CompletedServerRunOptions,
 	serviceResolver webhook.ServiceResolver,
 	authResolverWrapper webhook.AuthenticationInfoResolverWrapper,
 ) (*apiextensionsapiserver.Config, error) {

--- a/pkg/genericcontrolplane/options/flags.go
+++ b/pkg/genericcontrolplane/options/flags.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+import (
+	cliflag "k8s.io/component-base/cli/flag"
+)
+
+// Flags returns flags for a specific APIServer by section name
+func (s *ServerRunOptions) Flags() (fss cliflag.NamedFlagSets) {
+	s.GenericServerRunOptions.AddUniversalFlags(fss.FlagSet("generic"))
+	s.Etcd.AddFlags(fss.FlagSet("etcd"))
+	s.SecureServing.AddFlags(fss.FlagSet("secure serving"))
+	s.Audit.AddFlags(fss.FlagSet("auditing"))
+	s.Features.AddFlags(fss.FlagSet("features"))
+	s.Authentication.AddFlags(fss.FlagSet("authentication"))
+
+	s.APIEnablement.AddFlags(fss.FlagSet("API enablement"))
+	s.EgressSelector.AddFlags(fss.FlagSet("egress selector"))
+	s.Admission.AddFlags(fss.FlagSet("admission"))
+
+	s.Metrics.AddFlags(fss.FlagSet("metrics"))
+	s.Logs.AddFlags(fss.FlagSet("logs"))
+	s.Traces.AddFlags(fss.FlagSet("traces"))
+
+	fs := fss.FlagSet("misc")
+	fs.DurationVar(&s.EventTTL, "event-ttl", s.EventTTL,
+		"Amount of time to retain events.")
+
+	fs.BoolVar(&s.EnableLogsHandler, "enable-logs-handler", s.EnableLogsHandler,
+		"If true, install a /logs handler for the apiserver logs.")
+	fs.MarkDeprecated("enable-logs-handler", "This flag will be removed in v1.19") //nolint:golint,errcheck
+
+	fs.Int64Var(&s.MaxConnectionBytesPerSec, "max-connection-bytes-per-sec", s.MaxConnectionBytesPerSec, ""+
+		"If non-zero, throttle each user connection to this number of bytes/sec. "+
+		"Currently only applies to long-running requests.")
+
+	fs.IntVar(&s.IdentityLeaseDurationSeconds, "identity-lease-duration-seconds", s.IdentityLeaseDurationSeconds,
+		"The duration of kube-apiserver lease in seconds, must be a positive number. (In use when the APIServerIdentity feature gate is enabled.)")
+
+	fs.IntVar(&s.IdentityLeaseRenewIntervalSeconds, "identity-lease-renew-interval-seconds", s.IdentityLeaseRenewIntervalSeconds,
+		"The interval of kube-apiserver renewing its lease in seconds, must be a positive number. (In use when the APIServerIdentity feature gate is enabled.)")
+
+	fs.StringVar(&s.ProxyClientCertFile, "proxy-client-cert-file", s.ProxyClientCertFile, ""+
+		"Client certificate used to prove the identity of the aggregator or kube-apiserver "+
+		"when it must call out during a request. This includes proxying requests to a user "+
+		"api-server and calling out to webhook admission plugins. It is expected that this "+
+		"cert includes a signature from the CA in the --requestheader-client-ca-file flag. "+
+		"That CA is published in the 'extension-apiserver-authentication' configmap in "+
+		"the kube-system namespace. Components receiving calls from kube-aggregator should "+
+		"use that CA to perform their half of the mutual TLS verification.")
+	fs.StringVar(&s.ProxyClientKeyFile, "proxy-client-key-file", s.ProxyClientKeyFile, ""+
+		"Private key for the client certificate used to prove the identity of the aggregator or kube-apiserver "+
+		"when it must call out during a request. This includes proxying requests to a user "+
+		"api-server and calling out to webhook admission plugins.")
+
+	return fss
+}

--- a/pkg/genericcontrolplane/options/validation.go
+++ b/pkg/genericcontrolplane/options/validation.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+import (
+	"fmt"
+
+	apiextensionsapiserver "k8s.io/apiextensions-apiserver/pkg/apiserver"
+
+	"k8s.io/kubernetes/pkg/api/genericcontrolplanescheme"
+)
+
+func validateAPIServerIdentity(options *CompletedServerRunOptions) []error {
+	var errs []error
+	if options.IdentityLeaseDurationSeconds <= 0 {
+		errs = append(errs, fmt.Errorf("--identity-lease-duration-seconds should be a positive number, but value '%d' provided", options.IdentityLeaseDurationSeconds))
+	}
+	if options.IdentityLeaseRenewIntervalSeconds <= 0 {
+		errs = append(errs, fmt.Errorf("--identity-lease-renew-interval-seconds should be a positive number, but value '%d' provided", options.IdentityLeaseRenewIntervalSeconds))
+	}
+	return errs
+}
+
+// Validate checks Options and return a slice of found errs.
+func (s *CompletedServerRunOptions) Validate() []error {
+	var errs []error
+	errs = append(errs, s.Etcd.Validate()...)
+	errs = append(errs, s.SecureServing.Validate()...)
+	errs = append(errs, s.Authentication.Validate()...)
+	errs = append(errs, s.Audit.Validate()...)
+	errs = append(errs, s.Admission.Validate()...)
+	errs = append(errs, s.APIEnablement.Validate(genericcontrolplanescheme.Scheme, apiextensionsapiserver.Scheme)...)
+	errs = append(errs, s.Metrics.Validate()...)
+	errs = append(errs, validateAPIServerIdentity(s)...)
+
+	return errs
+}

--- a/pkg/genericcontrolplane/server.go
+++ b/pkg/genericcontrolplane/server.go
@@ -20,7 +20,9 @@ limitations under the License.
 package genericcontrolplane
 
 import (
+	"errors"
 	"fmt"
+	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -44,11 +46,12 @@ import (
 	"k8s.io/apiserver/pkg/util/openapi"
 	"k8s.io/apiserver/pkg/util/webhook"
 	clientgoinformers "k8s.io/client-go/informers"
+	kubeexternalinformers "k8s.io/client-go/informers"
 	clientgoclientset "k8s.io/client-go/kubernetes"
-	_ "k8s.io/component-base/metrics/prometheus/workqueue" // for workqueue metric registration
+	_ "k8s.io/component-base/metrics/prometheus/workqueue"
 	"k8s.io/component-base/version"
 	"k8s.io/klog/v2"
-	aggregatorapiserver "k8s.io/kube-aggregator/pkg/apiserver"
+
 	"k8s.io/kubernetes/pkg/api/genericcontrolplanescheme"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	generatedopenapi "k8s.io/kubernetes/pkg/generated/openapi"
@@ -70,11 +73,22 @@ const (
 )
 
 // Run runs the specified APIServer.  This should never exit.
-func Run(completeOptions completedServerRunOptions, stopCh <-chan struct{}) error {
+func Run(completedOptions completedServerRunOptions, stopCh <-chan struct{}) error {
 	// To help debugging, immediately log version
 	klog.Infof("Version: %+v", version.Get())
 
-	config, serviceResolver, pluginInitializer, err := CreateKubeAPIServerConfig(completeOptions)
+	genericConfig, storageFactory, err := BuildGenericConfig(completedOptions.ServerRunOptions)
+	if err != nil {
+		return err
+	}
+
+	client, err := clientgoclientset.NewForConfig(genericConfig.LoopbackClientConfig)
+	if err != nil {
+		return fmt.Errorf("failed to create loopback client: %v", err)
+	}
+	versionedInformers := clientgoinformers.NewSharedInformerFactory(client, 10*time.Minute)
+
+	config, err := CreateKubeAPIServerConfig(genericConfig, completedOptions, versionedInformers, nil, storageFactory)
 	if err != nil {
 		return err
 	}
@@ -83,9 +97,9 @@ func Run(completeOptions completedServerRunOptions, stopCh <-chan struct{}) erro
 	apiExtensionsConfig, err := CreateAPIExtensionsConfig(
 		*config.GenericConfig,
 		config.ExtraConfig.VersionedInformers,
-		pluginInitializer,
-		completeOptions.ServerRunOptions,
-		serviceResolver,
+		nil,
+		completedOptions.ServerRunOptions,
+		&unimplementedServiceResolver{},
 		webhook.NewDefaultAuthenticationInfoResolverWrapper(
 			nil,
 			config.GenericConfig.EgressSelector,
@@ -94,7 +108,7 @@ func Run(completeOptions completedServerRunOptions, stopCh <-chan struct{}) erro
 		),
 	)
 	if err != nil {
-		return fmt.Errorf("configure api extensions: %v", err)
+		return fmt.Errorf("failed to create apiextensions-apiserver config: %v", err)
 	}
 
 	serverChain, err := CreateServerChain(config.Complete(), apiExtensionsConfig.Complete())
@@ -141,31 +155,23 @@ func CreateServerChain(config apis.CompletedConfig, apiExtensionConfig apiextens
 }
 
 // CreateKubeAPIServerConfig creates all the resources for running the API server, but runs none of them
-func CreateKubeAPIServerConfig(s completedServerRunOptions) (
+func CreateKubeAPIServerConfig(
+	genericConfig *genericapiserver.Config,
+	s completedServerRunOptions,
+	versionedInformers kubeexternalinformers.SharedInformerFactory,
+	additionalPluginInitializers []admission.PluginInitializer,
+	storageFactory *serverstorage.DefaultStorageFactory,
+) (
 	*apis.Config,
-	aggregatorapiserver.ServiceResolver,
-	[]admission.PluginInitializer,
 	error,
 ) {
-	genericConfig, serviceResolver, pluginInitializers, storageFactory, err := BuildGenericConfig(s.ServerRunOptions)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-
 	s.Metrics.Apply()
 	serviceaccount.RegisterMetrics()
-
-	kubeClientConfig := genericConfig.LoopbackClientConfig
-	clientgoExternalClient, err := clientgoclientset.NewForConfig(kubeClientConfig)
-	if err != nil {
-		return nil, nil, nil, fmt.Errorf("failed to create real external clientset: %v", err)
-	}
-	versionedInformers := clientgoinformers.NewSharedInformerFactory(clientgoExternalClient, 10*time.Minute)
 
 	// TODO(ncdc,1.23) upstream has this in the Cobra RunE method and it's called as early as
 	// possible. Do we want to consider doing something similar?
 	if err := s.Logs.ValidateAndApply(); err != nil {
-		return nil, nil, nil, err
+		return nil, err
 	}
 
 	config := &apis.Config{
@@ -185,13 +191,13 @@ func CreateKubeAPIServerConfig(s completedServerRunOptions) (
 
 	clientCAProvider, err := s.Authentication.ClientCert.GetClientCAContentProvider()
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, err
 	}
 	config.ExtraConfig.ClusterAuthenticationInfo.ClientCA = clientCAProvider
 
 	requestHeaderConfig, err := s.Authentication.RequestHeader.ToAuthenticationRequestHeaderConfig()
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, err
 	}
 	if requestHeaderConfig != nil {
 		config.ExtraConfig.ClusterAuthenticationInfo.RequestHeaderCA = requestHeaderConfig.CAContentProvider
@@ -206,15 +212,11 @@ func CreateKubeAPIServerConfig(s completedServerRunOptions) (
 		config.ExtraConfig.VersionedInformers,
 		config.GenericConfig.LoopbackClientConfig,
 		feature.DefaultFeatureGate,
-		pluginInitializers...); err != nil {
-		return nil, nil, nil, err
+		additionalPluginInitializers...); err != nil {
+		return nil, err
 	}
 
-	// if err := config.GenericConfig.AddPostStartHook("start-kube-apiserver-admission-initializer", admissionPostStartHook); err != nil {
-	// 	return nil, nil, nil, err
-	// }
-
-	// // Load the public keys.
+	// // Load the public keys.g
 	// var pubKeys []interface{}
 	// for _, f := range s.Authentication.ServiceAccounts.KeyFiles {
 	// 	keys, err := keyutil.PublicKeysFromFile(f)
@@ -228,7 +230,7 @@ func CreateKubeAPIServerConfig(s completedServerRunOptions) (
 	// config.ExtraConfig.ServiceAccountJWKSURI = s.Authentication.ServiceAccounts.JWKSURI
 	// config.ExtraConfig.ServiceAccountPublicKeys = pubKeys
 
-	return config, serviceResolver, pluginInitializers, nil
+	return config, nil
 }
 
 // BuildGenericConfig takes the master server options and produces the genericapiserver.Config associated with it
@@ -236,9 +238,6 @@ func BuildGenericConfig(
 	s *options.ServerRunOptions,
 ) (
 	genericConfig *genericapiserver.Config,
-	serviceResolver aggregatorapiserver.ServiceResolver,
-	pluginInitializers []admission.PluginInitializer,
-	// admissionPostStartHook genericapiserver.PostStartHookFunc,
 	storageFactory *serverstorage.DefaultStorageFactory,
 	lastErr error,
 ) {
@@ -312,9 +311,7 @@ func BuildGenericConfig(
 	genericConfig.LoopbackClientConfig.DisableCompression = true
 
 	kubeClientConfig := genericConfig.LoopbackClientConfig
-
 	clientutils.EnableMultiCluster(genericConfig.LoopbackClientConfig, genericConfig, true, "namespaces", "apiservices", "customresourcedefinitions", "clusterroles", "clusterrolebindings", "roles", "rolebindings")
-
 	clientgoExternalClient, err := clientgoclientset.NewForConfig(kubeClientConfig)
 	if err != nil {
 		lastErr = fmt.Errorf("failed to create real external clientset: %v", err)
@@ -332,6 +329,10 @@ func BuildGenericConfig(
 		lastErr = fmt.Errorf("invalid authorization config: %v", err)
 		return
 	}
+
+	//if utilfeature.DefaultFeatureGate.Enabled(genericfeatures.APIPriorityAndFairness) && s.GenericServerRunOptions.EnablePriorityAndFairness {
+	//	genericConfig.FlowControl, lastErr = BuildPriorityAndFairness(s, clientgoExternalClient, versionedInformers)
+	//}
 
 	return
 }
@@ -412,4 +413,12 @@ func Complete(s *options.ServerRunOptions) (completedServerRunOptions, error) {
 
 	options.ServerRunOptions = s
 	return options, nil
+}
+
+// unimplementedServiceResolver is a webhook.ServiceResolver that always returns an error.
+type unimplementedServiceResolver struct{}
+
+// ResolveEndpoint always returns an error that this is not yet supported.
+func (r *unimplementedServiceResolver) ResolveEndpoint(namespace string, name string, port int32) (*url.URL, error) {
+	return nil, errors.New("webhook admission and  conversions are not yet supported in kcp")
 }

--- a/pkg/genericcontrolplane/server.go
+++ b/pkg/genericcontrolplane/server.go
@@ -95,7 +95,7 @@ func Run(options options.CompletedServerRunOptions, stopCh <-chan struct{}) erro
 	apiExtensionsConfig, err := CreateAPIExtensionsConfig(
 		*config.GenericConfig,
 		config.ExtraConfig.VersionedInformers,
-		nil,
+		nil, // pluginInitializer
 		options,
 		&unimplementedServiceResolver{},
 		webhook.NewDefaultAuthenticationInfoResolverWrapper(
@@ -214,7 +214,7 @@ func CreateKubeAPIServerConfig(
 		return nil, err
 	}
 
-	// // Load the public keys.g
+	// // Load the public keys.
 	// var pubKeys []interface{}
 	// for _, f := range s.Authentication.ServiceAccounts.KeyFiles {
 	// 	keys, err := keyutil.PublicKeysFromFile(f)
@@ -328,9 +328,10 @@ func BuildGenericConfig(
 		return
 	}
 
-	//if utilfeature.DefaultFeatureGate.Enabled(genericfeatures.APIPriorityAndFairness) && s.GenericServerRunOptions.EnablePriorityAndFairness {
-	//	genericConfig.FlowControl, lastErr = BuildPriorityAndFairness(s, clientgoExternalClient, versionedInformers)
-	//}
+	if utilfeature.DefaultFeatureGate.Enabled(genericfeatures.APIPriorityAndFairness) && o.GenericServerRunOptions.EnablePriorityAndFairness {
+		// TODO(sttts): make BuildPriorityAndFairness take the completed options
+		genericConfig.FlowControl, lastErr = BuildPriorityAndFairness(&o.ServerRunOptions, clientgoExternalClient, versionedInformers)
+	}
 
 	return
 }


### PR DESCRIPTION
Based on 1.23 rebase https://github.com/kcp-dev/kubernetes/pull/30/files.