### PR TITLE
RootCACertPublisher: Make the controller multi-workspace aware

### DIFF
--- a/pkg/controller/certificates/rootcacertpublisher/publisher.go
+++ b/pkg/controller/certificates/rootcacertpublisher/publisher.go
@@ -160,6 +160,7 @@ func (c *Publisher) namespaceAdded(obj interface{}) {
 	key, err := cache.MetaNamespaceKeyFunc(namespace)
 	if err != nil {
 		utilruntime.HandleError(err)
+		return
 	}
 
 	c.queue.Add(key)
@@ -174,6 +175,7 @@ func (c *Publisher) namespaceUpdated(oldObj interface{}, newObj interface{}) {
 	key, err := cache.MetaNamespaceKeyFunc(newNamespace)
 	if err != nil {
 		utilruntime.HandleError(err)
+		return
 	}
 
 	c.queue.Add(key)


### PR DESCRIPTION
Makes the RootCACertPublisher multi workspace aware. 

Required by: https://github.com/kcp-dev/kcp/issues/280 