### PR TITLE
Plumb through github.com/kcp-dev/apimachinery/pkg/logicalcluster.LogicalCluster

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -49,6 +49,7 @@ require (
 	github.com/googleapis/gnostic v0.5.5
 	github.com/heketi/heketi v10.3.0+incompatible
 	github.com/ishidawataru/sctp v0.0.0-20190723014705-7c296d48a2b5
+	github.com/kcp-dev/apimachinery v0.0.0-20220325201419-1610634c582d
 	github.com/libopenstorage/openstorage v1.0.0
 	github.com/lithammer/dedent v1.1.0
 	github.com/moby/ipvs v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -299,6 +299,13 @@ github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8
 github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
 github.com/karrick/godirwalk v1.16.1 h1:DynhcF+bztK8gooS0+NDJFrdNZjJ3gzVzC545UNA9iw=
 github.com/karrick/godirwalk v1.16.1/go.mod h1:j4mkqPuvaLI8mp1DroR3P6ad7cyYd4c1qeJ3RV7ULlk=
+github.com/kcp-dev/apimachinery v0.0.0-20220317232611-6ebdde002160/go.mod h1:0HwFQX/gr6dnKxiB2+J7eyg2RbnKOxSTMme+dImw+o0=
+github.com/kcp-dev/apimachinery v0.0.0-20220317233623-d41dea6b2d6c/go.mod h1:0HwFQX/gr6dnKxiB2+J7eyg2RbnKOxSTMme+dImw+o0=
+github.com/kcp-dev/apimachinery v0.0.0-20220318083534-272a7619a234/go.mod h1:0HwFQX/gr6dnKxiB2+J7eyg2RbnKOxSTMme+dImw+o0=
+github.com/kcp-dev/apimachinery v0.0.0-20220322210311-c4d60a5abde3 h1:gbXvMrFLPElwZmu3Qr0RVP+pXSO94s2OBTEQIucinn0=
+github.com/kcp-dev/apimachinery v0.0.0-20220322210311-c4d60a5abde3/go.mod h1:0HwFQX/gr6dnKxiB2+J7eyg2RbnKOxSTMme+dImw+o0=
+github.com/kcp-dev/apimachinery v0.0.0-20220325201419-1610634c582d h1:qSjLwZXAEkrEHS8AxHbEPw5UGNmlj8Dub9Wm8ar66Ho=
+github.com/kcp-dev/apimachinery v0.0.0-20220325201419-1610634c582d/go.mod h1:nGlccFL2GBMAyoqqpVd519U7ci/fEAAHVJCIYwlsLUo=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=

--- a/pkg/controller/certificates/rootcacertpublisher/publisher.go
+++ b/pkg/controller/certificates/rootcacertpublisher/publisher.go
@@ -22,6 +22,8 @@ import (
 	"reflect"
 	"time"
 
+	"github.com/kcp-dev/apimachinery/pkg/logicalcluster"
+
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -276,8 +278,8 @@ func convertToCM(obj interface{}) (*v1.ConfigMap, error) {
 }
 
 func getNamespaceKey(configmap *v1.ConfigMap) string {
-	clusterName := configmap.GetClusterName()
-	if len(clusterName) == 0 {
+	clusterName := logicalcluster.From(configmap)
+	if clusterName.Empty() {
 		return ""
 	}
 

--- a/pkg/controller/namespace/namespace_controller.go
+++ b/pkg/controller/namespace/namespace_controller.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	"golang.org/x/time/rate"
 
 	v1 "k8s.io/api/core/v1"
@@ -66,7 +67,7 @@ type NamespaceController struct {
 func NewNamespaceController(
 	kubeClient clientset.Interface,
 	metadataClient metadata.Interface,
-	discoverResourcesFn func(clusterName string) ([]*metav1.APIResourceList, error),
+	discoverResourcesFn func(clusterName logicalcluster.LogicalCluster) ([]*metav1.APIResourceList, error),
 	namespaceInformer coreinformers.NamespaceInformer,
 	resyncPeriod time.Duration,
 	finalizerToken v1.FinalizerName) *NamespaceController {
@@ -189,7 +190,7 @@ func (nm *NamespaceController) syncNamespaceFromKey(key string) (err error) {
 		utilruntime.HandleError(fmt.Errorf("Unable to retrieve namespace %v from store: %v", key, err))
 		return err
 	}
-	return nm.namespacedResourcesDeleter.Delete(namespace.ClusterName, namespace.Name)
+	return nm.namespacedResourcesDeleter.Delete(logicalcluster.From(namespace), namespace.Name)
 }
 
 // Run starts observing the system with the specified number of workers.

--- a/pkg/controller/serviceaccount/serviceaccounts_controller.go
+++ b/pkg/controller/serviceaccount/serviceaccounts_controller.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/kcp-dev/apimachinery/pkg/logicalcluster"
+
 	"k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -202,7 +204,7 @@ func (c *ServiceAccountsController) syncNamespace(ctx context.Context, key strin
 		return nil
 	}
 
-	clusterCtx := genericapirequest.WithCluster(ctx, genericapirequest.Cluster{Name: ns.ClusterName})
+	clusterCtx := genericapirequest.WithCluster(ctx, genericapirequest.Cluster{Name: logicalcluster.From(ns)})
 
 	createFailures := []error{}
 	for _, sa := range c.serviceAccountsToEnsure {
@@ -234,8 +236,8 @@ func (c *ServiceAccountsController) enqueueNamespace(obj metav1.Object) {
 		namespaceKey = obj.GetName()
 	}
 
-	clusterName := obj.GetClusterName()
-	if len(clusterName) > 0 {
+	clusterName := logicalcluster.From(obj)
+	if !clusterName.Empty() {
 		namespaceKey = clusters.ToClusterAwareKey(clusterName, namespaceKey)
 	}
 

--- a/pkg/genericcontrolplane/server.go
+++ b/pkg/genericcontrolplane/server.go
@@ -25,6 +25,8 @@ import (
 	"net/url"
 	"time"
 
+	"github.com/kcp-dev/apimachinery/pkg/logicalcluster"
+
 	apiextensionsapiserver "k8s.io/apiextensions-apiserver/pkg/apiserver"
 	extensionsapiserver "k8s.io/apiextensions-apiserver/pkg/apiserver"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -68,8 +70,9 @@ const Include = "kube-control-plane"
 const (
 	etcdRetryLimit    = 60
 	etcdRetryInterval = 1 * time.Second
-	LocalAdminCluster = "system:admin"
 )
+
+var LocalAdminCluster = logicalcluster.New("system:admin")
 
 // Run runs the specified APIServer.  This should never exit.
 func Run(options options.CompletedServerRunOptions, stopCh <-chan struct{}) error {

--- a/pkg/registry/core/serviceaccount/storage/token.go
+++ b/pkg/registry/core/serviceaccount/storage/token.go
@@ -89,6 +89,11 @@ func (r *TokenREST) Create(ctx context.Context, name string, obj runtime.Object,
 		gvk := schema.FromAPIVersionAndKind(ref.APIVersion, ref.Kind)
 		switch {
 		case gvk.Group == "" && gvk.Kind == "Pod":
+			if r.pods == nil {
+				// TODO(sttts): kubelet will try to create bound tokens against the pcluster, but those obviously
+				//              will not work against kcp. ¯\_(ツ)_/¯
+				return nil, errors.NewBadRequest("spec.BoundObjectRef.Kind equal to Pod is invalid")
+			}
 			newCtx := newContext(ctx, "pods", ref.Name, gvk)
 			podObj, err := r.pods.Get(newCtx, ref.Name, &metav1.GetOptions{})
 			if err != nil {

--- a/pkg/registry/rbac/rest/storage_rbac.go
+++ b/pkg/registry/rbac/rest/storage_rbac.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/kcp-dev/apimachinery/pkg/logicalcluster"
+
 	rbacapiv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -163,7 +165,7 @@ func (p *PolicyData) EnsureRBACPolicy() genericapiserver.PostStartHookFunc {
 				utilruntime.HandleError(fmt.Errorf("unable to initialize client set: %v", err))
 				return false, nil
 			}
-			client := clientClusterGetter.Cluster("system:admin")
+			client := clientClusterGetter.Cluster(logicalcluster.New("system:admin"))
 			return ensureRBACPolicy(p, client)
 		})
 		// if we're never able to make it through initialization, kill the API server

--- a/pkg/serviceaccount/claims.go
+++ b/pkg/serviceaccount/claims.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	"gopkg.in/square/go-jose.v2/jwt"
 	"k8s.io/apiserver/pkg/audit"
 	"k8s.io/client-go/tools/clusters"
@@ -47,12 +48,13 @@ type privateClaims struct {
 }
 
 type kubernetes struct {
-	ClusterName string          `json:"clusterName,omitempty"`
-	Namespace   string          `json:"namespace,omitempty"`
-	Svcacct     ref             `json:"serviceaccount,omitempty"`
-	Pod         *ref            `json:"pod,omitempty"`
-	Secret      *ref            `json:"secret,omitempty"`
-	WarnAfter   jwt.NumericDate `json:"warnafter,omitempty"`
+	ClusterName logicalcluster.LogicalCluster `json:"clusterName,omitempty"`
+
+	Namespace string          `json:"namespace,omitempty"`
+	Svcacct   ref             `json:"serviceaccount,omitempty"`
+	Pod       *ref            `json:"pod,omitempty"`
+	Secret    *ref            `json:"secret,omitempty"`
+	WarnAfter jwt.NumericDate `json:"warnafter,omitempty"`
 }
 
 type ref struct {
@@ -71,7 +73,7 @@ func Claims(sa core.ServiceAccount, pod *core.Pod, secret *core.Secret, expirati
 	}
 	pc := &privateClaims{
 		Kubernetes: kubernetes{
-			ClusterName: sa.ClusterName,
+			ClusterName: logicalcluster.From(&sa),
 			Namespace:   sa.Namespace,
 			Svcacct: ref{
 				Name: sa.Name,

--- a/pkg/serviceaccount/legacy.go
+++ b/pkg/serviceaccount/legacy.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	"gopkg.in/square/go-jose.v2/jwt"
 	"k8s.io/klog/v2"
 
@@ -38,18 +39,18 @@ func LegacyClaims(serviceAccount v1.ServiceAccount, secret v1.Secret) (*jwt.Clai
 			ServiceAccountName: serviceAccount.Name,
 			ServiceAccountUID:  string(serviceAccount.UID),
 			SecretName:         secret.Name,
-			ClusterName:        serviceAccount.ClusterName,
+			ClusterName:        logicalcluster.From(&serviceAccount),
 		}
 }
 
 const LegacyIssuer = "kubernetes/serviceaccount"
 
 type legacyPrivateClaims struct {
-	ServiceAccountName string `json:"kubernetes.io/serviceaccount/service-account.name"`
-	ServiceAccountUID  string `json:"kubernetes.io/serviceaccount/service-account.uid"`
-	SecretName         string `json:"kubernetes.io/serviceaccount/secret.name"`
-	Namespace          string `json:"kubernetes.io/serviceaccount/namespace"`
-	ClusterName        string `json:"kubernetes.io/serviceaccount/clusterName"`
+	ServiceAccountName string                        `json:"kubernetes.io/serviceaccount/service-account.name"`
+	ServiceAccountUID  string                        `json:"kubernetes.io/serviceaccount/service-account.uid"`
+	SecretName         string                        `json:"kubernetes.io/serviceaccount/secret.name"`
+	Namespace          string                        `json:"kubernetes.io/serviceaccount/namespace"`
+	ClusterName        logicalcluster.LogicalCluster `json:"kubernetes.io/serviceaccount/clusterName"`
 }
 
 func NewLegacyValidator(lookup bool, getter ServiceAccountTokenGetter) Validator {

--- a/plugin/pkg/admission/security/podsecuritypolicy/admission.go
+++ b/plugin/pkg/admission/security/podsecuritypolicy/admission.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	"k8s.io/klog/v2"
+	"github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
@@ -211,7 +212,7 @@ func (p *Plugin) computeSecurityContext(ctx context.Context, a admission.Attribu
 	klog.V(4).Infof("getting pod security policies for pod %s (generate: %s)", pod.Name, pod.GenerateName)
 	var saInfo user.Info
 	if len(pod.Spec.ServiceAccountName) > 0 {
-		saInfo = serviceaccount.UserInfo(pod.ClusterName, a.GetNamespace(), pod.Spec.ServiceAccountName, "")
+		saInfo = serviceaccount.UserInfo(logicalcluster.From(pod), a.GetNamespace(), pod.Spec.ServiceAccountName, "")
 	}
 
 	policies, err := p.lister.List(labels.Everything())

--- a/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/clientset.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/clientset.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"net/http"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	crv1 "k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/typed/cr/v1"
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
@@ -29,7 +30,7 @@ import (
 )
 
 type ClusterInterface interface {
-	Cluster(name string) Interface
+	Cluster(name logicalcluster.LogicalCluster) Interface
 }
 
 type Cluster struct {
@@ -37,7 +38,7 @@ type Cluster struct {
 }
 
 // Cluster sets the cluster for a Clientset.
-func (c *Cluster) Cluster(name string) Interface {
+func (c *Cluster) Cluster(name logicalcluster.LogicalCluster) Interface {
 	return &Clientset{
 		scopedClientset: c.scopedClientset,
 		cluster:         name,
@@ -64,7 +65,7 @@ type Interface interface {
 // version included in a Clientset.
 type Clientset struct {
 	*scopedClientset
-	cluster string
+	cluster logicalcluster.LogicalCluster
 }
 
 // scopedClientset contains the clients for groups. Each group has exactly one

--- a/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/typed/cr/v1/cr_client.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/typed/cr/v1/cr_client.go
@@ -21,6 +21,7 @@ package v1
 import (
 	"net/http"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1 "k8s.io/apiextensions-apiserver/examples/client-go/pkg/apis/cr/v1"
 	"k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/scheme"
 	rest "k8s.io/client-go/rest"
@@ -34,7 +35,7 @@ type CrV1Interface interface {
 // CrV1Client is used to interact with features provided by the cr.example.apiextensions.k8s.io group.
 type CrV1Client struct {
 	restClient rest.Interface
-	cluster    string
+	cluster    logicalcluster.LogicalCluster
 }
 
 func (c *CrV1Client) Examples(namespace string) ExampleInterface {
@@ -86,7 +87,7 @@ func New(c rest.Interface) *CrV1Client {
 }
 
 // NewWithCluster creates a new CrV1Client for the given RESTClient and cluster.
-func NewWithCluster(c rest.Interface, cluster string) *CrV1Client {
+func NewWithCluster(c rest.Interface, cluster logicalcluster.LogicalCluster) *CrV1Client {
 	return &CrV1Client{restClient: c, cluster: cluster}
 }
 

--- a/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/typed/cr/v1/example.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/typed/cr/v1/example.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1 "k8s.io/apiextensions-apiserver/examples/client-go/pkg/apis/cr/v1"
 	scheme "k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/scheme"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -52,7 +53,7 @@ type ExampleInterface interface {
 // examples implements ExampleInterface
 type examples struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 	ns      string
 }
 

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go
@@ -48,6 +48,7 @@ import (
 	"k8s.io/apiextensions-apiserver/pkg/registry/customresource"
 	"k8s.io/apiextensions-apiserver/pkg/registry/customresource/tableconvertor"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
+	"github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -562,9 +563,9 @@ func (r *crdHandler) updateCustomResourceDefinition(oldObj, newObj interface{}) 
 	if !apiextensionshelpers.IsCRDConditionTrue(newCRD, apiextensionsv1.Established) &&
 		apiextensionshelpers.IsCRDConditionTrue(newCRD, apiextensionsv1.NamesAccepted) {
 		if r.masterCount > 1 {
-			r.establishingController.QueueCRD(newCRD.Name, newCRD.GetClusterName(), 5*time.Second)
+			r.establishingController.QueueCRD(newCRD.Name, logicalcluster.From(newCRD), 5*time.Second)
 		} else {
-			r.establishingController.QueueCRD(newCRD.Name, newCRD.GetClusterName(), 0)
+			r.establishingController.QueueCRD(newCRD.Name, logicalcluster.From(newCRD), 0)
 		}
 	}
 

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/clientset.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/clientset.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"net/http"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1"
 	discovery "k8s.io/client-go/discovery"
@@ -30,7 +31,7 @@ import (
 )
 
 type ClusterInterface interface {
-	Cluster(name string) Interface
+	Cluster(name logicalcluster.LogicalCluster) Interface
 }
 
 type Cluster struct {
@@ -38,7 +39,7 @@ type Cluster struct {
 }
 
 // Cluster sets the cluster for a Clientset.
-func (c *Cluster) Cluster(name string) Interface {
+func (c *Cluster) Cluster(name logicalcluster.LogicalCluster) Interface {
 	return &Clientset{
 		scopedClientset: c.scopedClientset,
 		cluster:         name,
@@ -66,7 +67,7 @@ type Interface interface {
 // version included in a Clientset.
 type Clientset struct {
 	*scopedClientset
-	cluster string
+	cluster logicalcluster.LogicalCluster
 }
 
 // scopedClientset contains the clients for groups. Each group has exactly one

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1/apiextensions_client.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1/apiextensions_client.go
@@ -21,6 +21,7 @@ package v1
 import (
 	"net/http"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/scheme"
 	rest "k8s.io/client-go/rest"
@@ -34,7 +35,7 @@ type ApiextensionsV1Interface interface {
 // ApiextensionsV1Client is used to interact with features provided by the apiextensions.k8s.io group.
 type ApiextensionsV1Client struct {
 	restClient rest.Interface
-	cluster    string
+	cluster    logicalcluster.LogicalCluster
 }
 
 func (c *ApiextensionsV1Client) CustomResourceDefinitions() CustomResourceDefinitionInterface {
@@ -86,7 +87,7 @@ func New(c rest.Interface) *ApiextensionsV1Client {
 }
 
 // NewWithCluster creates a new ApiextensionsV1Client for the given RESTClient and cluster.
-func NewWithCluster(c rest.Interface, cluster string) *ApiextensionsV1Client {
+func NewWithCluster(c rest.Interface, cluster logicalcluster.LogicalCluster) *ApiextensionsV1Client {
 	return &ApiextensionsV1Client{restClient: c, cluster: cluster}
 }
 

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1/customresourcedefinition.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1/customresourcedefinition.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	scheme "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/scheme"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -53,7 +54,7 @@ type CustomResourceDefinitionInterface interface {
 // customResourceDefinitions implements CustomResourceDefinitionInterface
 type customResourceDefinitions struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 }
 
 // newCustomResourceDefinitions returns a CustomResourceDefinitions

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1/apiextensions_client.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1/apiextensions_client.go
@@ -21,6 +21,7 @@ package v1beta1
 import (
 	"net/http"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/scheme"
 	rest "k8s.io/client-go/rest"
@@ -34,7 +35,7 @@ type ApiextensionsV1beta1Interface interface {
 // ApiextensionsV1beta1Client is used to interact with features provided by the apiextensions.k8s.io group.
 type ApiextensionsV1beta1Client struct {
 	restClient rest.Interface
-	cluster    string
+	cluster    logicalcluster.LogicalCluster
 }
 
 func (c *ApiextensionsV1beta1Client) CustomResourceDefinitions() CustomResourceDefinitionInterface {
@@ -86,7 +87,7 @@ func New(c rest.Interface) *ApiextensionsV1beta1Client {
 }
 
 // NewWithCluster creates a new ApiextensionsV1beta1Client for the given RESTClient and cluster.
-func NewWithCluster(c rest.Interface, cluster string) *ApiextensionsV1beta1Client {
+func NewWithCluster(c rest.Interface, cluster logicalcluster.LogicalCluster) *ApiextensionsV1beta1Client {
 	return &ApiextensionsV1beta1Client{restClient: c, cluster: cluster}
 }
 

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1/customresourcedefinition.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1/customresourcedefinition.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	scheme "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/scheme"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -53,7 +54,7 @@ type CustomResourceDefinitionInterface interface {
 // customResourceDefinitions implements CustomResourceDefinitionInterface
 type customResourceDefinitions struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 }
 
 // newCustomResourceDefinitions returns a CustomResourceDefinitions

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/establish/establishing_controller.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/establish/establishing_controller.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/kcp-dev/apimachinery/pkg/logicalcluster"
+
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -65,7 +67,7 @@ func NewEstablishingController(crdInformer informers.CustomResourceDefinitionInf
 }
 
 // QueueCRD adds CRD into the establishing queue.
-func (ec *EstablishingController) QueueCRD(name, clusterName string, timeout time.Duration) {
+func (ec *EstablishingController) QueueCRD(name string, clusterName logicalcluster.LogicalCluster, timeout time.Duration) {
 	ec.queue.AddAfter(clusters.ToClusterAwareKey(clusterName, name), timeout)
 }
 

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/finalizer/crd_finalizer.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/finalizer/crd_finalizer.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"k8s.io/klog/v2"
+	"github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -191,7 +192,7 @@ func (c *CRDFinalizer) deleteInstances(crd *apiextensionsv1.CustomResourceDefini
 	}
 
 	ctx := genericapirequest.WithCluster(genericapirequest.NewContext(), genericapirequest.Cluster{
-		Name: crd.GetClusterName(),
+		Name: logicalcluster.From(crd),
 	})
 
 	allResources, err := crClient.List(ctx, nil)

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/status/naming_controller.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/status/naming_controller.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"k8s.io/klog/v2"
+	"github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -109,7 +110,7 @@ func (c *NamingConditionController) getAcceptedNamesForGroup(clusterName, group 
 		// this makes sure that if we tight loop on update and run, our mutation cache will show
 		// us the version of the objects we just updated to.
 		item := curr
-		obj, exists, err := c.crdMutationCache.GetByKey(clusters.ToClusterAwareKey(curr.GetClusterName(), curr.Name))
+		obj, exists, err := c.crdMutationCache.GetByKey(clusters.ToClusterAwareKey(logicalcluster.From(curr), curr.Name))
 		if exists && err == nil {
 			item = obj.(*apiextensionsv1.CustomResourceDefinition)
 		}
@@ -397,7 +398,7 @@ func (c *NamingConditionController) requeueAllOtherGroupCRDs(name string) error 
 	}
 
 	for _, curr := range list {
-		if curr.ClusterName != clusterName {
+		if logicalcluster.From(curr) != clusterName {
 			continue
 		}
 

--- a/staging/src/k8s.io/apiserver/pkg/authentication/serviceaccount/util.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/serviceaccount/util.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/kcp-dev/apimachinery/pkg/logicalcluster"
+
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimachineryvalidation "k8s.io/apimachinery/pkg/api/validation"
@@ -110,7 +112,7 @@ func MakeNamespaceGroupName(namespace string) string {
 }
 
 // UserInfo returns a user.Info interface for the given namespace, service account name and UID
-func UserInfo(clusterName, namespace, name, uid string) user.Info {
+func UserInfo(clusterName logicalcluster.LogicalCluster, namespace, name, uid string) user.Info {
 	return (&ServiceAccountInfo{
 		ClusterName: clusterName,
 		Name:        name,
@@ -120,7 +122,7 @@ func UserInfo(clusterName, namespace, name, uid string) user.Info {
 }
 
 type ServiceAccountInfo struct {
-	ClusterName          string
+	ClusterName          logicalcluster.LogicalCluster
 	Name, Namespace, UID string
 	PodName, PodUID      string
 }
@@ -140,7 +142,7 @@ func (sa *ServiceAccountInfo) UserInfo() user.Info {
 	if info.Extra == nil {
 		info.Extra = map[string][]string{}
 	}
-	info.Extra[ClusterNameKey] = []string{sa.ClusterName}
+	info.Extra[ClusterNameKey] = []string{sa.ClusterName.String()}
 	return info
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/request/context_cluster.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/request/context_cluster.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
+	"github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 )
 
 type clusterKey int
@@ -31,9 +33,7 @@ const (
 
 type Cluster struct {
 	// Name is the name of the cluster.
-	Name string
-	// Parents defines the parent clusters that apply to this request.
-	Parents []string
+	Name logicalcluster.LogicalCluster
 
 	// HACK: only for testing wildcard semantics
 	// If true the query applies to all clusters
@@ -70,7 +70,7 @@ func ValidClusterFrom(ctx context.Context) (*Cluster, error) {
 	if cluster == nil {
 		return nil, buildClusterError("no cluster in the request context", ctx)
 	}
-	if cluster.Name == "" && !cluster.Wildcard {
+	if cluster.Name.Empty() && !cluster.Wildcard {
 		return nil, buildClusterError("cluster name is empty in the request context", ctx)
 	}
 	return cluster, nil
@@ -79,13 +79,13 @@ func ValidClusterFrom(ctx context.Context) (*Cluster, error) {
 // ClusterNameFrom returns the cluster name from the value of the cluster
 // key on the ctx.
 // If the cluster name is empty, then return an error.
-func ClusterNameFrom(ctx context.Context) (string, error) {
+func ClusterNameFrom(ctx context.Context) (logicalcluster.LogicalCluster, error) {
 	cluster, err := ValidClusterFrom(ctx)
 	if err != nil {
-		return "", err
+		return logicalcluster.LogicalCluster{}, err
 	}
-	if cluster.Name == "" {
-		return "", buildClusterError("cluster name is empty in the request context", ctx)
+	if cluster.Name.Empty() {
+		return logicalcluster.LogicalCluster{}, buildClusterError("cluster name is empty in the request context", ctx)
 	}
 	return cluster.Name, nil
 }

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
@@ -243,7 +243,7 @@ func NoNamespaceKeyRootFunc(ctx context.Context, prefix string) string {
 	if cluster.Wildcard {
 		return key
 	}
-	return key + "/" + cluster.Name
+	return key + "/" + cluster.Name.String()
 }
 
 // NamespaceKeyRootFunc is the default function for constructing storage paths

--- a/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
@@ -56,6 +56,7 @@ import (
 	openapiproto "k8s.io/kube-openapi/pkg/util/proto"
 	"k8s.io/kube-openapi/pkg/validation/spec"
 	"k8s.io/utils/clock"
+	"github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 )
 
 // Info about an API group.
@@ -250,7 +251,7 @@ type DelegationTarget interface {
 	HealthzChecks() []healthz.HealthChecker
 
 	// ListedPaths returns the paths for supporting an index
-	ListedPaths(clusterName string) []string
+	ListedPaths(clusterName logicalcluster.LogicalCluster) []string
 
 	// NextDelegate returns the next delegationTarget in the chain of delegations
 	NextDelegate() DelegationTarget
@@ -275,7 +276,7 @@ func (s *GenericAPIServer) PreShutdownHooks() map[string]preShutdownHookEntry {
 func (s *GenericAPIServer) HealthzChecks() []healthz.HealthChecker {
 	return s.healthzChecks
 }
-func (s *GenericAPIServer) ListedPaths(clusterName string) []string {
+func (s *GenericAPIServer) ListedPaths(clusterName logicalcluster.LogicalCluster) []string {
 	return s.listedPathProvider.ListedPaths(clusterName)
 }
 
@@ -324,7 +325,7 @@ func (s emptyDelegate) PreShutdownHooks() map[string]preShutdownHookEntry {
 func (s emptyDelegate) HealthzChecks() []healthz.HealthChecker {
 	return []healthz.HealthChecker{}
 }
-func (s emptyDelegate) ListedPaths(clusterName string) []string {
+func (s emptyDelegate) ListedPaths(clusterName logicalcluster.LogicalCluster) []string {
 	return []string{}
 }
 func (s emptyDelegate) NextDelegate() DelegationTarget {

--- a/staging/src/k8s.io/apiserver/pkg/server/mux/pathrecorder.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/mux/pathrecorder.go
@@ -29,6 +29,7 @@ import (
 
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 )
 
 // PathRecorderMux wraps a mux object and records the registered exposedPaths.
@@ -95,7 +96,7 @@ func NewPathRecorderMux(name string) *PathRecorderMux {
 }
 
 // ListedPaths returns the registered handler exposedPaths.
-func (m *PathRecorderMux) ListedPaths(clusterName string) []string {
+func (m *PathRecorderMux) ListedPaths(clusterName logicalcluster.LogicalCluster) []string {
 	handledPaths := append([]string{}, m.exposedPaths...)
 	sort.Strings(handledPaths)
 

--- a/staging/src/k8s.io/apiserver/pkg/server/routes/index.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/routes/index.go
@@ -19,8 +19,11 @@ package routes
 import (
 	"net/http"
 
+	"github.com/kcp-dev/apimachinery/pkg/logicalcluster"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
+
 	"k8s.io/apiserver/pkg/endpoints/handlers/responsewriters"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/server/mux"
@@ -29,14 +32,14 @@ import (
 // ListedPathProvider is an interface for providing paths that should be reported at /.
 type ListedPathProvider interface {
 	// ListedPaths is an alphabetically sorted list of paths to be reported at /.
-	ListedPaths(clusterName string) []string
+	ListedPaths(clusterName logicalcluster.LogicalCluster) []string
 }
 
 // ListedPathProviders is a convenient way to combine multiple ListedPathProviders
 type ListedPathProviders []ListedPathProvider
 
 // ListedPaths unions and sorts the included paths.
-func (p ListedPathProviders) ListedPaths(clusterName string) []string {
+func (p ListedPathProviders) ListedPaths(clusterName logicalcluster.LogicalCluster) []string {
 	ret := sets.String{}
 	for _, provider := range p {
 		for _, path := range provider.ListedPaths(clusterName) {

--- a/staging/src/k8s.io/client-go/discovery/discovery_client.go
+++ b/staging/src/k8s.io/client-go/discovery/discovery_client.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	gopath "path"
 	"sort"
 	"strings"
 	"sync"
@@ -30,6 +31,8 @@ import (
 	//nolint:staticcheck // SA1019 Keep using module since it's still being maintained and the api of google.golang.org/protobuf/proto differs
 	"github.com/golang/protobuf/proto"
 	openapi_v2 "github.com/googleapis/gnostic/openapiv2"
+
+	"github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -132,10 +135,10 @@ type OpenAPISchemaInterface interface {
 // versions and resources.
 type DiscoveryClient struct {
 	*scopedClient
-	cluster string
+	cluster logicalcluster.LogicalCluster
 }
 
-func (d *DiscoveryClient) WithCluster(cluster string) DiscoveryInterface {
+func (d *DiscoveryClient) WithCluster(cluster logicalcluster.LogicalCluster) DiscoveryInterface {
 	return &DiscoveryClient{
 		scopedClient: d.scopedClient,
 		cluster:      cluster,
@@ -419,10 +422,10 @@ func ServerPreferredNamespacedResources(d DiscoveryInterface) ([]*metav1.APIReso
 }
 
 func (d *DiscoveryClient) clusterAwarePath(path string) string {
-	if d.cluster == "" {
+	if d.cluster.Empty() {
 		return path
 	}
-	return "/clusters/" + d.cluster + path
+	return gopath.Join(d.cluster.Path(), path)
 }
 
 // ServerVersion retrieves and parses the server's version (git version).

--- a/staging/src/k8s.io/client-go/dynamic/simple.go
+++ b/staging/src/k8s.io/client-go/dynamic/simple.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/kcp-dev/apimachinery/pkg/logicalcluster"
+
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -28,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
+
 	"k8s.io/client-go/rest"
 )
 
@@ -43,7 +46,7 @@ func NewClusterForConfig(c *rest.Config) (*Cluster, error) {
 }
 
 type ClusterInterface interface {
-	Cluster(name string) Interface
+	Cluster(name logicalcluster.LogicalCluster) Interface
 }
 
 type Cluster struct {
@@ -51,7 +54,7 @@ type Cluster struct {
 }
 
 // Cluster sets the cluster for a Clientset.
-func (c *Cluster) Cluster(name string) Interface {
+func (c *Cluster) Cluster(name logicalcluster.LogicalCluster) Interface {
 	return &DynamicClient{
 		scopedClient: c.scopedClient,
 		cluster:      name,
@@ -60,7 +63,7 @@ func (c *Cluster) Cluster(name string) Interface {
 
 type DynamicClient struct {
 	*scopedClient
-	cluster string
+	cluster logicalcluster.LogicalCluster
 }
 
 type scopedClient struct {

--- a/staging/src/k8s.io/client-go/kubernetes/clientset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/clientset.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"net/http"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	discovery "k8s.io/client-go/discovery"
 	admissionregistrationv1 "k8s.io/client-go/kubernetes/typed/admissionregistration/v1"
 	admissionregistrationv1beta1 "k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1"
@@ -73,7 +74,7 @@ import (
 )
 
 type ClusterInterface interface {
-	Cluster(name string) Interface
+	Cluster(name logicalcluster.LogicalCluster) Interface
 }
 
 type Cluster struct {
@@ -81,7 +82,7 @@ type Cluster struct {
 }
 
 // Cluster sets the cluster for a Clientset.
-func (c *Cluster) Cluster(name string) Interface {
+func (c *Cluster) Cluster(name logicalcluster.LogicalCluster) Interface {
 	return &Clientset{
 		scopedClientset: c.scopedClientset,
 		cluster:         name,
@@ -152,7 +153,7 @@ type Interface interface {
 // version included in a Clientset.
 type Clientset struct {
 	*scopedClientset
-	cluster string
+	cluster logicalcluster.LogicalCluster
 }
 
 // scopedClientset contains the clients for groups. Each group has exactly one

--- a/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1/admissionregistration_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1/admissionregistration_client.go
@@ -21,6 +21,7 @@ package v1
 import (
 	"net/http"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1 "k8s.io/api/admissionregistration/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
@@ -35,7 +36,7 @@ type AdmissionregistrationV1Interface interface {
 // AdmissionregistrationV1Client is used to interact with features provided by the admissionregistration.k8s.io group.
 type AdmissionregistrationV1Client struct {
 	restClient rest.Interface
-	cluster    string
+	cluster    logicalcluster.LogicalCluster
 }
 
 func (c *AdmissionregistrationV1Client) MutatingWebhookConfigurations() MutatingWebhookConfigurationInterface {
@@ -91,7 +92,7 @@ func New(c rest.Interface) *AdmissionregistrationV1Client {
 }
 
 // NewWithCluster creates a new AdmissionregistrationV1Client for the given RESTClient and cluster.
-func NewWithCluster(c rest.Interface, cluster string) *AdmissionregistrationV1Client {
+func NewWithCluster(c rest.Interface, cluster logicalcluster.LogicalCluster) *AdmissionregistrationV1Client {
 	return &AdmissionregistrationV1Client{restClient: c, cluster: cluster}
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1/mutatingwebhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1/mutatingwebhookconfiguration.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1 "k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -56,7 +57,7 @@ type MutatingWebhookConfigurationInterface interface {
 // mutatingWebhookConfigurations implements MutatingWebhookConfigurationInterface
 type mutatingWebhookConfigurations struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 }
 
 // newMutatingWebhookConfigurations returns a MutatingWebhookConfigurations

--- a/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1/validatingwebhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1/validatingwebhookconfiguration.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1 "k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -56,7 +57,7 @@ type ValidatingWebhookConfigurationInterface interface {
 // validatingWebhookConfigurations implements ValidatingWebhookConfigurationInterface
 type validatingWebhookConfigurations struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 }
 
 // newValidatingWebhookConfigurations returns a ValidatingWebhookConfigurations

--- a/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/admissionregistration_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/admissionregistration_client.go
@@ -21,6 +21,7 @@ package v1beta1
 import (
 	"net/http"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
@@ -35,7 +36,7 @@ type AdmissionregistrationV1beta1Interface interface {
 // AdmissionregistrationV1beta1Client is used to interact with features provided by the admissionregistration.k8s.io group.
 type AdmissionregistrationV1beta1Client struct {
 	restClient rest.Interface
-	cluster    string
+	cluster    logicalcluster.LogicalCluster
 }
 
 func (c *AdmissionregistrationV1beta1Client) MutatingWebhookConfigurations() MutatingWebhookConfigurationInterface {
@@ -91,7 +92,7 @@ func New(c rest.Interface) *AdmissionregistrationV1beta1Client {
 }
 
 // NewWithCluster creates a new AdmissionregistrationV1beta1Client for the given RESTClient and cluster.
-func NewWithCluster(c rest.Interface, cluster string) *AdmissionregistrationV1beta1Client {
+func NewWithCluster(c rest.Interface, cluster logicalcluster.LogicalCluster) *AdmissionregistrationV1beta1Client {
 	return &AdmissionregistrationV1beta1Client{restClient: c, cluster: cluster}
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/mutatingwebhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/mutatingwebhookconfiguration.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -56,7 +57,7 @@ type MutatingWebhookConfigurationInterface interface {
 // mutatingWebhookConfigurations implements MutatingWebhookConfigurationInterface
 type mutatingWebhookConfigurations struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 }
 
 // newMutatingWebhookConfigurations returns a MutatingWebhookConfigurations

--- a/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/validatingwebhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/validatingwebhookconfiguration.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -56,7 +57,7 @@ type ValidatingWebhookConfigurationInterface interface {
 // validatingWebhookConfigurations implements ValidatingWebhookConfigurationInterface
 type validatingWebhookConfigurations struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 }
 
 // newValidatingWebhookConfigurations returns a ValidatingWebhookConfigurations

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apiserverinternal/v1alpha1/apiserverinternal_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apiserverinternal/v1alpha1/apiserverinternal_client.go
@@ -21,6 +21,7 @@ package v1alpha1
 import (
 	"net/http"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1alpha1 "k8s.io/api/apiserverinternal/v1alpha1"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
@@ -34,7 +35,7 @@ type InternalV1alpha1Interface interface {
 // InternalV1alpha1Client is used to interact with features provided by the internal.apiserver.k8s.io group.
 type InternalV1alpha1Client struct {
 	restClient rest.Interface
-	cluster    string
+	cluster    logicalcluster.LogicalCluster
 }
 
 func (c *InternalV1alpha1Client) StorageVersions() StorageVersionInterface {
@@ -86,7 +87,7 @@ func New(c rest.Interface) *InternalV1alpha1Client {
 }
 
 // NewWithCluster creates a new InternalV1alpha1Client for the given RESTClient and cluster.
-func NewWithCluster(c rest.Interface, cluster string) *InternalV1alpha1Client {
+func NewWithCluster(c rest.Interface, cluster logicalcluster.LogicalCluster) *InternalV1alpha1Client {
 	return &InternalV1alpha1Client{restClient: c, cluster: cluster}
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apiserverinternal/v1alpha1/storageversion.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apiserverinternal/v1alpha1/storageversion.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1alpha1 "k8s.io/api/apiserverinternal/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -58,7 +59,7 @@ type StorageVersionInterface interface {
 // storageVersions implements StorageVersionInterface
 type storageVersions struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 }
 
 // newStorageVersions returns a StorageVersions

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/apps_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/apps_client.go
@@ -21,6 +21,7 @@ package v1
 import (
 	"net/http"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1 "k8s.io/api/apps/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
@@ -38,7 +39,7 @@ type AppsV1Interface interface {
 // AppsV1Client is used to interact with features provided by the apps group.
 type AppsV1Client struct {
 	restClient rest.Interface
-	cluster    string
+	cluster    logicalcluster.LogicalCluster
 }
 
 func (c *AppsV1Client) ControllerRevisions(namespace string) ControllerRevisionInterface {
@@ -106,7 +107,7 @@ func New(c rest.Interface) *AppsV1Client {
 }
 
 // NewWithCluster creates a new AppsV1Client for the given RESTClient and cluster.
-func NewWithCluster(c rest.Interface, cluster string) *AppsV1Client {
+func NewWithCluster(c rest.Interface, cluster logicalcluster.LogicalCluster) *AppsV1Client {
 	return &AppsV1Client{restClient: c, cluster: cluster}
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/controllerrevision.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/controllerrevision.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -56,7 +57,7 @@ type ControllerRevisionInterface interface {
 // controllerRevisions implements ControllerRevisionInterface
 type controllerRevisions struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 	ns      string
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/daemonset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/daemonset.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -58,7 +59,7 @@ type DaemonSetInterface interface {
 // daemonSets implements DaemonSetInterface
 type daemonSets struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 	ns      string
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/deployment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/deployment.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1 "k8s.io/api/apps/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -64,7 +65,7 @@ type DeploymentInterface interface {
 // deployments implements DeploymentInterface
 type deployments struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 	ns      string
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/replicaset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/replicaset.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1 "k8s.io/api/apps/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -64,7 +65,7 @@ type ReplicaSetInterface interface {
 // replicaSets implements ReplicaSetInterface
 type replicaSets struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 	ns      string
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/statefulset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/statefulset.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1 "k8s.io/api/apps/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -64,7 +65,7 @@ type StatefulSetInterface interface {
 // statefulSets implements StatefulSetInterface
 type statefulSets struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 	ns      string
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/apps_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/apps_client.go
@@ -21,6 +21,7 @@ package v1beta1
 import (
 	"net/http"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1beta1 "k8s.io/api/apps/v1beta1"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
@@ -36,7 +37,7 @@ type AppsV1beta1Interface interface {
 // AppsV1beta1Client is used to interact with features provided by the apps group.
 type AppsV1beta1Client struct {
 	restClient rest.Interface
-	cluster    string
+	cluster    logicalcluster.LogicalCluster
 }
 
 func (c *AppsV1beta1Client) ControllerRevisions(namespace string) ControllerRevisionInterface {
@@ -96,7 +97,7 @@ func New(c rest.Interface) *AppsV1beta1Client {
 }
 
 // NewWithCluster creates a new AppsV1beta1Client for the given RESTClient and cluster.
-func NewWithCluster(c rest.Interface, cluster string) *AppsV1beta1Client {
+func NewWithCluster(c rest.Interface, cluster logicalcluster.LogicalCluster) *AppsV1beta1Client {
 	return &AppsV1beta1Client{restClient: c, cluster: cluster}
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/controllerrevision.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/controllerrevision.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1beta1 "k8s.io/api/apps/v1beta1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -56,7 +57,7 @@ type ControllerRevisionInterface interface {
 // controllerRevisions implements ControllerRevisionInterface
 type controllerRevisions struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 	ns      string
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/deployment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/deployment.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1beta1 "k8s.io/api/apps/v1beta1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -58,7 +59,7 @@ type DeploymentInterface interface {
 // deployments implements DeploymentInterface
 type deployments struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 	ns      string
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/statefulset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/statefulset.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1beta1 "k8s.io/api/apps/v1beta1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -58,7 +59,7 @@ type StatefulSetInterface interface {
 // statefulSets implements StatefulSetInterface
 type statefulSets struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 	ns      string
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/apps_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/apps_client.go
@@ -21,6 +21,7 @@ package v1beta2
 import (
 	"net/http"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1beta2 "k8s.io/api/apps/v1beta2"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
@@ -38,7 +39,7 @@ type AppsV1beta2Interface interface {
 // AppsV1beta2Client is used to interact with features provided by the apps group.
 type AppsV1beta2Client struct {
 	restClient rest.Interface
-	cluster    string
+	cluster    logicalcluster.LogicalCluster
 }
 
 func (c *AppsV1beta2Client) ControllerRevisions(namespace string) ControllerRevisionInterface {
@@ -106,7 +107,7 @@ func New(c rest.Interface) *AppsV1beta2Client {
 }
 
 // NewWithCluster creates a new AppsV1beta2Client for the given RESTClient and cluster.
-func NewWithCluster(c rest.Interface, cluster string) *AppsV1beta2Client {
+func NewWithCluster(c rest.Interface, cluster logicalcluster.LogicalCluster) *AppsV1beta2Client {
 	return &AppsV1beta2Client{restClient: c, cluster: cluster}
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/controllerrevision.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/controllerrevision.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1beta2 "k8s.io/api/apps/v1beta2"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -56,7 +57,7 @@ type ControllerRevisionInterface interface {
 // controllerRevisions implements ControllerRevisionInterface
 type controllerRevisions struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 	ns      string
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/daemonset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/daemonset.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1beta2 "k8s.io/api/apps/v1beta2"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -58,7 +59,7 @@ type DaemonSetInterface interface {
 // daemonSets implements DaemonSetInterface
 type daemonSets struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 	ns      string
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/deployment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/deployment.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1beta2 "k8s.io/api/apps/v1beta2"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -58,7 +59,7 @@ type DeploymentInterface interface {
 // deployments implements DeploymentInterface
 type deployments struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 	ns      string
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/replicaset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/replicaset.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1beta2 "k8s.io/api/apps/v1beta2"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -58,7 +59,7 @@ type ReplicaSetInterface interface {
 // replicaSets implements ReplicaSetInterface
 type replicaSets struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 	ns      string
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/statefulset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/statefulset.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1beta2 "k8s.io/api/apps/v1beta2"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -62,7 +63,7 @@ type StatefulSetInterface interface {
 // statefulSets implements StatefulSetInterface
 type statefulSets struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 	ns      string
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/authentication/v1/authentication_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/authentication/v1/authentication_client.go
@@ -21,6 +21,7 @@ package v1
 import (
 	"net/http"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1 "k8s.io/api/authentication/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
@@ -34,7 +35,7 @@ type AuthenticationV1Interface interface {
 // AuthenticationV1Client is used to interact with features provided by the authentication.k8s.io group.
 type AuthenticationV1Client struct {
 	restClient rest.Interface
-	cluster    string
+	cluster    logicalcluster.LogicalCluster
 }
 
 func (c *AuthenticationV1Client) TokenReviews() TokenReviewInterface {
@@ -86,7 +87,7 @@ func New(c rest.Interface) *AuthenticationV1Client {
 }
 
 // NewWithCluster creates a new AuthenticationV1Client for the given RESTClient and cluster.
-func NewWithCluster(c rest.Interface, cluster string) *AuthenticationV1Client {
+func NewWithCluster(c rest.Interface, cluster logicalcluster.LogicalCluster) *AuthenticationV1Client {
 	return &AuthenticationV1Client{restClient: c, cluster: cluster}
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/authentication/v1/tokenreview.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/authentication/v1/tokenreview.go
@@ -21,6 +21,7 @@ package v1
 import (
 	"context"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1 "k8s.io/api/authentication/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	scheme "k8s.io/client-go/kubernetes/scheme"
@@ -42,7 +43,7 @@ type TokenReviewInterface interface {
 // tokenReviews implements TokenReviewInterface
 type tokenReviews struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 }
 
 // newTokenReviews returns a TokenReviews

--- a/staging/src/k8s.io/client-go/kubernetes/typed/authentication/v1beta1/authentication_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/authentication/v1beta1/authentication_client.go
@@ -21,6 +21,7 @@ package v1beta1
 import (
 	"net/http"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1beta1 "k8s.io/api/authentication/v1beta1"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
@@ -34,7 +35,7 @@ type AuthenticationV1beta1Interface interface {
 // AuthenticationV1beta1Client is used to interact with features provided by the authentication.k8s.io group.
 type AuthenticationV1beta1Client struct {
 	restClient rest.Interface
-	cluster    string
+	cluster    logicalcluster.LogicalCluster
 }
 
 func (c *AuthenticationV1beta1Client) TokenReviews() TokenReviewInterface {
@@ -86,7 +87,7 @@ func New(c rest.Interface) *AuthenticationV1beta1Client {
 }
 
 // NewWithCluster creates a new AuthenticationV1beta1Client for the given RESTClient and cluster.
-func NewWithCluster(c rest.Interface, cluster string) *AuthenticationV1beta1Client {
+func NewWithCluster(c rest.Interface, cluster logicalcluster.LogicalCluster) *AuthenticationV1beta1Client {
 	return &AuthenticationV1beta1Client{restClient: c, cluster: cluster}
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/authentication/v1beta1/tokenreview.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/authentication/v1beta1/tokenreview.go
@@ -21,6 +21,7 @@ package v1beta1
 import (
 	"context"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1beta1 "k8s.io/api/authentication/v1beta1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	scheme "k8s.io/client-go/kubernetes/scheme"
@@ -42,7 +43,7 @@ type TokenReviewInterface interface {
 // tokenReviews implements TokenReviewInterface
 type tokenReviews struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 }
 
 // newTokenReviews returns a TokenReviews

--- a/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1/authorization_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1/authorization_client.go
@@ -21,6 +21,7 @@ package v1
 import (
 	"net/http"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1 "k8s.io/api/authorization/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
@@ -37,7 +38,7 @@ type AuthorizationV1Interface interface {
 // AuthorizationV1Client is used to interact with features provided by the authorization.k8s.io group.
 type AuthorizationV1Client struct {
 	restClient rest.Interface
-	cluster    string
+	cluster    logicalcluster.LogicalCluster
 }
 
 func (c *AuthorizationV1Client) LocalSubjectAccessReviews(namespace string) LocalSubjectAccessReviewInterface {
@@ -101,7 +102,7 @@ func New(c rest.Interface) *AuthorizationV1Client {
 }
 
 // NewWithCluster creates a new AuthorizationV1Client for the given RESTClient and cluster.
-func NewWithCluster(c rest.Interface, cluster string) *AuthorizationV1Client {
+func NewWithCluster(c rest.Interface, cluster logicalcluster.LogicalCluster) *AuthorizationV1Client {
 	return &AuthorizationV1Client{restClient: c, cluster: cluster}
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1/localsubjectaccessreview.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1/localsubjectaccessreview.go
@@ -21,6 +21,7 @@ package v1
 import (
 	"context"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1 "k8s.io/api/authorization/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	scheme "k8s.io/client-go/kubernetes/scheme"
@@ -42,7 +43,7 @@ type LocalSubjectAccessReviewInterface interface {
 // localSubjectAccessReviews implements LocalSubjectAccessReviewInterface
 type localSubjectAccessReviews struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 	ns      string
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1/selfsubjectaccessreview.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1/selfsubjectaccessreview.go
@@ -21,6 +21,7 @@ package v1
 import (
 	"context"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1 "k8s.io/api/authorization/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	scheme "k8s.io/client-go/kubernetes/scheme"
@@ -42,7 +43,7 @@ type SelfSubjectAccessReviewInterface interface {
 // selfSubjectAccessReviews implements SelfSubjectAccessReviewInterface
 type selfSubjectAccessReviews struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 }
 
 // newSelfSubjectAccessReviews returns a SelfSubjectAccessReviews

--- a/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1/selfsubjectrulesreview.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1/selfsubjectrulesreview.go
@@ -21,6 +21,7 @@ package v1
 import (
 	"context"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1 "k8s.io/api/authorization/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	scheme "k8s.io/client-go/kubernetes/scheme"
@@ -42,7 +43,7 @@ type SelfSubjectRulesReviewInterface interface {
 // selfSubjectRulesReviews implements SelfSubjectRulesReviewInterface
 type selfSubjectRulesReviews struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 }
 
 // newSelfSubjectRulesReviews returns a SelfSubjectRulesReviews

--- a/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1/subjectaccessreview.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1/subjectaccessreview.go
@@ -21,6 +21,7 @@ package v1
 import (
 	"context"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1 "k8s.io/api/authorization/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	scheme "k8s.io/client-go/kubernetes/scheme"
@@ -42,7 +43,7 @@ type SubjectAccessReviewInterface interface {
 // subjectAccessReviews implements SubjectAccessReviewInterface
 type subjectAccessReviews struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 }
 
 // newSubjectAccessReviews returns a SubjectAccessReviews

--- a/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1beta1/authorization_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1beta1/authorization_client.go
@@ -21,6 +21,7 @@ package v1beta1
 import (
 	"net/http"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1beta1 "k8s.io/api/authorization/v1beta1"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
@@ -37,7 +38,7 @@ type AuthorizationV1beta1Interface interface {
 // AuthorizationV1beta1Client is used to interact with features provided by the authorization.k8s.io group.
 type AuthorizationV1beta1Client struct {
 	restClient rest.Interface
-	cluster    string
+	cluster    logicalcluster.LogicalCluster
 }
 
 func (c *AuthorizationV1beta1Client) LocalSubjectAccessReviews(namespace string) LocalSubjectAccessReviewInterface {
@@ -101,7 +102,7 @@ func New(c rest.Interface) *AuthorizationV1beta1Client {
 }
 
 // NewWithCluster creates a new AuthorizationV1beta1Client for the given RESTClient and cluster.
-func NewWithCluster(c rest.Interface, cluster string) *AuthorizationV1beta1Client {
+func NewWithCluster(c rest.Interface, cluster logicalcluster.LogicalCluster) *AuthorizationV1beta1Client {
 	return &AuthorizationV1beta1Client{restClient: c, cluster: cluster}
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1beta1/localsubjectaccessreview.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1beta1/localsubjectaccessreview.go
@@ -21,6 +21,7 @@ package v1beta1
 import (
 	"context"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1beta1 "k8s.io/api/authorization/v1beta1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	scheme "k8s.io/client-go/kubernetes/scheme"
@@ -42,7 +43,7 @@ type LocalSubjectAccessReviewInterface interface {
 // localSubjectAccessReviews implements LocalSubjectAccessReviewInterface
 type localSubjectAccessReviews struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 	ns      string
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1beta1/selfsubjectaccessreview.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1beta1/selfsubjectaccessreview.go
@@ -21,6 +21,7 @@ package v1beta1
 import (
 	"context"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1beta1 "k8s.io/api/authorization/v1beta1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	scheme "k8s.io/client-go/kubernetes/scheme"
@@ -42,7 +43,7 @@ type SelfSubjectAccessReviewInterface interface {
 // selfSubjectAccessReviews implements SelfSubjectAccessReviewInterface
 type selfSubjectAccessReviews struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 }
 
 // newSelfSubjectAccessReviews returns a SelfSubjectAccessReviews

--- a/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1beta1/selfsubjectrulesreview.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1beta1/selfsubjectrulesreview.go
@@ -21,6 +21,7 @@ package v1beta1
 import (
 	"context"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1beta1 "k8s.io/api/authorization/v1beta1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	scheme "k8s.io/client-go/kubernetes/scheme"
@@ -42,7 +43,7 @@ type SelfSubjectRulesReviewInterface interface {
 // selfSubjectRulesReviews implements SelfSubjectRulesReviewInterface
 type selfSubjectRulesReviews struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 }
 
 // newSelfSubjectRulesReviews returns a SelfSubjectRulesReviews

--- a/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1beta1/subjectaccessreview.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1beta1/subjectaccessreview.go
@@ -21,6 +21,7 @@ package v1beta1
 import (
 	"context"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1beta1 "k8s.io/api/authorization/v1beta1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	scheme "k8s.io/client-go/kubernetes/scheme"
@@ -42,7 +43,7 @@ type SubjectAccessReviewInterface interface {
 // subjectAccessReviews implements SubjectAccessReviewInterface
 type subjectAccessReviews struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 }
 
 // newSubjectAccessReviews returns a SubjectAccessReviews

--- a/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v1/autoscaling_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v1/autoscaling_client.go
@@ -21,6 +21,7 @@ package v1
 import (
 	"net/http"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1 "k8s.io/api/autoscaling/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
@@ -34,7 +35,7 @@ type AutoscalingV1Interface interface {
 // AutoscalingV1Client is used to interact with features provided by the autoscaling group.
 type AutoscalingV1Client struct {
 	restClient rest.Interface
-	cluster    string
+	cluster    logicalcluster.LogicalCluster
 }
 
 func (c *AutoscalingV1Client) HorizontalPodAutoscalers(namespace string) HorizontalPodAutoscalerInterface {
@@ -86,7 +87,7 @@ func New(c rest.Interface) *AutoscalingV1Client {
 }
 
 // NewWithCluster creates a new AutoscalingV1Client for the given RESTClient and cluster.
-func NewWithCluster(c rest.Interface, cluster string) *AutoscalingV1Client {
+func NewWithCluster(c rest.Interface, cluster logicalcluster.LogicalCluster) *AutoscalingV1Client {
 	return &AutoscalingV1Client{restClient: c, cluster: cluster}
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v1/horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v1/horizontalpodautoscaler.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1 "k8s.io/api/autoscaling/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -58,7 +59,7 @@ type HorizontalPodAutoscalerInterface interface {
 // horizontalPodAutoscalers implements HorizontalPodAutoscalerInterface
 type horizontalPodAutoscalers struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 	ns      string
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2/autoscaling_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2/autoscaling_client.go
@@ -21,6 +21,7 @@ package v2
 import (
 	"net/http"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
@@ -34,7 +35,7 @@ type AutoscalingV2Interface interface {
 // AutoscalingV2Client is used to interact with features provided by the autoscaling group.
 type AutoscalingV2Client struct {
 	restClient rest.Interface
-	cluster    string
+	cluster    logicalcluster.LogicalCluster
 }
 
 func (c *AutoscalingV2Client) HorizontalPodAutoscalers(namespace string) HorizontalPodAutoscalerInterface {
@@ -86,7 +87,7 @@ func New(c rest.Interface) *AutoscalingV2Client {
 }
 
 // NewWithCluster creates a new AutoscalingV2Client for the given RESTClient and cluster.
-func NewWithCluster(c rest.Interface, cluster string) *AutoscalingV2Client {
+func NewWithCluster(c rest.Interface, cluster logicalcluster.LogicalCluster) *AutoscalingV2Client {
 	return &AutoscalingV2Client{restClient: c, cluster: cluster}
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2/horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2/horizontalpodautoscaler.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v2 "k8s.io/api/autoscaling/v2"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -58,7 +59,7 @@ type HorizontalPodAutoscalerInterface interface {
 // horizontalPodAutoscalers implements HorizontalPodAutoscalerInterface
 type horizontalPodAutoscalers struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 	ns      string
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta1/autoscaling_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta1/autoscaling_client.go
@@ -21,6 +21,7 @@ package v2beta1
 import (
 	"net/http"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v2beta1 "k8s.io/api/autoscaling/v2beta1"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
@@ -34,7 +35,7 @@ type AutoscalingV2beta1Interface interface {
 // AutoscalingV2beta1Client is used to interact with features provided by the autoscaling group.
 type AutoscalingV2beta1Client struct {
 	restClient rest.Interface
-	cluster    string
+	cluster    logicalcluster.LogicalCluster
 }
 
 func (c *AutoscalingV2beta1Client) HorizontalPodAutoscalers(namespace string) HorizontalPodAutoscalerInterface {
@@ -86,7 +87,7 @@ func New(c rest.Interface) *AutoscalingV2beta1Client {
 }
 
 // NewWithCluster creates a new AutoscalingV2beta1Client for the given RESTClient and cluster.
-func NewWithCluster(c rest.Interface, cluster string) *AutoscalingV2beta1Client {
+func NewWithCluster(c rest.Interface, cluster logicalcluster.LogicalCluster) *AutoscalingV2beta1Client {
 	return &AutoscalingV2beta1Client{restClient: c, cluster: cluster}
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta1/horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta1/horizontalpodautoscaler.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v2beta1 "k8s.io/api/autoscaling/v2beta1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -58,7 +59,7 @@ type HorizontalPodAutoscalerInterface interface {
 // horizontalPodAutoscalers implements HorizontalPodAutoscalerInterface
 type horizontalPodAutoscalers struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 	ns      string
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta2/autoscaling_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta2/autoscaling_client.go
@@ -21,6 +21,7 @@ package v2beta2
 import (
 	"net/http"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v2beta2 "k8s.io/api/autoscaling/v2beta2"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
@@ -34,7 +35,7 @@ type AutoscalingV2beta2Interface interface {
 // AutoscalingV2beta2Client is used to interact with features provided by the autoscaling group.
 type AutoscalingV2beta2Client struct {
 	restClient rest.Interface
-	cluster    string
+	cluster    logicalcluster.LogicalCluster
 }
 
 func (c *AutoscalingV2beta2Client) HorizontalPodAutoscalers(namespace string) HorizontalPodAutoscalerInterface {
@@ -86,7 +87,7 @@ func New(c rest.Interface) *AutoscalingV2beta2Client {
 }
 
 // NewWithCluster creates a new AutoscalingV2beta2Client for the given RESTClient and cluster.
-func NewWithCluster(c rest.Interface, cluster string) *AutoscalingV2beta2Client {
+func NewWithCluster(c rest.Interface, cluster logicalcluster.LogicalCluster) *AutoscalingV2beta2Client {
 	return &AutoscalingV2beta2Client{restClient: c, cluster: cluster}
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta2/horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta2/horizontalpodautoscaler.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v2beta2 "k8s.io/api/autoscaling/v2beta2"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -58,7 +59,7 @@ type HorizontalPodAutoscalerInterface interface {
 // horizontalPodAutoscalers implements HorizontalPodAutoscalerInterface
 type horizontalPodAutoscalers struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 	ns      string
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1/batch_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1/batch_client.go
@@ -21,6 +21,7 @@ package v1
 import (
 	"net/http"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1 "k8s.io/api/batch/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
@@ -35,7 +36,7 @@ type BatchV1Interface interface {
 // BatchV1Client is used to interact with features provided by the batch group.
 type BatchV1Client struct {
 	restClient rest.Interface
-	cluster    string
+	cluster    logicalcluster.LogicalCluster
 }
 
 func (c *BatchV1Client) CronJobs(namespace string) CronJobInterface {
@@ -91,7 +92,7 @@ func New(c rest.Interface) *BatchV1Client {
 }
 
 // NewWithCluster creates a new BatchV1Client for the given RESTClient and cluster.
-func NewWithCluster(c rest.Interface, cluster string) *BatchV1Client {
+func NewWithCluster(c rest.Interface, cluster logicalcluster.LogicalCluster) *BatchV1Client {
 	return &BatchV1Client{restClient: c, cluster: cluster}
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1/cronjob.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1/cronjob.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1 "k8s.io/api/batch/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -58,7 +59,7 @@ type CronJobInterface interface {
 // cronJobs implements CronJobInterface
 type cronJobs struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 	ns      string
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1/job.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1/job.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1 "k8s.io/api/batch/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -58,7 +59,7 @@ type JobInterface interface {
 // jobs implements JobInterface
 type jobs struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 	ns      string
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1beta1/batch_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1beta1/batch_client.go
@@ -21,6 +21,7 @@ package v1beta1
 import (
 	"net/http"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1beta1 "k8s.io/api/batch/v1beta1"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
@@ -34,7 +35,7 @@ type BatchV1beta1Interface interface {
 // BatchV1beta1Client is used to interact with features provided by the batch group.
 type BatchV1beta1Client struct {
 	restClient rest.Interface
-	cluster    string
+	cluster    logicalcluster.LogicalCluster
 }
 
 func (c *BatchV1beta1Client) CronJobs(namespace string) CronJobInterface {
@@ -86,7 +87,7 @@ func New(c rest.Interface) *BatchV1beta1Client {
 }
 
 // NewWithCluster creates a new BatchV1beta1Client for the given RESTClient and cluster.
-func NewWithCluster(c rest.Interface, cluster string) *BatchV1beta1Client {
+func NewWithCluster(c rest.Interface, cluster logicalcluster.LogicalCluster) *BatchV1beta1Client {
 	return &BatchV1beta1Client{restClient: c, cluster: cluster}
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1beta1/cronjob.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1beta1/cronjob.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1beta1 "k8s.io/api/batch/v1beta1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -58,7 +59,7 @@ type CronJobInterface interface {
 // cronJobs implements CronJobInterface
 type cronJobs struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 	ns      string
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1/certificates_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1/certificates_client.go
@@ -21,6 +21,7 @@ package v1
 import (
 	"net/http"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1 "k8s.io/api/certificates/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
@@ -34,7 +35,7 @@ type CertificatesV1Interface interface {
 // CertificatesV1Client is used to interact with features provided by the certificates.k8s.io group.
 type CertificatesV1Client struct {
 	restClient rest.Interface
-	cluster    string
+	cluster    logicalcluster.LogicalCluster
 }
 
 func (c *CertificatesV1Client) CertificateSigningRequests() CertificateSigningRequestInterface {
@@ -86,7 +87,7 @@ func New(c rest.Interface) *CertificatesV1Client {
 }
 
 // NewWithCluster creates a new CertificatesV1Client for the given RESTClient and cluster.
-func NewWithCluster(c rest.Interface, cluster string) *CertificatesV1Client {
+func NewWithCluster(c rest.Interface, cluster logicalcluster.LogicalCluster) *CertificatesV1Client {
 	return &CertificatesV1Client{restClient: c, cluster: cluster}
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1/certificatesigningrequest.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1/certificatesigningrequest.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1 "k8s.io/api/certificates/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -60,7 +61,7 @@ type CertificateSigningRequestInterface interface {
 // certificateSigningRequests implements CertificateSigningRequestInterface
 type certificateSigningRequests struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 }
 
 // newCertificateSigningRequests returns a CertificateSigningRequests

--- a/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1beta1/certificates_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1beta1/certificates_client.go
@@ -21,6 +21,7 @@ package v1beta1
 import (
 	"net/http"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1beta1 "k8s.io/api/certificates/v1beta1"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
@@ -34,7 +35,7 @@ type CertificatesV1beta1Interface interface {
 // CertificatesV1beta1Client is used to interact with features provided by the certificates.k8s.io group.
 type CertificatesV1beta1Client struct {
 	restClient rest.Interface
-	cluster    string
+	cluster    logicalcluster.LogicalCluster
 }
 
 func (c *CertificatesV1beta1Client) CertificateSigningRequests() CertificateSigningRequestInterface {
@@ -86,7 +87,7 @@ func New(c rest.Interface) *CertificatesV1beta1Client {
 }
 
 // NewWithCluster creates a new CertificatesV1beta1Client for the given RESTClient and cluster.
-func NewWithCluster(c rest.Interface, cluster string) *CertificatesV1beta1Client {
+func NewWithCluster(c rest.Interface, cluster logicalcluster.LogicalCluster) *CertificatesV1beta1Client {
 	return &CertificatesV1beta1Client{restClient: c, cluster: cluster}
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1beta1/certificatesigningrequest.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1beta1/certificatesigningrequest.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1beta1 "k8s.io/api/certificates/v1beta1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -58,7 +59,7 @@ type CertificateSigningRequestInterface interface {
 // certificateSigningRequests implements CertificateSigningRequestInterface
 type certificateSigningRequests struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 }
 
 // newCertificateSigningRequests returns a CertificateSigningRequests

--- a/staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1/coordination_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1/coordination_client.go
@@ -21,6 +21,7 @@ package v1
 import (
 	"net/http"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1 "k8s.io/api/coordination/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
@@ -34,7 +35,7 @@ type CoordinationV1Interface interface {
 // CoordinationV1Client is used to interact with features provided by the coordination.k8s.io group.
 type CoordinationV1Client struct {
 	restClient rest.Interface
-	cluster    string
+	cluster    logicalcluster.LogicalCluster
 }
 
 func (c *CoordinationV1Client) Leases(namespace string) LeaseInterface {
@@ -86,7 +87,7 @@ func New(c rest.Interface) *CoordinationV1Client {
 }
 
 // NewWithCluster creates a new CoordinationV1Client for the given RESTClient and cluster.
-func NewWithCluster(c rest.Interface, cluster string) *CoordinationV1Client {
+func NewWithCluster(c rest.Interface, cluster logicalcluster.LogicalCluster) *CoordinationV1Client {
 	return &CoordinationV1Client{restClient: c, cluster: cluster}
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1/lease.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1/lease.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1 "k8s.io/api/coordination/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -56,7 +57,7 @@ type LeaseInterface interface {
 // leases implements LeaseInterface
 type leases struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 	ns      string
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1beta1/coordination_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1beta1/coordination_client.go
@@ -21,6 +21,7 @@ package v1beta1
 import (
 	"net/http"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1beta1 "k8s.io/api/coordination/v1beta1"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
@@ -34,7 +35,7 @@ type CoordinationV1beta1Interface interface {
 // CoordinationV1beta1Client is used to interact with features provided by the coordination.k8s.io group.
 type CoordinationV1beta1Client struct {
 	restClient rest.Interface
-	cluster    string
+	cluster    logicalcluster.LogicalCluster
 }
 
 func (c *CoordinationV1beta1Client) Leases(namespace string) LeaseInterface {
@@ -86,7 +87,7 @@ func New(c rest.Interface) *CoordinationV1beta1Client {
 }
 
 // NewWithCluster creates a new CoordinationV1beta1Client for the given RESTClient and cluster.
-func NewWithCluster(c rest.Interface, cluster string) *CoordinationV1beta1Client {
+func NewWithCluster(c rest.Interface, cluster logicalcluster.LogicalCluster) *CoordinationV1beta1Client {
 	return &CoordinationV1beta1Client{restClient: c, cluster: cluster}
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1beta1/lease.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1beta1/lease.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1beta1 "k8s.io/api/coordination/v1beta1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -56,7 +57,7 @@ type LeaseInterface interface {
 // leases implements LeaseInterface
 type leases struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 	ns      string
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/componentstatus.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/componentstatus.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -56,7 +57,7 @@ type ComponentStatusInterface interface {
 // componentStatuses implements ComponentStatusInterface
 type componentStatuses struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 }
 
 // newComponentStatuses returns a ComponentStatuses

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/configmap.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/configmap.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -56,7 +57,7 @@ type ConfigMapInterface interface {
 // configMaps implements ConfigMapInterface
 type configMaps struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 	ns      string
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/core_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/core_client.go
@@ -21,6 +21,7 @@ package v1
 import (
 	"net/http"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
@@ -49,7 +50,7 @@ type CoreV1Interface interface {
 // CoreV1Client is used to interact with features provided by the  group.
 type CoreV1Client struct {
 	restClient rest.Interface
-	cluster    string
+	cluster    logicalcluster.LogicalCluster
 }
 
 func (c *CoreV1Client) ComponentStatuses() ComponentStatusInterface {
@@ -161,7 +162,7 @@ func New(c rest.Interface) *CoreV1Client {
 }
 
 // NewWithCluster creates a new CoreV1Client for the given RESTClient and cluster.
-func NewWithCluster(c rest.Interface, cluster string) *CoreV1Client {
+func NewWithCluster(c rest.Interface, cluster logicalcluster.LogicalCluster) *CoreV1Client {
 	return &CoreV1Client{restClient: c, cluster: cluster}
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/endpoints.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/endpoints.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -56,7 +57,7 @@ type EndpointsInterface interface {
 // endpoints implements EndpointsInterface
 type endpoints struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 	ns      string
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/event.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/event.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -56,7 +57,7 @@ type EventInterface interface {
 // events implements EventInterface
 type events struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 	ns      string
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/limitrange.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/limitrange.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -56,7 +57,7 @@ type LimitRangeInterface interface {
 // limitRanges implements LimitRangeInterface
 type limitRanges struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 	ns      string
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/namespace.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/namespace.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -57,7 +58,7 @@ type NamespaceInterface interface {
 // namespaces implements NamespaceInterface
 type namespaces struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 }
 
 // newNamespaces returns a Namespaces

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/node.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/node.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -58,7 +59,7 @@ type NodeInterface interface {
 // nodes implements NodeInterface
 type nodes struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 }
 
 // newNodes returns a Nodes

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/persistentvolume.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/persistentvolume.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -58,7 +59,7 @@ type PersistentVolumeInterface interface {
 // persistentVolumes implements PersistentVolumeInterface
 type persistentVolumes struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 }
 
 // newPersistentVolumes returns a PersistentVolumes

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/persistentvolumeclaim.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/persistentvolumeclaim.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -58,7 +59,7 @@ type PersistentVolumeClaimInterface interface {
 // persistentVolumeClaims implements PersistentVolumeClaimInterface
 type persistentVolumeClaims struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 	ns      string
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/pod.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/pod.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -60,7 +61,7 @@ type PodInterface interface {
 // pods implements PodInterface
 type pods struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 	ns      string
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/podtemplate.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/podtemplate.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -56,7 +57,7 @@ type PodTemplateInterface interface {
 // podTemplates implements PodTemplateInterface
 type podTemplates struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 	ns      string
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/replicationcontroller.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/replicationcontroller.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -62,7 +63,7 @@ type ReplicationControllerInterface interface {
 // replicationControllers implements ReplicationControllerInterface
 type replicationControllers struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 	ns      string
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/resourcequota.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/resourcequota.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -58,7 +59,7 @@ type ResourceQuotaInterface interface {
 // resourceQuotas implements ResourceQuotaInterface
 type resourceQuotas struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 	ns      string
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/secret.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/secret.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -56,7 +57,7 @@ type SecretInterface interface {
 // secrets implements SecretInterface
 type secrets struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 	ns      string
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/service.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/service.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -57,7 +58,7 @@ type ServiceInterface interface {
 // services implements ServiceInterface
 type services struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 	ns      string
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/serviceaccount.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/serviceaccount.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	authenticationv1 "k8s.io/api/authentication/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -59,7 +60,7 @@ type ServiceAccountInterface interface {
 // serviceAccounts implements ServiceAccountInterface
 type serviceAccounts struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 	ns      string
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/discovery/v1/discovery_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/discovery/v1/discovery_client.go
@@ -21,6 +21,7 @@ package v1
 import (
 	"net/http"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1 "k8s.io/api/discovery/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
@@ -34,7 +35,7 @@ type DiscoveryV1Interface interface {
 // DiscoveryV1Client is used to interact with features provided by the discovery.k8s.io group.
 type DiscoveryV1Client struct {
 	restClient rest.Interface
-	cluster    string
+	cluster    logicalcluster.LogicalCluster
 }
 
 func (c *DiscoveryV1Client) EndpointSlices(namespace string) EndpointSliceInterface {
@@ -86,7 +87,7 @@ func New(c rest.Interface) *DiscoveryV1Client {
 }
 
 // NewWithCluster creates a new DiscoveryV1Client for the given RESTClient and cluster.
-func NewWithCluster(c rest.Interface, cluster string) *DiscoveryV1Client {
+func NewWithCluster(c rest.Interface, cluster logicalcluster.LogicalCluster) *DiscoveryV1Client {
 	return &DiscoveryV1Client{restClient: c, cluster: cluster}
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/discovery/v1/endpointslice.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/discovery/v1/endpointslice.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -56,7 +57,7 @@ type EndpointSliceInterface interface {
 // endpointSlices implements EndpointSliceInterface
 type endpointSlices struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 	ns      string
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/discovery/v1beta1/discovery_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/discovery/v1beta1/discovery_client.go
@@ -21,6 +21,7 @@ package v1beta1
 import (
 	"net/http"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1beta1 "k8s.io/api/discovery/v1beta1"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
@@ -34,7 +35,7 @@ type DiscoveryV1beta1Interface interface {
 // DiscoveryV1beta1Client is used to interact with features provided by the discovery.k8s.io group.
 type DiscoveryV1beta1Client struct {
 	restClient rest.Interface
-	cluster    string
+	cluster    logicalcluster.LogicalCluster
 }
 
 func (c *DiscoveryV1beta1Client) EndpointSlices(namespace string) EndpointSliceInterface {
@@ -86,7 +87,7 @@ func New(c rest.Interface) *DiscoveryV1beta1Client {
 }
 
 // NewWithCluster creates a new DiscoveryV1beta1Client for the given RESTClient and cluster.
-func NewWithCluster(c rest.Interface, cluster string) *DiscoveryV1beta1Client {
+func NewWithCluster(c rest.Interface, cluster logicalcluster.LogicalCluster) *DiscoveryV1beta1Client {
 	return &DiscoveryV1beta1Client{restClient: c, cluster: cluster}
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/discovery/v1beta1/endpointslice.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/discovery/v1beta1/endpointslice.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1beta1 "k8s.io/api/discovery/v1beta1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -56,7 +57,7 @@ type EndpointSliceInterface interface {
 // endpointSlices implements EndpointSliceInterface
 type endpointSlices struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 	ns      string
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/events/v1/event.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/events/v1/event.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1 "k8s.io/api/events/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -56,7 +57,7 @@ type EventInterface interface {
 // events implements EventInterface
 type events struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 	ns      string
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/events/v1/events_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/events/v1/events_client.go
@@ -21,6 +21,7 @@ package v1
 import (
 	"net/http"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1 "k8s.io/api/events/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
@@ -34,7 +35,7 @@ type EventsV1Interface interface {
 // EventsV1Client is used to interact with features provided by the events.k8s.io group.
 type EventsV1Client struct {
 	restClient rest.Interface
-	cluster    string
+	cluster    logicalcluster.LogicalCluster
 }
 
 func (c *EventsV1Client) Events(namespace string) EventInterface {
@@ -86,7 +87,7 @@ func New(c rest.Interface) *EventsV1Client {
 }
 
 // NewWithCluster creates a new EventsV1Client for the given RESTClient and cluster.
-func NewWithCluster(c rest.Interface, cluster string) *EventsV1Client {
+func NewWithCluster(c rest.Interface, cluster logicalcluster.LogicalCluster) *EventsV1Client {
 	return &EventsV1Client{restClient: c, cluster: cluster}
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/events/v1beta1/event.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/events/v1beta1/event.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1beta1 "k8s.io/api/events/v1beta1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -56,7 +57,7 @@ type EventInterface interface {
 // events implements EventInterface
 type events struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 	ns      string
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/events/v1beta1/events_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/events/v1beta1/events_client.go
@@ -21,6 +21,7 @@ package v1beta1
 import (
 	"net/http"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1beta1 "k8s.io/api/events/v1beta1"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
@@ -34,7 +35,7 @@ type EventsV1beta1Interface interface {
 // EventsV1beta1Client is used to interact with features provided by the events.k8s.io group.
 type EventsV1beta1Client struct {
 	restClient rest.Interface
-	cluster    string
+	cluster    logicalcluster.LogicalCluster
 }
 
 func (c *EventsV1beta1Client) Events(namespace string) EventInterface {
@@ -86,7 +87,7 @@ func New(c rest.Interface) *EventsV1beta1Client {
 }
 
 // NewWithCluster creates a new EventsV1beta1Client for the given RESTClient and cluster.
-func NewWithCluster(c rest.Interface, cluster string) *EventsV1beta1Client {
+func NewWithCluster(c rest.Interface, cluster logicalcluster.LogicalCluster) *EventsV1beta1Client {
 	return &EventsV1beta1Client{restClient: c, cluster: cluster}
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/daemonset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/daemonset.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1beta1 "k8s.io/api/extensions/v1beta1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -58,7 +59,7 @@ type DaemonSetInterface interface {
 // daemonSets implements DaemonSetInterface
 type daemonSets struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 	ns      string
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/deployment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/deployment.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1beta1 "k8s.io/api/extensions/v1beta1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -62,7 +63,7 @@ type DeploymentInterface interface {
 // deployments implements DeploymentInterface
 type deployments struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 	ns      string
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/extensions_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/extensions_client.go
@@ -21,6 +21,7 @@ package v1beta1
 import (
 	"net/http"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1beta1 "k8s.io/api/extensions/v1beta1"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
@@ -39,7 +40,7 @@ type ExtensionsV1beta1Interface interface {
 // ExtensionsV1beta1Client is used to interact with features provided by the extensions group.
 type ExtensionsV1beta1Client struct {
 	restClient rest.Interface
-	cluster    string
+	cluster    logicalcluster.LogicalCluster
 }
 
 func (c *ExtensionsV1beta1Client) DaemonSets(namespace string) DaemonSetInterface {
@@ -111,7 +112,7 @@ func New(c rest.Interface) *ExtensionsV1beta1Client {
 }
 
 // NewWithCluster creates a new ExtensionsV1beta1Client for the given RESTClient and cluster.
-func NewWithCluster(c rest.Interface, cluster string) *ExtensionsV1beta1Client {
+func NewWithCluster(c rest.Interface, cluster logicalcluster.LogicalCluster) *ExtensionsV1beta1Client {
 	return &ExtensionsV1beta1Client{restClient: c, cluster: cluster}
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/ingress.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/ingress.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1beta1 "k8s.io/api/extensions/v1beta1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -58,7 +59,7 @@ type IngressInterface interface {
 // ingresses implements IngressInterface
 type ingresses struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 	ns      string
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/networkpolicy.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/networkpolicy.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1beta1 "k8s.io/api/extensions/v1beta1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -56,7 +57,7 @@ type NetworkPolicyInterface interface {
 // networkPolicies implements NetworkPolicyInterface
 type networkPolicies struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 	ns      string
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/podsecuritypolicy.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/podsecuritypolicy.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1beta1 "k8s.io/api/extensions/v1beta1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -56,7 +57,7 @@ type PodSecurityPolicyInterface interface {
 // podSecurityPolicies implements PodSecurityPolicyInterface
 type podSecurityPolicies struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 }
 
 // newPodSecurityPolicies returns a PodSecurityPolicies

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/replicaset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/replicaset.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1beta1 "k8s.io/api/extensions/v1beta1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -62,7 +63,7 @@ type ReplicaSetInterface interface {
 // replicaSets implements ReplicaSetInterface
 type replicaSets struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 	ns      string
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1alpha1/flowcontrol_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1alpha1/flowcontrol_client.go
@@ -21,6 +21,7 @@ package v1alpha1
 import (
 	"net/http"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1alpha1 "k8s.io/api/flowcontrol/v1alpha1"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
@@ -35,7 +36,7 @@ type FlowcontrolV1alpha1Interface interface {
 // FlowcontrolV1alpha1Client is used to interact with features provided by the flowcontrol.apiserver.k8s.io group.
 type FlowcontrolV1alpha1Client struct {
 	restClient rest.Interface
-	cluster    string
+	cluster    logicalcluster.LogicalCluster
 }
 
 func (c *FlowcontrolV1alpha1Client) FlowSchemas() FlowSchemaInterface {
@@ -91,7 +92,7 @@ func New(c rest.Interface) *FlowcontrolV1alpha1Client {
 }
 
 // NewWithCluster creates a new FlowcontrolV1alpha1Client for the given RESTClient and cluster.
-func NewWithCluster(c rest.Interface, cluster string) *FlowcontrolV1alpha1Client {
+func NewWithCluster(c rest.Interface, cluster logicalcluster.LogicalCluster) *FlowcontrolV1alpha1Client {
 	return &FlowcontrolV1alpha1Client{restClient: c, cluster: cluster}
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1alpha1/flowschema.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1alpha1/flowschema.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1alpha1 "k8s.io/api/flowcontrol/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -58,7 +59,7 @@ type FlowSchemaInterface interface {
 // flowSchemas implements FlowSchemaInterface
 type flowSchemas struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 }
 
 // newFlowSchemas returns a FlowSchemas

--- a/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1alpha1/prioritylevelconfiguration.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1alpha1/prioritylevelconfiguration.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1alpha1 "k8s.io/api/flowcontrol/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -58,7 +59,7 @@ type PriorityLevelConfigurationInterface interface {
 // priorityLevelConfigurations implements PriorityLevelConfigurationInterface
 type priorityLevelConfigurations struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 }
 
 // newPriorityLevelConfigurations returns a PriorityLevelConfigurations

--- a/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta1/flowcontrol_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta1/flowcontrol_client.go
@@ -21,6 +21,7 @@ package v1beta1
 import (
 	"net/http"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1beta1 "k8s.io/api/flowcontrol/v1beta1"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
@@ -35,7 +36,7 @@ type FlowcontrolV1beta1Interface interface {
 // FlowcontrolV1beta1Client is used to interact with features provided by the flowcontrol.apiserver.k8s.io group.
 type FlowcontrolV1beta1Client struct {
 	restClient rest.Interface
-	cluster    string
+	cluster    logicalcluster.LogicalCluster
 }
 
 func (c *FlowcontrolV1beta1Client) FlowSchemas() FlowSchemaInterface {
@@ -91,7 +92,7 @@ func New(c rest.Interface) *FlowcontrolV1beta1Client {
 }
 
 // NewWithCluster creates a new FlowcontrolV1beta1Client for the given RESTClient and cluster.
-func NewWithCluster(c rest.Interface, cluster string) *FlowcontrolV1beta1Client {
+func NewWithCluster(c rest.Interface, cluster logicalcluster.LogicalCluster) *FlowcontrolV1beta1Client {
 	return &FlowcontrolV1beta1Client{restClient: c, cluster: cluster}
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta1/flowschema.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta1/flowschema.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1beta1 "k8s.io/api/flowcontrol/v1beta1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -58,7 +59,7 @@ type FlowSchemaInterface interface {
 // flowSchemas implements FlowSchemaInterface
 type flowSchemas struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 }
 
 // newFlowSchemas returns a FlowSchemas

--- a/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta1/prioritylevelconfiguration.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta1/prioritylevelconfiguration.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1beta1 "k8s.io/api/flowcontrol/v1beta1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -58,7 +59,7 @@ type PriorityLevelConfigurationInterface interface {
 // priorityLevelConfigurations implements PriorityLevelConfigurationInterface
 type priorityLevelConfigurations struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 }
 
 // newPriorityLevelConfigurations returns a PriorityLevelConfigurations

--- a/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta2/flowcontrol_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta2/flowcontrol_client.go
@@ -21,6 +21,7 @@ package v1beta2
 import (
 	"net/http"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1beta2 "k8s.io/api/flowcontrol/v1beta2"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
@@ -35,7 +36,7 @@ type FlowcontrolV1beta2Interface interface {
 // FlowcontrolV1beta2Client is used to interact with features provided by the flowcontrol.apiserver.k8s.io group.
 type FlowcontrolV1beta2Client struct {
 	restClient rest.Interface
-	cluster    string
+	cluster    logicalcluster.LogicalCluster
 }
 
 func (c *FlowcontrolV1beta2Client) FlowSchemas() FlowSchemaInterface {
@@ -91,7 +92,7 @@ func New(c rest.Interface) *FlowcontrolV1beta2Client {
 }
 
 // NewWithCluster creates a new FlowcontrolV1beta2Client for the given RESTClient and cluster.
-func NewWithCluster(c rest.Interface, cluster string) *FlowcontrolV1beta2Client {
+func NewWithCluster(c rest.Interface, cluster logicalcluster.LogicalCluster) *FlowcontrolV1beta2Client {
 	return &FlowcontrolV1beta2Client{restClient: c, cluster: cluster}
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta2/flowschema.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta2/flowschema.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1beta2 "k8s.io/api/flowcontrol/v1beta2"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -58,7 +59,7 @@ type FlowSchemaInterface interface {
 // flowSchemas implements FlowSchemaInterface
 type flowSchemas struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 }
 
 // newFlowSchemas returns a FlowSchemas

--- a/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta2/prioritylevelconfiguration.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta2/prioritylevelconfiguration.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1beta2 "k8s.io/api/flowcontrol/v1beta2"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -58,7 +59,7 @@ type PriorityLevelConfigurationInterface interface {
 // priorityLevelConfigurations implements PriorityLevelConfigurationInterface
 type priorityLevelConfigurations struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 }
 
 // newPriorityLevelConfigurations returns a PriorityLevelConfigurations

--- a/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1/ingress.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1/ingress.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -58,7 +59,7 @@ type IngressInterface interface {
 // ingresses implements IngressInterface
 type ingresses struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 	ns      string
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1/ingressclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1/ingressclass.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -56,7 +57,7 @@ type IngressClassInterface interface {
 // ingressClasses implements IngressClassInterface
 type ingressClasses struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 }
 
 // newIngressClasses returns a IngressClasses

--- a/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1/networking_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1/networking_client.go
@@ -21,6 +21,7 @@ package v1
 import (
 	"net/http"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1 "k8s.io/api/networking/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
@@ -36,7 +37,7 @@ type NetworkingV1Interface interface {
 // NetworkingV1Client is used to interact with features provided by the networking.k8s.io group.
 type NetworkingV1Client struct {
 	restClient rest.Interface
-	cluster    string
+	cluster    logicalcluster.LogicalCluster
 }
 
 func (c *NetworkingV1Client) Ingresses(namespace string) IngressInterface {
@@ -96,7 +97,7 @@ func New(c rest.Interface) *NetworkingV1Client {
 }
 
 // NewWithCluster creates a new NetworkingV1Client for the given RESTClient and cluster.
-func NewWithCluster(c rest.Interface, cluster string) *NetworkingV1Client {
+func NewWithCluster(c rest.Interface, cluster logicalcluster.LogicalCluster) *NetworkingV1Client {
 	return &NetworkingV1Client{restClient: c, cluster: cluster}
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1/networkpolicy.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1/networkpolicy.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -56,7 +57,7 @@ type NetworkPolicyInterface interface {
 // networkPolicies implements NetworkPolicyInterface
 type networkPolicies struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 	ns      string
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1beta1/ingress.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1beta1/ingress.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1beta1 "k8s.io/api/networking/v1beta1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -58,7 +59,7 @@ type IngressInterface interface {
 // ingresses implements IngressInterface
 type ingresses struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 	ns      string
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1beta1/ingressclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1beta1/ingressclass.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1beta1 "k8s.io/api/networking/v1beta1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -56,7 +57,7 @@ type IngressClassInterface interface {
 // ingressClasses implements IngressClassInterface
 type ingressClasses struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 }
 
 // newIngressClasses returns a IngressClasses

--- a/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1beta1/networking_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1beta1/networking_client.go
@@ -21,6 +21,7 @@ package v1beta1
 import (
 	"net/http"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1beta1 "k8s.io/api/networking/v1beta1"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
@@ -35,7 +36,7 @@ type NetworkingV1beta1Interface interface {
 // NetworkingV1beta1Client is used to interact with features provided by the networking.k8s.io group.
 type NetworkingV1beta1Client struct {
 	restClient rest.Interface
-	cluster    string
+	cluster    logicalcluster.LogicalCluster
 }
 
 func (c *NetworkingV1beta1Client) Ingresses(namespace string) IngressInterface {
@@ -91,7 +92,7 @@ func New(c rest.Interface) *NetworkingV1beta1Client {
 }
 
 // NewWithCluster creates a new NetworkingV1beta1Client for the given RESTClient and cluster.
-func NewWithCluster(c rest.Interface, cluster string) *NetworkingV1beta1Client {
+func NewWithCluster(c rest.Interface, cluster logicalcluster.LogicalCluster) *NetworkingV1beta1Client {
 	return &NetworkingV1beta1Client{restClient: c, cluster: cluster}
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/node/v1/node_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/node/v1/node_client.go
@@ -21,6 +21,7 @@ package v1
 import (
 	"net/http"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1 "k8s.io/api/node/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
@@ -34,7 +35,7 @@ type NodeV1Interface interface {
 // NodeV1Client is used to interact with features provided by the node.k8s.io group.
 type NodeV1Client struct {
 	restClient rest.Interface
-	cluster    string
+	cluster    logicalcluster.LogicalCluster
 }
 
 func (c *NodeV1Client) RuntimeClasses() RuntimeClassInterface {
@@ -86,7 +87,7 @@ func New(c rest.Interface) *NodeV1Client {
 }
 
 // NewWithCluster creates a new NodeV1Client for the given RESTClient and cluster.
-func NewWithCluster(c rest.Interface, cluster string) *NodeV1Client {
+func NewWithCluster(c rest.Interface, cluster logicalcluster.LogicalCluster) *NodeV1Client {
 	return &NodeV1Client{restClient: c, cluster: cluster}
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/node/v1/runtimeclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/node/v1/runtimeclass.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1 "k8s.io/api/node/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -56,7 +57,7 @@ type RuntimeClassInterface interface {
 // runtimeClasses implements RuntimeClassInterface
 type runtimeClasses struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 }
 
 // newRuntimeClasses returns a RuntimeClasses

--- a/staging/src/k8s.io/client-go/kubernetes/typed/node/v1alpha1/node_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/node/v1alpha1/node_client.go
@@ -21,6 +21,7 @@ package v1alpha1
 import (
 	"net/http"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1alpha1 "k8s.io/api/node/v1alpha1"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
@@ -34,7 +35,7 @@ type NodeV1alpha1Interface interface {
 // NodeV1alpha1Client is used to interact with features provided by the node.k8s.io group.
 type NodeV1alpha1Client struct {
 	restClient rest.Interface
-	cluster    string
+	cluster    logicalcluster.LogicalCluster
 }
 
 func (c *NodeV1alpha1Client) RuntimeClasses() RuntimeClassInterface {
@@ -86,7 +87,7 @@ func New(c rest.Interface) *NodeV1alpha1Client {
 }
 
 // NewWithCluster creates a new NodeV1alpha1Client for the given RESTClient and cluster.
-func NewWithCluster(c rest.Interface, cluster string) *NodeV1alpha1Client {
+func NewWithCluster(c rest.Interface, cluster logicalcluster.LogicalCluster) *NodeV1alpha1Client {
 	return &NodeV1alpha1Client{restClient: c, cluster: cluster}
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/node/v1alpha1/runtimeclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/node/v1alpha1/runtimeclass.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1alpha1 "k8s.io/api/node/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -56,7 +57,7 @@ type RuntimeClassInterface interface {
 // runtimeClasses implements RuntimeClassInterface
 type runtimeClasses struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 }
 
 // newRuntimeClasses returns a RuntimeClasses

--- a/staging/src/k8s.io/client-go/kubernetes/typed/node/v1beta1/node_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/node/v1beta1/node_client.go
@@ -21,6 +21,7 @@ package v1beta1
 import (
 	"net/http"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1beta1 "k8s.io/api/node/v1beta1"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
@@ -34,7 +35,7 @@ type NodeV1beta1Interface interface {
 // NodeV1beta1Client is used to interact with features provided by the node.k8s.io group.
 type NodeV1beta1Client struct {
 	restClient rest.Interface
-	cluster    string
+	cluster    logicalcluster.LogicalCluster
 }
 
 func (c *NodeV1beta1Client) RuntimeClasses() RuntimeClassInterface {
@@ -86,7 +87,7 @@ func New(c rest.Interface) *NodeV1beta1Client {
 }
 
 // NewWithCluster creates a new NodeV1beta1Client for the given RESTClient and cluster.
-func NewWithCluster(c rest.Interface, cluster string) *NodeV1beta1Client {
+func NewWithCluster(c rest.Interface, cluster logicalcluster.LogicalCluster) *NodeV1beta1Client {
 	return &NodeV1beta1Client{restClient: c, cluster: cluster}
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/node/v1beta1/runtimeclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/node/v1beta1/runtimeclass.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1beta1 "k8s.io/api/node/v1beta1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -56,7 +57,7 @@ type RuntimeClassInterface interface {
 // runtimeClasses implements RuntimeClassInterface
 type runtimeClasses struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 }
 
 // newRuntimeClasses returns a RuntimeClasses

--- a/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1/eviction.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1/eviction.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1
 
 import (
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	rest "k8s.io/client-go/rest"
 )
 
@@ -36,7 +37,7 @@ type EvictionInterface interface {
 // evictions implements EvictionInterface
 type evictions struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 	ns      string
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1/poddisruptionbudget.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1/poddisruptionbudget.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -58,7 +59,7 @@ type PodDisruptionBudgetInterface interface {
 // podDisruptionBudgets implements PodDisruptionBudgetInterface
 type podDisruptionBudgets struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 	ns      string
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1/policy_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1/policy_client.go
@@ -21,6 +21,7 @@ package v1
 import (
 	"net/http"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1 "k8s.io/api/policy/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
@@ -35,7 +36,7 @@ type PolicyV1Interface interface {
 // PolicyV1Client is used to interact with features provided by the policy group.
 type PolicyV1Client struct {
 	restClient rest.Interface
-	cluster    string
+	cluster    logicalcluster.LogicalCluster
 }
 
 func (c *PolicyV1Client) Evictions(namespace string) EvictionInterface {
@@ -91,7 +92,7 @@ func New(c rest.Interface) *PolicyV1Client {
 }
 
 // NewWithCluster creates a new PolicyV1Client for the given RESTClient and cluster.
-func NewWithCluster(c rest.Interface, cluster string) *PolicyV1Client {
+func NewWithCluster(c rest.Interface, cluster logicalcluster.LogicalCluster) *PolicyV1Client {
 	return &PolicyV1Client{restClient: c, cluster: cluster}
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1beta1/eviction.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1beta1/eviction.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	rest "k8s.io/client-go/rest"
 )
 
@@ -36,7 +37,7 @@ type EvictionInterface interface {
 // evictions implements EvictionInterface
 type evictions struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 	ns      string
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1beta1/poddisruptionbudget.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1beta1/poddisruptionbudget.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1beta1 "k8s.io/api/policy/v1beta1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -58,7 +59,7 @@ type PodDisruptionBudgetInterface interface {
 // podDisruptionBudgets implements PodDisruptionBudgetInterface
 type podDisruptionBudgets struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 	ns      string
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1beta1/podsecuritypolicy.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1beta1/podsecuritypolicy.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1beta1 "k8s.io/api/policy/v1beta1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -56,7 +57,7 @@ type PodSecurityPolicyInterface interface {
 // podSecurityPolicies implements PodSecurityPolicyInterface
 type podSecurityPolicies struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 }
 
 // newPodSecurityPolicies returns a PodSecurityPolicies

--- a/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1beta1/policy_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1beta1/policy_client.go
@@ -21,6 +21,7 @@ package v1beta1
 import (
 	"net/http"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1beta1 "k8s.io/api/policy/v1beta1"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
@@ -36,7 +37,7 @@ type PolicyV1beta1Interface interface {
 // PolicyV1beta1Client is used to interact with features provided by the policy group.
 type PolicyV1beta1Client struct {
 	restClient rest.Interface
-	cluster    string
+	cluster    logicalcluster.LogicalCluster
 }
 
 func (c *PolicyV1beta1Client) Evictions(namespace string) EvictionInterface {
@@ -96,7 +97,7 @@ func New(c rest.Interface) *PolicyV1beta1Client {
 }
 
 // NewWithCluster creates a new PolicyV1beta1Client for the given RESTClient and cluster.
-func NewWithCluster(c rest.Interface, cluster string) *PolicyV1beta1Client {
+func NewWithCluster(c rest.Interface, cluster logicalcluster.LogicalCluster) *PolicyV1beta1Client {
 	return &PolicyV1beta1Client{restClient: c, cluster: cluster}
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/clusterrole.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/clusterrole.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -56,7 +57,7 @@ type ClusterRoleInterface interface {
 // clusterRoles implements ClusterRoleInterface
 type clusterRoles struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 }
 
 // newClusterRoles returns a ClusterRoles

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/clusterrolebinding.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -56,7 +57,7 @@ type ClusterRoleBindingInterface interface {
 // clusterRoleBindings implements ClusterRoleBindingInterface
 type clusterRoleBindings struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 }
 
 // newClusterRoleBindings returns a ClusterRoleBindings

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/rbac_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/rbac_client.go
@@ -21,6 +21,7 @@ package v1
 import (
 	"net/http"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1 "k8s.io/api/rbac/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
@@ -37,7 +38,7 @@ type RbacV1Interface interface {
 // RbacV1Client is used to interact with features provided by the rbac.authorization.k8s.io group.
 type RbacV1Client struct {
 	restClient rest.Interface
-	cluster    string
+	cluster    logicalcluster.LogicalCluster
 }
 
 func (c *RbacV1Client) ClusterRoles() ClusterRoleInterface {
@@ -101,7 +102,7 @@ func New(c rest.Interface) *RbacV1Client {
 }
 
 // NewWithCluster creates a new RbacV1Client for the given RESTClient and cluster.
-func NewWithCluster(c rest.Interface, cluster string) *RbacV1Client {
+func NewWithCluster(c rest.Interface, cluster logicalcluster.LogicalCluster) *RbacV1Client {
 	return &RbacV1Client{restClient: c, cluster: cluster}
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/role.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/role.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -56,7 +57,7 @@ type RoleInterface interface {
 // roles implements RoleInterface
 type roles struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 	ns      string
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/rolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/rolebinding.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -56,7 +57,7 @@ type RoleBindingInterface interface {
 // roleBindings implements RoleBindingInterface
 type roleBindings struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 	ns      string
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/clusterrole.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/clusterrole.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1alpha1 "k8s.io/api/rbac/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -56,7 +57,7 @@ type ClusterRoleInterface interface {
 // clusterRoles implements ClusterRoleInterface
 type clusterRoles struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 }
 
 // newClusterRoles returns a ClusterRoles

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/clusterrolebinding.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1alpha1 "k8s.io/api/rbac/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -56,7 +57,7 @@ type ClusterRoleBindingInterface interface {
 // clusterRoleBindings implements ClusterRoleBindingInterface
 type clusterRoleBindings struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 }
 
 // newClusterRoleBindings returns a ClusterRoleBindings

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/rbac_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/rbac_client.go
@@ -21,6 +21,7 @@ package v1alpha1
 import (
 	"net/http"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1alpha1 "k8s.io/api/rbac/v1alpha1"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
@@ -37,7 +38,7 @@ type RbacV1alpha1Interface interface {
 // RbacV1alpha1Client is used to interact with features provided by the rbac.authorization.k8s.io group.
 type RbacV1alpha1Client struct {
 	restClient rest.Interface
-	cluster    string
+	cluster    logicalcluster.LogicalCluster
 }
 
 func (c *RbacV1alpha1Client) ClusterRoles() ClusterRoleInterface {
@@ -101,7 +102,7 @@ func New(c rest.Interface) *RbacV1alpha1Client {
 }
 
 // NewWithCluster creates a new RbacV1alpha1Client for the given RESTClient and cluster.
-func NewWithCluster(c rest.Interface, cluster string) *RbacV1alpha1Client {
+func NewWithCluster(c rest.Interface, cluster logicalcluster.LogicalCluster) *RbacV1alpha1Client {
 	return &RbacV1alpha1Client{restClient: c, cluster: cluster}
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/role.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/role.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1alpha1 "k8s.io/api/rbac/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -56,7 +57,7 @@ type RoleInterface interface {
 // roles implements RoleInterface
 type roles struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 	ns      string
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/rolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/rolebinding.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1alpha1 "k8s.io/api/rbac/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -56,7 +57,7 @@ type RoleBindingInterface interface {
 // roleBindings implements RoleBindingInterface
 type roleBindings struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 	ns      string
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/clusterrole.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/clusterrole.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1beta1 "k8s.io/api/rbac/v1beta1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -56,7 +57,7 @@ type ClusterRoleInterface interface {
 // clusterRoles implements ClusterRoleInterface
 type clusterRoles struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 }
 
 // newClusterRoles returns a ClusterRoles

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/clusterrolebinding.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1beta1 "k8s.io/api/rbac/v1beta1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -56,7 +57,7 @@ type ClusterRoleBindingInterface interface {
 // clusterRoleBindings implements ClusterRoleBindingInterface
 type clusterRoleBindings struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 }
 
 // newClusterRoleBindings returns a ClusterRoleBindings

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/rbac_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/rbac_client.go
@@ -21,6 +21,7 @@ package v1beta1
 import (
 	"net/http"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1beta1 "k8s.io/api/rbac/v1beta1"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
@@ -37,7 +38,7 @@ type RbacV1beta1Interface interface {
 // RbacV1beta1Client is used to interact with features provided by the rbac.authorization.k8s.io group.
 type RbacV1beta1Client struct {
 	restClient rest.Interface
-	cluster    string
+	cluster    logicalcluster.LogicalCluster
 }
 
 func (c *RbacV1beta1Client) ClusterRoles() ClusterRoleInterface {
@@ -101,7 +102,7 @@ func New(c rest.Interface) *RbacV1beta1Client {
 }
 
 // NewWithCluster creates a new RbacV1beta1Client for the given RESTClient and cluster.
-func NewWithCluster(c rest.Interface, cluster string) *RbacV1beta1Client {
+func NewWithCluster(c rest.Interface, cluster logicalcluster.LogicalCluster) *RbacV1beta1Client {
 	return &RbacV1beta1Client{restClient: c, cluster: cluster}
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/role.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/role.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1beta1 "k8s.io/api/rbac/v1beta1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -56,7 +57,7 @@ type RoleInterface interface {
 // roles implements RoleInterface
 type roles struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 	ns      string
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/rolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/rolebinding.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1beta1 "k8s.io/api/rbac/v1beta1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -56,7 +57,7 @@ type RoleBindingInterface interface {
 // roleBindings implements RoleBindingInterface
 type roleBindings struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 	ns      string
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1/priorityclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1/priorityclass.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1 "k8s.io/api/scheduling/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -56,7 +57,7 @@ type PriorityClassInterface interface {
 // priorityClasses implements PriorityClassInterface
 type priorityClasses struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 }
 
 // newPriorityClasses returns a PriorityClasses

--- a/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1/scheduling_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1/scheduling_client.go
@@ -21,6 +21,7 @@ package v1
 import (
 	"net/http"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1 "k8s.io/api/scheduling/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
@@ -34,7 +35,7 @@ type SchedulingV1Interface interface {
 // SchedulingV1Client is used to interact with features provided by the scheduling.k8s.io group.
 type SchedulingV1Client struct {
 	restClient rest.Interface
-	cluster    string
+	cluster    logicalcluster.LogicalCluster
 }
 
 func (c *SchedulingV1Client) PriorityClasses() PriorityClassInterface {
@@ -86,7 +87,7 @@ func New(c rest.Interface) *SchedulingV1Client {
 }
 
 // NewWithCluster creates a new SchedulingV1Client for the given RESTClient and cluster.
-func NewWithCluster(c rest.Interface, cluster string) *SchedulingV1Client {
+func NewWithCluster(c rest.Interface, cluster logicalcluster.LogicalCluster) *SchedulingV1Client {
 	return &SchedulingV1Client{restClient: c, cluster: cluster}
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1alpha1/priorityclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1alpha1/priorityclass.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1alpha1 "k8s.io/api/scheduling/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -56,7 +57,7 @@ type PriorityClassInterface interface {
 // priorityClasses implements PriorityClassInterface
 type priorityClasses struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 }
 
 // newPriorityClasses returns a PriorityClasses

--- a/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1alpha1/scheduling_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1alpha1/scheduling_client.go
@@ -21,6 +21,7 @@ package v1alpha1
 import (
 	"net/http"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1alpha1 "k8s.io/api/scheduling/v1alpha1"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
@@ -34,7 +35,7 @@ type SchedulingV1alpha1Interface interface {
 // SchedulingV1alpha1Client is used to interact with features provided by the scheduling.k8s.io group.
 type SchedulingV1alpha1Client struct {
 	restClient rest.Interface
-	cluster    string
+	cluster    logicalcluster.LogicalCluster
 }
 
 func (c *SchedulingV1alpha1Client) PriorityClasses() PriorityClassInterface {
@@ -86,7 +87,7 @@ func New(c rest.Interface) *SchedulingV1alpha1Client {
 }
 
 // NewWithCluster creates a new SchedulingV1alpha1Client for the given RESTClient and cluster.
-func NewWithCluster(c rest.Interface, cluster string) *SchedulingV1alpha1Client {
+func NewWithCluster(c rest.Interface, cluster logicalcluster.LogicalCluster) *SchedulingV1alpha1Client {
 	return &SchedulingV1alpha1Client{restClient: c, cluster: cluster}
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1beta1/priorityclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1beta1/priorityclass.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1beta1 "k8s.io/api/scheduling/v1beta1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -56,7 +57,7 @@ type PriorityClassInterface interface {
 // priorityClasses implements PriorityClassInterface
 type priorityClasses struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 }
 
 // newPriorityClasses returns a PriorityClasses

--- a/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1beta1/scheduling_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1beta1/scheduling_client.go
@@ -21,6 +21,7 @@ package v1beta1
 import (
 	"net/http"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1beta1 "k8s.io/api/scheduling/v1beta1"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
@@ -34,7 +35,7 @@ type SchedulingV1beta1Interface interface {
 // SchedulingV1beta1Client is used to interact with features provided by the scheduling.k8s.io group.
 type SchedulingV1beta1Client struct {
 	restClient rest.Interface
-	cluster    string
+	cluster    logicalcluster.LogicalCluster
 }
 
 func (c *SchedulingV1beta1Client) PriorityClasses() PriorityClassInterface {
@@ -86,7 +87,7 @@ func New(c rest.Interface) *SchedulingV1beta1Client {
 }
 
 // NewWithCluster creates a new SchedulingV1beta1Client for the given RESTClient and cluster.
-func NewWithCluster(c rest.Interface, cluster string) *SchedulingV1beta1Client {
+func NewWithCluster(c rest.Interface, cluster logicalcluster.LogicalCluster) *SchedulingV1beta1Client {
 	return &SchedulingV1beta1Client{restClient: c, cluster: cluster}
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/csidriver.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/csidriver.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -56,7 +57,7 @@ type CSIDriverInterface interface {
 // cSIDrivers implements CSIDriverInterface
 type cSIDrivers struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 }
 
 // newCSIDrivers returns a CSIDrivers

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/csinode.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/csinode.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -56,7 +57,7 @@ type CSINodeInterface interface {
 // cSINodes implements CSINodeInterface
 type cSINodes struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 }
 
 // newCSINodes returns a CSINodes

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/storage_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/storage_client.go
@@ -21,6 +21,7 @@ package v1
 import (
 	"net/http"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1 "k8s.io/api/storage/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
@@ -37,7 +38,7 @@ type StorageV1Interface interface {
 // StorageV1Client is used to interact with features provided by the storage.k8s.io group.
 type StorageV1Client struct {
 	restClient rest.Interface
-	cluster    string
+	cluster    logicalcluster.LogicalCluster
 }
 
 func (c *StorageV1Client) CSIDrivers() CSIDriverInterface {
@@ -101,7 +102,7 @@ func New(c rest.Interface) *StorageV1Client {
 }
 
 // NewWithCluster creates a new StorageV1Client for the given RESTClient and cluster.
-func NewWithCluster(c rest.Interface, cluster string) *StorageV1Client {
+func NewWithCluster(c rest.Interface, cluster logicalcluster.LogicalCluster) *StorageV1Client {
 	return &StorageV1Client{restClient: c, cluster: cluster}
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/storageclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/storageclass.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -56,7 +57,7 @@ type StorageClassInterface interface {
 // storageClasses implements StorageClassInterface
 type storageClasses struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 }
 
 // newStorageClasses returns a StorageClasses

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/volumeattachment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/volumeattachment.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -58,7 +59,7 @@ type VolumeAttachmentInterface interface {
 // volumeAttachments implements VolumeAttachmentInterface
 type volumeAttachments struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 }
 
 // newVolumeAttachments returns a VolumeAttachments

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1alpha1/csistoragecapacity.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1alpha1/csistoragecapacity.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1alpha1 "k8s.io/api/storage/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -56,7 +57,7 @@ type CSIStorageCapacityInterface interface {
 // cSIStorageCapacities implements CSIStorageCapacityInterface
 type cSIStorageCapacities struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 	ns      string
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1alpha1/storage_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1alpha1/storage_client.go
@@ -21,6 +21,7 @@ package v1alpha1
 import (
 	"net/http"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1alpha1 "k8s.io/api/storage/v1alpha1"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
@@ -35,7 +36,7 @@ type StorageV1alpha1Interface interface {
 // StorageV1alpha1Client is used to interact with features provided by the storage.k8s.io group.
 type StorageV1alpha1Client struct {
 	restClient rest.Interface
-	cluster    string
+	cluster    logicalcluster.LogicalCluster
 }
 
 func (c *StorageV1alpha1Client) CSIStorageCapacities(namespace string) CSIStorageCapacityInterface {
@@ -91,7 +92,7 @@ func New(c rest.Interface) *StorageV1alpha1Client {
 }
 
 // NewWithCluster creates a new StorageV1alpha1Client for the given RESTClient and cluster.
-func NewWithCluster(c rest.Interface, cluster string) *StorageV1alpha1Client {
+func NewWithCluster(c rest.Interface, cluster logicalcluster.LogicalCluster) *StorageV1alpha1Client {
 	return &StorageV1alpha1Client{restClient: c, cluster: cluster}
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1alpha1/volumeattachment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1alpha1/volumeattachment.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1alpha1 "k8s.io/api/storage/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -58,7 +59,7 @@ type VolumeAttachmentInterface interface {
 // volumeAttachments implements VolumeAttachmentInterface
 type volumeAttachments struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 }
 
 // newVolumeAttachments returns a VolumeAttachments

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/csidriver.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/csidriver.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1beta1 "k8s.io/api/storage/v1beta1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -56,7 +57,7 @@ type CSIDriverInterface interface {
 // cSIDrivers implements CSIDriverInterface
 type cSIDrivers struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 }
 
 // newCSIDrivers returns a CSIDrivers

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/csinode.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/csinode.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1beta1 "k8s.io/api/storage/v1beta1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -56,7 +57,7 @@ type CSINodeInterface interface {
 // cSINodes implements CSINodeInterface
 type cSINodes struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 }
 
 // newCSINodes returns a CSINodes

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/csistoragecapacity.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/csistoragecapacity.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1beta1 "k8s.io/api/storage/v1beta1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -56,7 +57,7 @@ type CSIStorageCapacityInterface interface {
 // cSIStorageCapacities implements CSIStorageCapacityInterface
 type cSIStorageCapacities struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 	ns      string
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/storage_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/storage_client.go
@@ -21,6 +21,7 @@ package v1beta1
 import (
 	"net/http"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1beta1 "k8s.io/api/storage/v1beta1"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
@@ -38,7 +39,7 @@ type StorageV1beta1Interface interface {
 // StorageV1beta1Client is used to interact with features provided by the storage.k8s.io group.
 type StorageV1beta1Client struct {
 	restClient rest.Interface
-	cluster    string
+	cluster    logicalcluster.LogicalCluster
 }
 
 func (c *StorageV1beta1Client) CSIDrivers() CSIDriverInterface {
@@ -106,7 +107,7 @@ func New(c rest.Interface) *StorageV1beta1Client {
 }
 
 // NewWithCluster creates a new StorageV1beta1Client for the given RESTClient and cluster.
-func NewWithCluster(c rest.Interface, cluster string) *StorageV1beta1Client {
+func NewWithCluster(c rest.Interface, cluster logicalcluster.LogicalCluster) *StorageV1beta1Client {
 	return &StorageV1beta1Client{restClient: c, cluster: cluster}
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/storageclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/storageclass.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1beta1 "k8s.io/api/storage/v1beta1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -56,7 +57,7 @@ type StorageClassInterface interface {
 // storageClasses implements StorageClassInterface
 type storageClasses struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 }
 
 // newStorageClasses returns a StorageClasses

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/volumeattachment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/volumeattachment.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1beta1 "k8s.io/api/storage/v1beta1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -58,7 +59,7 @@ type VolumeAttachmentInterface interface {
 // volumeAttachments implements VolumeAttachmentInterface
 type volumeAttachments struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 }
 
 // newVolumeAttachments returns a VolumeAttachments

--- a/staging/src/k8s.io/client-go/tools/cache/store.go
+++ b/staging/src/k8s.io/client-go/tools/cache/store.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/kcp-dev/apimachinery/pkg/logicalcluster"
+
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/client-go/tools/clusters"
 )
@@ -111,7 +113,7 @@ func MetaNamespaceKeyFunc(obj interface{}) (string, error) {
 		return "", fmt.Errorf("object has no meta: %v", err)
 	}
 
-	name := clusters.ToClusterAwareKey(metaObj.GetClusterName(), metaObj.GetName())
+	name := clusters.ToClusterAwareKey(logicalcluster.From(metaObj), metaObj.GetName())
 	if len(metaObj.GetNamespace()) > 0 {
 		return metaObj.GetNamespace() + "/" + name, nil
 	}

--- a/staging/src/k8s.io/client-go/tools/clusters/cache.go
+++ b/staging/src/k8s.io/client-go/tools/clusters/cache.go
@@ -1,6 +1,10 @@
 package clusters
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/kcp-dev/apimachinery/pkg/logicalcluster"
+)
 
 // ToClusterAwareKey allows combining the object name and
 // the object cluster in a single key that can be used by informers.
@@ -9,22 +13,22 @@ import "strings"
 //
 // This is a temporary hack and should be replaced by thoughtful
 // and real support of logical cluster in the client-go layer
-func ToClusterAwareKey(clusterName, name string) string {
-	if clusterName != "" {
-		return clusterName + "#$#" + name
+func ToClusterAwareKey(clusterName logicalcluster.LogicalCluster, name string) string {
+	if !clusterName.Empty() {
+		return clusterName.String() + "#$#" + name
 	}
 
 	return name
 }
 
-// ToClusterAwareKey just allows extract the name and clusterName
+// SplitClusterAwareKey just allows extract the name and clusterName
 // from a Key initially created with ToClusterAwareKey
-func SplitClusterAwareKey(clusterAwareKey string) (clusterName, name string) {
+func SplitClusterAwareKey(clusterAwareKey string) (clusterName logicalcluster.LogicalCluster, name string) {
 	parts := strings.SplitN(clusterAwareKey, "#$#", 2)
 	if len(parts) == 1 {
 		// name only, no cluster
-		return "", parts[0]
+		return logicalcluster.LogicalCluster{}, parts[0]
 	}
 	// clusterName and name
-	return parts[0], parts[1]
+	return logicalcluster.New(parts[0]), parts[1]
 }

--- a/staging/src/k8s.io/code-generator/cmd/client-gen/generators/generator_for_clientset.go
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/generators/generator_for_clientset.go
@@ -84,6 +84,7 @@ func (g *genClientset) GenerateType(c *generator.Context, t *types.Type, w io.Wr
 		"NewDiscoveryClientForConfigOrDie":     c.Universe.Function(types.Name{Package: "k8s.io/client-go/discovery", Name: "NewDiscoveryClientForConfigOrDie"}),
 		"NewDiscoveryClient":                   c.Universe.Function(types.Name{Package: "k8s.io/client-go/discovery", Name: "NewDiscoveryClient"}),
 		"flowcontrolNewTokenBucketRateLimiter": c.Universe.Function(types.Name{Package: "k8s.io/client-go/util/flowcontrol", Name: "NewTokenBucketRateLimiter"}),
+		"LogicalCluster":                       c.Universe.Type(types.Name{Package: "github.com/kcp-dev/apimachinery/pkg/logicalcluster", Name: "LogicalCluster"}),
 	}
 	sw.Do(clusterInterface, m)
 	sw.Do(clusterTemplate, m)
@@ -106,7 +107,7 @@ func (g *genClientset) GenerateType(c *generator.Context, t *types.Type, w io.Wr
 
 var clusterInterface = `
 type ClusterInterface interface {
-	Cluster(name string) Interface
+	Cluster(name $.LogicalCluster|raw$) Interface
 }
 `
 
@@ -118,7 +119,7 @@ type Cluster struct {
 
 var setClusterTemplate = `
 // Cluster sets the cluster for a Clientset.
-func (c *Cluster) Cluster(name string) Interface {
+func (c *Cluster) Cluster(name $.LogicalCluster|raw$) Interface {
 	return &Clientset{
 		scopedClientset: c.scopedClientset,
 		cluster:         name,
@@ -152,7 +153,7 @@ var clientsetTemplate = `
 // version included in a Clientset.
 type Clientset struct {
 	*scopedClientset
-	cluster string
+	cluster $.LogicalCluster|raw$
 }
 `
 

--- a/staging/src/k8s.io/code-generator/cmd/client-gen/generators/generator_for_group.go
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/generators/generator_for_group.go
@@ -105,6 +105,7 @@ func (g *genGroup) GenerateType(c *generator.Context, t *types.Type, w io.Writer
 		"restRESTClientFor":                c.Universe.Function(types.Name{Package: "k8s.io/client-go/rest", Name: "RESTClientFor"}),
 		"restRESTClientForConfigAndClient": c.Universe.Function(types.Name{Package: "k8s.io/client-go/rest", Name: "RESTClientForConfigAndClient"}),
 		"SchemeGroupVersion":               c.Universe.Variable(types.Name{Package: path.Vendorless(g.inputPackage), Name: "SchemeGroupVersion"}),
+		"LogicalCluster":                   c.Universe.Type(types.Name{Package: "github.com/kcp-dev/apimachinery/pkg/logicalcluster", Name: "LogicalCluster"}),
 	}
 	sw.Do(groupInterfaceTemplate, m)
 	sw.Do(groupClientTemplate, m)
@@ -151,7 +152,7 @@ var groupClientTemplate = `
 // $.GroupGoName$$.Version$Client is used to interact with features provided by the $.groupName$ group.
 type $.GroupGoName$$.Version$Client struct {
 	restClient $.restRESTClientInterface|raw$
-	cluster    string
+	cluster    $.LogicalCluster|raw$
 }
 `
 
@@ -232,7 +233,7 @@ func New(c $.restRESTClientInterface|raw$) *$.GroupGoName$$.Version$Client {
 
 var newClientForRESTClientAndClusterTemplate = `
 // NewWithCluster creates a new $.GroupGoName$$.Version$Client for the given RESTClient and cluster.
-func NewWithCluster(c $.restRESTClientInterface|raw$, cluster string) *$.GroupGoName$$.Version$Client {
+func NewWithCluster(c $.restRESTClientInterface|raw$, cluster $.LogicalCluster|raw$) *$.GroupGoName$$.Version$Client {
 	return &$.GroupGoName$$.Version$Client{restClient: c, cluster: cluster}
 }
 `

--- a/staging/src/k8s.io/code-generator/cmd/client-gen/generators/generator_for_type.go
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/generators/generator_for_type.go
@@ -127,16 +127,17 @@ func (g *genClientForType) GenerateType(c *generator.Context, t *types.Type, w i
 		extendedMethod := extendedInterfaceMethod{
 			template: updatedVerbtemplate,
 			args: map[string]interface{}{
-				"type":          t,
-				"inputType":     &inputType,
-				"resultType":    &resultType,
-				"CreateOptions": c.Universe.Type(types.Name{Package: "k8s.io/apimachinery/pkg/apis/meta/v1", Name: "CreateOptions"}),
-				"GetOptions":    c.Universe.Type(types.Name{Package: "k8s.io/apimachinery/pkg/apis/meta/v1", Name: "GetOptions"}),
-				"ListOptions":   c.Universe.Type(types.Name{Package: "k8s.io/apimachinery/pkg/apis/meta/v1", Name: "ListOptions"}),
-				"UpdateOptions": c.Universe.Type(types.Name{Package: "k8s.io/apimachinery/pkg/apis/meta/v1", Name: "UpdateOptions"}),
-				"ApplyOptions":  c.Universe.Type(types.Name{Package: "k8s.io/apimachinery/pkg/apis/meta/v1", Name: "ApplyOptions"}),
-				"PatchType":     c.Universe.Type(types.Name{Package: "k8s.io/apimachinery/pkg/types", Name: "PatchType"}),
-				"jsonMarshal":   c.Universe.Type(types.Name{Package: "encoding/json", Name: "Marshal"}),
+				"type":           t,
+				"inputType":      &inputType,
+				"resultType":     &resultType,
+				"CreateOptions":  c.Universe.Type(types.Name{Package: "k8s.io/apimachinery/pkg/apis/meta/v1", Name: "CreateOptions"}),
+				"GetOptions":     c.Universe.Type(types.Name{Package: "k8s.io/apimachinery/pkg/apis/meta/v1", Name: "GetOptions"}),
+				"ListOptions":    c.Universe.Type(types.Name{Package: "k8s.io/apimachinery/pkg/apis/meta/v1", Name: "ListOptions"}),
+				"UpdateOptions":  c.Universe.Type(types.Name{Package: "k8s.io/apimachinery/pkg/apis/meta/v1", Name: "UpdateOptions"}),
+				"ApplyOptions":   c.Universe.Type(types.Name{Package: "k8s.io/apimachinery/pkg/apis/meta/v1", Name: "ApplyOptions"}),
+				"PatchType":      c.Universe.Type(types.Name{Package: "k8s.io/apimachinery/pkg/types", Name: "PatchType"}),
+				"jsonMarshal":    c.Universe.Type(types.Name{Package: "encoding/json", Name: "Marshal"}),
+				"LogicalCluster": c.Universe.Type(types.Name{Package: "github.com/kcp-dev/apimachinery/pkg/logicalcluster", Name: "LogicalCluster"}),
 			},
 		}
 		if e.HasVerb("apply") {
@@ -169,6 +170,7 @@ func (g *genClientForType) GenerateType(c *generator.Context, t *types.Type, w i
 		"RESTClientInterface":  c.Universe.Type(types.Name{Package: "k8s.io/client-go/rest", Name: "Interface"}),
 		"schemeParameterCodec": c.Universe.Variable(types.Name{Package: filepath.Join(g.clientsetPackage, "scheme"), Name: "ParameterCodec"}),
 		"jsonMarshal":          c.Universe.Type(types.Name{Package: "encoding/json", Name: "Marshal"}),
+		"LogicalCluster":       c.Universe.Type(types.Name{Package: "github.com/kcp-dev/apimachinery/pkg/logicalcluster", Name: "LogicalCluster"}),
 	}
 
 	if generateApply {
@@ -423,7 +425,7 @@ var structNamespaced = `
 // $.type|privatePlural$ implements $.type|public$Interface
 type $.type|privatePlural$ struct {
 	client  $.RESTClientInterface|raw$
-	cluster string
+	cluster $.LogicalCluster|raw$
 	ns      string
 }
 `
@@ -433,7 +435,7 @@ var structNonNamespaced = `
 // $.type|privatePlural$ implements $.type|public$Interface
 type $.type|privatePlural$ struct {
 	client  $.RESTClientInterface|raw$
-	cluster string
+	cluster $.LogicalCluster|raw$
 }
 `
 

--- a/staging/src/k8s.io/code-generator/examples/HyphenGroup/clientset/versioned/clientset.go
+++ b/staging/src/k8s.io/code-generator/examples/HyphenGroup/clientset/versioned/clientset.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"net/http"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
 	flowcontrol "k8s.io/client-go/util/flowcontrol"
@@ -29,7 +30,7 @@ import (
 )
 
 type ClusterInterface interface {
-	Cluster(name string) Interface
+	Cluster(name logicalcluster.LogicalCluster) Interface
 }
 
 type Cluster struct {
@@ -37,7 +38,7 @@ type Cluster struct {
 }
 
 // Cluster sets the cluster for a Clientset.
-func (c *Cluster) Cluster(name string) Interface {
+func (c *Cluster) Cluster(name logicalcluster.LogicalCluster) Interface {
 	return &Clientset{
 		scopedClientset: c.scopedClientset,
 		cluster:         name,
@@ -64,7 +65,7 @@ type Interface interface {
 // version included in a Clientset.
 type Clientset struct {
 	*scopedClientset
-	cluster string
+	cluster logicalcluster.LogicalCluster
 }
 
 // scopedClientset contains the clients for groups. Each group has exactly one

--- a/staging/src/k8s.io/code-generator/examples/HyphenGroup/clientset/versioned/typed/example/v1/clustertesttype.go
+++ b/staging/src/k8s.io/code-generator/examples/HyphenGroup/clientset/versioned/typed/example/v1/clustertesttype.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -57,7 +58,7 @@ type ClusterTestTypeInterface interface {
 // clusterTestTypes implements ClusterTestTypeInterface
 type clusterTestTypes struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 }
 
 // newClusterTestTypes returns a ClusterTestTypes

--- a/staging/src/k8s.io/code-generator/examples/HyphenGroup/clientset/versioned/typed/example/v1/example_client.go
+++ b/staging/src/k8s.io/code-generator/examples/HyphenGroup/clientset/versioned/typed/example/v1/example_client.go
@@ -21,6 +21,7 @@ package v1
 import (
 	"net/http"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	rest "k8s.io/client-go/rest"
 	v1 "k8s.io/code-generator/examples/HyphenGroup/apis/example/v1"
 	"k8s.io/code-generator/examples/HyphenGroup/clientset/versioned/scheme"
@@ -35,7 +36,7 @@ type ExampleGroupV1Interface interface {
 // ExampleGroupV1Client is used to interact with features provided by the example-group.hyphens.code-generator.k8s.io group.
 type ExampleGroupV1Client struct {
 	restClient rest.Interface
-	cluster    string
+	cluster    logicalcluster.LogicalCluster
 }
 
 func (c *ExampleGroupV1Client) ClusterTestTypes() ClusterTestTypeInterface {
@@ -91,7 +92,7 @@ func New(c rest.Interface) *ExampleGroupV1Client {
 }
 
 // NewWithCluster creates a new ExampleGroupV1Client for the given RESTClient and cluster.
-func NewWithCluster(c rest.Interface, cluster string) *ExampleGroupV1Client {
+func NewWithCluster(c rest.Interface, cluster logicalcluster.LogicalCluster) *ExampleGroupV1Client {
 	return &ExampleGroupV1Client{restClient: c, cluster: cluster}
 }
 

--- a/staging/src/k8s.io/code-generator/examples/HyphenGroup/clientset/versioned/typed/example/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/HyphenGroup/clientset/versioned/typed/example/v1/testtype.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
@@ -53,7 +54,7 @@ type TestTypeInterface interface {
 // testTypes implements TestTypeInterface
 type testTypes struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 	ns      string
 }
 

--- a/staging/src/k8s.io/code-generator/examples/MixedCase/clientset/versioned/clientset.go
+++ b/staging/src/k8s.io/code-generator/examples/MixedCase/clientset/versioned/clientset.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"net/http"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
 	flowcontrol "k8s.io/client-go/util/flowcontrol"
@@ -29,7 +30,7 @@ import (
 )
 
 type ClusterInterface interface {
-	Cluster(name string) Interface
+	Cluster(name logicalcluster.LogicalCluster) Interface
 }
 
 type Cluster struct {
@@ -37,7 +38,7 @@ type Cluster struct {
 }
 
 // Cluster sets the cluster for a Clientset.
-func (c *Cluster) Cluster(name string) Interface {
+func (c *Cluster) Cluster(name logicalcluster.LogicalCluster) Interface {
 	return &Clientset{
 		scopedClientset: c.scopedClientset,
 		cluster:         name,
@@ -64,7 +65,7 @@ type Interface interface {
 // version included in a Clientset.
 type Clientset struct {
 	*scopedClientset
-	cluster string
+	cluster logicalcluster.LogicalCluster
 }
 
 // scopedClientset contains the clients for groups. Each group has exactly one

--- a/staging/src/k8s.io/code-generator/examples/MixedCase/clientset/versioned/typed/example/v1/clustertesttype.go
+++ b/staging/src/k8s.io/code-generator/examples/MixedCase/clientset/versioned/typed/example/v1/clustertesttype.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -58,7 +59,7 @@ type ClusterTestTypeInterface interface {
 // clusterTestTypes implements ClusterTestTypeInterface
 type clusterTestTypes struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 }
 
 // newClusterTestTypes returns a ClusterTestTypes

--- a/staging/src/k8s.io/code-generator/examples/MixedCase/clientset/versioned/typed/example/v1/example_client.go
+++ b/staging/src/k8s.io/code-generator/examples/MixedCase/clientset/versioned/typed/example/v1/example_client.go
@@ -21,6 +21,7 @@ package v1
 import (
 	"net/http"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	rest "k8s.io/client-go/rest"
 	v1 "k8s.io/code-generator/examples/MixedCase/apis/example/v1"
 	"k8s.io/code-generator/examples/MixedCase/clientset/versioned/scheme"
@@ -35,7 +36,7 @@ type ExampleV1Interface interface {
 // ExampleV1Client is used to interact with features provided by the example.crd.code-generator.k8s.io group.
 type ExampleV1Client struct {
 	restClient rest.Interface
-	cluster    string
+	cluster    logicalcluster.LogicalCluster
 }
 
 func (c *ExampleV1Client) ClusterTestTypes() ClusterTestTypeInterface {
@@ -91,7 +92,7 @@ func New(c rest.Interface) *ExampleV1Client {
 }
 
 // NewWithCluster creates a new ExampleV1Client for the given RESTClient and cluster.
-func NewWithCluster(c rest.Interface, cluster string) *ExampleV1Client {
+func NewWithCluster(c rest.Interface, cluster logicalcluster.LogicalCluster) *ExampleV1Client {
 	return &ExampleV1Client{restClient: c, cluster: cluster}
 }
 

--- a/staging/src/k8s.io/code-generator/examples/MixedCase/clientset/versioned/typed/example/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/MixedCase/clientset/versioned/typed/example/v1/testtype.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
@@ -53,7 +54,7 @@ type TestTypeInterface interface {
 // testTypes implements TestTypeInterface
 type testTypes struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 	ns      string
 }
 

--- a/staging/src/k8s.io/code-generator/examples/apiserver/clientset/internalversion/clientset.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/clientset/internalversion/clientset.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"net/http"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
 	flowcontrol "k8s.io/client-go/util/flowcontrol"
@@ -31,7 +32,7 @@ import (
 )
 
 type ClusterInterface interface {
-	Cluster(name string) Interface
+	Cluster(name logicalcluster.LogicalCluster) Interface
 }
 
 type Cluster struct {
@@ -39,7 +40,7 @@ type Cluster struct {
 }
 
 // Cluster sets the cluster for a Clientset.
-func (c *Cluster) Cluster(name string) Interface {
+func (c *Cluster) Cluster(name logicalcluster.LogicalCluster) Interface {
 	return &Clientset{
 		scopedClientset: c.scopedClientset,
 		cluster:         name,
@@ -68,7 +69,7 @@ type Interface interface {
 // version included in a Clientset.
 type Clientset struct {
 	*scopedClientset
-	cluster string
+	cluster logicalcluster.LogicalCluster
 }
 
 // scopedClientset contains the clients for groups. Each group has exactly one

--- a/staging/src/k8s.io/code-generator/examples/apiserver/clientset/internalversion/typed/example/internalversion/example_client.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/clientset/internalversion/typed/example/internalversion/example_client.go
@@ -21,6 +21,7 @@ package internalversion
 import (
 	"net/http"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	rest "k8s.io/client-go/rest"
 	"k8s.io/code-generator/examples/apiserver/clientset/internalversion/scheme"
 )
@@ -33,7 +34,7 @@ type ExampleInterface interface {
 // ExampleClient is used to interact with features provided by the example.apiserver.code-generator.k8s.io group.
 type ExampleClient struct {
 	restClient rest.Interface
-	cluster    string
+	cluster    logicalcluster.LogicalCluster
 }
 
 func (c *ExampleClient) TestTypes(namespace string) TestTypeInterface {
@@ -85,7 +86,7 @@ func New(c rest.Interface) *ExampleClient {
 }
 
 // NewWithCluster creates a new ExampleClient for the given RESTClient and cluster.
-func NewWithCluster(c rest.Interface, cluster string) *ExampleClient {
+func NewWithCluster(c rest.Interface, cluster logicalcluster.LogicalCluster) *ExampleClient {
 	return &ExampleClient{restClient: c, cluster: cluster}
 }
 

--- a/staging/src/k8s.io/code-generator/examples/apiserver/clientset/internalversion/typed/example/internalversion/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/clientset/internalversion/typed/example/internalversion/testtype.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
@@ -53,7 +54,7 @@ type TestTypeInterface interface {
 // testTypes implements TestTypeInterface
 type testTypes struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 	ns      string
 }
 

--- a/staging/src/k8s.io/code-generator/examples/apiserver/clientset/internalversion/typed/example2/internalversion/example2_client.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/clientset/internalversion/typed/example2/internalversion/example2_client.go
@@ -21,6 +21,7 @@ package internalversion
 import (
 	"net/http"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	rest "k8s.io/client-go/rest"
 	"k8s.io/code-generator/examples/apiserver/clientset/internalversion/scheme"
 )
@@ -33,7 +34,7 @@ type SecondExampleInterface interface {
 // SecondExampleClient is used to interact with features provided by the example.test.apiserver.code-generator.k8s.io group.
 type SecondExampleClient struct {
 	restClient rest.Interface
-	cluster    string
+	cluster    logicalcluster.LogicalCluster
 }
 
 func (c *SecondExampleClient) TestTypes() TestTypeInterface {
@@ -85,7 +86,7 @@ func New(c rest.Interface) *SecondExampleClient {
 }
 
 // NewWithCluster creates a new SecondExampleClient for the given RESTClient and cluster.
-func NewWithCluster(c rest.Interface, cluster string) *SecondExampleClient {
+func NewWithCluster(c rest.Interface, cluster logicalcluster.LogicalCluster) *SecondExampleClient {
 	return &SecondExampleClient{restClient: c, cluster: cluster}
 }
 

--- a/staging/src/k8s.io/code-generator/examples/apiserver/clientset/internalversion/typed/example2/internalversion/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/clientset/internalversion/typed/example2/internalversion/testtype.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
@@ -53,7 +54,7 @@ type TestTypeInterface interface {
 // testTypes implements TestTypeInterface
 type testTypes struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 }
 
 // newTestTypes returns a TestTypes

--- a/staging/src/k8s.io/code-generator/examples/apiserver/clientset/internalversion/typed/example3.io/internalversion/example3.io_client.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/clientset/internalversion/typed/example3.io/internalversion/example3.io_client.go
@@ -21,6 +21,7 @@ package internalversion
 import (
 	"net/http"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	rest "k8s.io/client-go/rest"
 	"k8s.io/code-generator/examples/apiserver/clientset/internalversion/scheme"
 )
@@ -33,7 +34,7 @@ type ThirdExampleInterface interface {
 // ThirdExampleClient is used to interact with features provided by the example.dots.apiserver.code-generator.k8s.io group.
 type ThirdExampleClient struct {
 	restClient rest.Interface
-	cluster    string
+	cluster    logicalcluster.LogicalCluster
 }
 
 func (c *ThirdExampleClient) TestTypes(namespace string) TestTypeInterface {
@@ -85,7 +86,7 @@ func New(c rest.Interface) *ThirdExampleClient {
 }
 
 // NewWithCluster creates a new ThirdExampleClient for the given RESTClient and cluster.
-func NewWithCluster(c rest.Interface, cluster string) *ThirdExampleClient {
+func NewWithCluster(c rest.Interface, cluster logicalcluster.LogicalCluster) *ThirdExampleClient {
 	return &ThirdExampleClient{restClient: c, cluster: cluster}
 }
 

--- a/staging/src/k8s.io/code-generator/examples/apiserver/clientset/internalversion/typed/example3.io/internalversion/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/clientset/internalversion/typed/example3.io/internalversion/testtype.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
@@ -53,7 +54,7 @@ type TestTypeInterface interface {
 // testTypes implements TestTypeInterface
 type testTypes struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 	ns      string
 }
 

--- a/staging/src/k8s.io/code-generator/examples/apiserver/clientset/versioned/clientset.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/clientset/versioned/clientset.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"net/http"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
 	flowcontrol "k8s.io/client-go/util/flowcontrol"
@@ -31,7 +32,7 @@ import (
 )
 
 type ClusterInterface interface {
-	Cluster(name string) Interface
+	Cluster(name logicalcluster.LogicalCluster) Interface
 }
 
 type Cluster struct {
@@ -39,7 +40,7 @@ type Cluster struct {
 }
 
 // Cluster sets the cluster for a Clientset.
-func (c *Cluster) Cluster(name string) Interface {
+func (c *Cluster) Cluster(name logicalcluster.LogicalCluster) Interface {
 	return &Clientset{
 		scopedClientset: c.scopedClientset,
 		cluster:         name,
@@ -68,7 +69,7 @@ type Interface interface {
 // version included in a Clientset.
 type Clientset struct {
 	*scopedClientset
-	cluster string
+	cluster logicalcluster.LogicalCluster
 }
 
 // scopedClientset contains the clients for groups. Each group has exactly one

--- a/staging/src/k8s.io/code-generator/examples/apiserver/clientset/versioned/typed/example/v1/example_client.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/clientset/versioned/typed/example/v1/example_client.go
@@ -21,6 +21,7 @@ package v1
 import (
 	"net/http"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	rest "k8s.io/client-go/rest"
 	v1 "k8s.io/code-generator/examples/apiserver/apis/example/v1"
 	"k8s.io/code-generator/examples/apiserver/clientset/versioned/scheme"
@@ -34,7 +35,7 @@ type ExampleV1Interface interface {
 // ExampleV1Client is used to interact with features provided by the example.apiserver.code-generator.k8s.io group.
 type ExampleV1Client struct {
 	restClient rest.Interface
-	cluster    string
+	cluster    logicalcluster.LogicalCluster
 }
 
 func (c *ExampleV1Client) TestTypes(namespace string) TestTypeInterface {
@@ -86,7 +87,7 @@ func New(c rest.Interface) *ExampleV1Client {
 }
 
 // NewWithCluster creates a new ExampleV1Client for the given RESTClient and cluster.
-func NewWithCluster(c rest.Interface, cluster string) *ExampleV1Client {
+func NewWithCluster(c rest.Interface, cluster logicalcluster.LogicalCluster) *ExampleV1Client {
 	return &ExampleV1Client{restClient: c, cluster: cluster}
 }
 

--- a/staging/src/k8s.io/code-generator/examples/apiserver/clientset/versioned/typed/example/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/clientset/versioned/typed/example/v1/testtype.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
@@ -53,7 +54,7 @@ type TestTypeInterface interface {
 // testTypes implements TestTypeInterface
 type testTypes struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 	ns      string
 }
 

--- a/staging/src/k8s.io/code-generator/examples/apiserver/clientset/versioned/typed/example2/v1/example2_client.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/clientset/versioned/typed/example2/v1/example2_client.go
@@ -21,6 +21,7 @@ package v1
 import (
 	"net/http"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	rest "k8s.io/client-go/rest"
 	v1 "k8s.io/code-generator/examples/apiserver/apis/example2/v1"
 	"k8s.io/code-generator/examples/apiserver/clientset/versioned/scheme"
@@ -34,7 +35,7 @@ type SecondExampleV1Interface interface {
 // SecondExampleV1Client is used to interact with features provided by the example.test.apiserver.code-generator.k8s.io group.
 type SecondExampleV1Client struct {
 	restClient rest.Interface
-	cluster    string
+	cluster    logicalcluster.LogicalCluster
 }
 
 func (c *SecondExampleV1Client) TestTypes(namespace string) TestTypeInterface {
@@ -86,7 +87,7 @@ func New(c rest.Interface) *SecondExampleV1Client {
 }
 
 // NewWithCluster creates a new SecondExampleV1Client for the given RESTClient and cluster.
-func NewWithCluster(c rest.Interface, cluster string) *SecondExampleV1Client {
+func NewWithCluster(c rest.Interface, cluster logicalcluster.LogicalCluster) *SecondExampleV1Client {
 	return &SecondExampleV1Client{restClient: c, cluster: cluster}
 }
 

--- a/staging/src/k8s.io/code-generator/examples/apiserver/clientset/versioned/typed/example2/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/clientset/versioned/typed/example2/v1/testtype.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
@@ -53,7 +54,7 @@ type TestTypeInterface interface {
 // testTypes implements TestTypeInterface
 type testTypes struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 	ns      string
 }
 

--- a/staging/src/k8s.io/code-generator/examples/apiserver/clientset/versioned/typed/example3.io/v1/example3.io_client.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/clientset/versioned/typed/example3.io/v1/example3.io_client.go
@@ -21,6 +21,7 @@ package v1
 import (
 	"net/http"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	rest "k8s.io/client-go/rest"
 	v1 "k8s.io/code-generator/examples/apiserver/apis/example3.io/v1"
 	"k8s.io/code-generator/examples/apiserver/clientset/versioned/scheme"
@@ -34,7 +35,7 @@ type ThirdExampleV1Interface interface {
 // ThirdExampleV1Client is used to interact with features provided by the example.dots.apiserver.code-generator.k8s.io group.
 type ThirdExampleV1Client struct {
 	restClient rest.Interface
-	cluster    string
+	cluster    logicalcluster.LogicalCluster
 }
 
 func (c *ThirdExampleV1Client) TestTypes(namespace string) TestTypeInterface {
@@ -86,7 +87,7 @@ func New(c rest.Interface) *ThirdExampleV1Client {
 }
 
 // NewWithCluster creates a new ThirdExampleV1Client for the given RESTClient and cluster.
-func NewWithCluster(c rest.Interface, cluster string) *ThirdExampleV1Client {
+func NewWithCluster(c rest.Interface, cluster logicalcluster.LogicalCluster) *ThirdExampleV1Client {
 	return &ThirdExampleV1Client{restClient: c, cluster: cluster}
 }
 

--- a/staging/src/k8s.io/code-generator/examples/apiserver/clientset/versioned/typed/example3.io/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/clientset/versioned/typed/example3.io/v1/testtype.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
@@ -53,7 +54,7 @@ type TestTypeInterface interface {
 // testTypes implements TestTypeInterface
 type testTypes struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 	ns      string
 }
 

--- a/staging/src/k8s.io/code-generator/examples/crd/clientset/versioned/clientset.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/clientset/versioned/clientset.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"net/http"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
 	flowcontrol "k8s.io/client-go/util/flowcontrol"
@@ -30,7 +31,7 @@ import (
 )
 
 type ClusterInterface interface {
-	Cluster(name string) Interface
+	Cluster(name logicalcluster.LogicalCluster) Interface
 }
 
 type Cluster struct {
@@ -38,7 +39,7 @@ type Cluster struct {
 }
 
 // Cluster sets the cluster for a Clientset.
-func (c *Cluster) Cluster(name string) Interface {
+func (c *Cluster) Cluster(name logicalcluster.LogicalCluster) Interface {
 	return &Clientset{
 		scopedClientset: c.scopedClientset,
 		cluster:         name,
@@ -66,7 +67,7 @@ type Interface interface {
 // version included in a Clientset.
 type Clientset struct {
 	*scopedClientset
-	cluster string
+	cluster logicalcluster.LogicalCluster
 }
 
 // scopedClientset contains the clients for groups. Each group has exactly one

--- a/staging/src/k8s.io/code-generator/examples/crd/clientset/versioned/typed/example/v1/clustertesttype.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/clientset/versioned/typed/example/v1/clustertesttype.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -57,7 +58,7 @@ type ClusterTestTypeInterface interface {
 // clusterTestTypes implements ClusterTestTypeInterface
 type clusterTestTypes struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 }
 
 // newClusterTestTypes returns a ClusterTestTypes

--- a/staging/src/k8s.io/code-generator/examples/crd/clientset/versioned/typed/example/v1/example_client.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/clientset/versioned/typed/example/v1/example_client.go
@@ -21,6 +21,7 @@ package v1
 import (
 	"net/http"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	rest "k8s.io/client-go/rest"
 	v1 "k8s.io/code-generator/examples/crd/apis/example/v1"
 	"k8s.io/code-generator/examples/crd/clientset/versioned/scheme"
@@ -35,7 +36,7 @@ type ExampleV1Interface interface {
 // ExampleV1Client is used to interact with features provided by the example.crd.code-generator.k8s.io group.
 type ExampleV1Client struct {
 	restClient rest.Interface
-	cluster    string
+	cluster    logicalcluster.LogicalCluster
 }
 
 func (c *ExampleV1Client) ClusterTestTypes() ClusterTestTypeInterface {
@@ -91,7 +92,7 @@ func New(c rest.Interface) *ExampleV1Client {
 }
 
 // NewWithCluster creates a new ExampleV1Client for the given RESTClient and cluster.
-func NewWithCluster(c rest.Interface, cluster string) *ExampleV1Client {
+func NewWithCluster(c rest.Interface, cluster logicalcluster.LogicalCluster) *ExampleV1Client {
 	return &ExampleV1Client{restClient: c, cluster: cluster}
 }
 

--- a/staging/src/k8s.io/code-generator/examples/crd/clientset/versioned/typed/example/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/clientset/versioned/typed/example/v1/testtype.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
@@ -53,7 +54,7 @@ type TestTypeInterface interface {
 // testTypes implements TestTypeInterface
 type testTypes struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 	ns      string
 }
 

--- a/staging/src/k8s.io/code-generator/examples/crd/clientset/versioned/typed/example2/v1/example2_client.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/clientset/versioned/typed/example2/v1/example2_client.go
@@ -21,6 +21,7 @@ package v1
 import (
 	"net/http"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	rest "k8s.io/client-go/rest"
 	v1 "k8s.io/code-generator/examples/crd/apis/example2/v1"
 	"k8s.io/code-generator/examples/crd/clientset/versioned/scheme"
@@ -34,7 +35,7 @@ type SecondExampleV1Interface interface {
 // SecondExampleV1Client is used to interact with features provided by the example.test.crd.code-generator.k8s.io group.
 type SecondExampleV1Client struct {
 	restClient rest.Interface
-	cluster    string
+	cluster    logicalcluster.LogicalCluster
 }
 
 func (c *SecondExampleV1Client) TestTypes(namespace string) TestTypeInterface {
@@ -86,7 +87,7 @@ func New(c rest.Interface) *SecondExampleV1Client {
 }
 
 // NewWithCluster creates a new SecondExampleV1Client for the given RESTClient and cluster.
-func NewWithCluster(c rest.Interface, cluster string) *SecondExampleV1Client {
+func NewWithCluster(c rest.Interface, cluster logicalcluster.LogicalCluster) *SecondExampleV1Client {
 	return &SecondExampleV1Client{restClient: c, cluster: cluster}
 }
 

--- a/staging/src/k8s.io/code-generator/examples/crd/clientset/versioned/typed/example2/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/clientset/versioned/typed/example2/v1/testtype.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
@@ -53,7 +54,7 @@ type TestTypeInterface interface {
 // testTypes implements TestTypeInterface
 type testTypes struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 	ns      string
 }
 

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/clientset.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/clientset.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"net/http"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
 	flowcontrol "k8s.io/client-go/util/flowcontrol"
@@ -30,7 +31,7 @@ import (
 )
 
 type ClusterInterface interface {
-	Cluster(name string) Interface
+	Cluster(name logicalcluster.LogicalCluster) Interface
 }
 
 type Cluster struct {
@@ -38,7 +39,7 @@ type Cluster struct {
 }
 
 // Cluster sets the cluster for a Clientset.
-func (c *Cluster) Cluster(name string) Interface {
+func (c *Cluster) Cluster(name logicalcluster.LogicalCluster) Interface {
 	return &Clientset{
 		scopedClientset: c.scopedClientset,
 		cluster:         name,
@@ -66,7 +67,7 @@ type Interface interface {
 // version included in a Clientset.
 type Clientset struct {
 	*scopedClientset
-	cluster string
+	cluster logicalcluster.LogicalCluster
 }
 
 // scopedClientset contains the clients for groups. Each group has exactly one

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1/apiregistration_client.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1/apiregistration_client.go
@@ -21,6 +21,7 @@ package v1
 import (
 	"net/http"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	rest "k8s.io/client-go/rest"
 	v1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 	"k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
@@ -34,7 +35,7 @@ type ApiregistrationV1Interface interface {
 // ApiregistrationV1Client is used to interact with features provided by the apiregistration.k8s.io group.
 type ApiregistrationV1Client struct {
 	restClient rest.Interface
-	cluster    string
+	cluster    logicalcluster.LogicalCluster
 }
 
 func (c *ApiregistrationV1Client) APIServices() APIServiceInterface {
@@ -86,7 +87,7 @@ func New(c rest.Interface) *ApiregistrationV1Client {
 }
 
 // NewWithCluster creates a new ApiregistrationV1Client for the given RESTClient and cluster.
-func NewWithCluster(c rest.Interface, cluster string) *ApiregistrationV1Client {
+func NewWithCluster(c rest.Interface, cluster logicalcluster.LogicalCluster) *ApiregistrationV1Client {
 	return &ApiregistrationV1Client{restClient: c, cluster: cluster}
 }
 

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1/apiservice.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1/apiservice.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
@@ -53,7 +54,7 @@ type APIServiceInterface interface {
 // aPIServices implements APIServiceInterface
 type aPIServices struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 }
 
 // newAPIServices returns a APIServices

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1beta1/apiregistration_client.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1beta1/apiregistration_client.go
@@ -21,6 +21,7 @@ package v1beta1
 import (
 	"net/http"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	rest "k8s.io/client-go/rest"
 	v1beta1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1"
 	"k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
@@ -34,7 +35,7 @@ type ApiregistrationV1beta1Interface interface {
 // ApiregistrationV1beta1Client is used to interact with features provided by the apiregistration.k8s.io group.
 type ApiregistrationV1beta1Client struct {
 	restClient rest.Interface
-	cluster    string
+	cluster    logicalcluster.LogicalCluster
 }
 
 func (c *ApiregistrationV1beta1Client) APIServices() APIServiceInterface {
@@ -86,7 +87,7 @@ func New(c rest.Interface) *ApiregistrationV1beta1Client {
 }
 
 // NewWithCluster creates a new ApiregistrationV1beta1Client for the given RESTClient and cluster.
-func NewWithCluster(c rest.Interface, cluster string) *ApiregistrationV1beta1Client {
+func NewWithCluster(c rest.Interface, cluster logicalcluster.LogicalCluster) *ApiregistrationV1beta1Client {
 	return &ApiregistrationV1beta1Client{restClient: c, cluster: cluster}
 }
 

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1beta1/apiservice.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1beta1/apiservice.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
@@ -53,7 +54,7 @@ type APIServiceInterface interface {
 // aPIServices implements APIServiceInterface
 type aPIServices struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 }
 
 // newAPIServices returns a APIServices

--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/aggregator/aggregator.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/aggregator/aggregator.go
@@ -26,6 +26,7 @@ import (
 	restful "github.com/emicklei/go-restful"
 
 	"k8s.io/klog/v2"
+	"github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 
 	"k8s.io/apiserver/pkg/server"
 	v1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
@@ -99,7 +100,7 @@ func BuildAndRegisterAggregator(downloader *Downloader, delegationTarget server.
 			// ignore errors for the empty delegate we attach at the end the chain
 			// atm the empty delegate returns 503 when the server hasn't been fully initialized
 			// and the spec downloader only silences 404s
-			if len(delegate.ListedPaths("")) == 0 && delegate.NextDelegate() == nil {
+			if len(delegate.ListedPaths(logicalcluster.New(""))) == 0 && delegate.NextDelegate() == nil {
 				continue
 			}
 			return nil, err

--- a/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/clientset.go
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/clientset.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"net/http"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
 	flowcontrol "k8s.io/client-go/util/flowcontrol"
@@ -30,7 +31,7 @@ import (
 )
 
 type ClusterInterface interface {
-	Cluster(name string) Interface
+	Cluster(name logicalcluster.LogicalCluster) Interface
 }
 
 type Cluster struct {
@@ -38,7 +39,7 @@ type Cluster struct {
 }
 
 // Cluster sets the cluster for a Clientset.
-func (c *Cluster) Cluster(name string) Interface {
+func (c *Cluster) Cluster(name logicalcluster.LogicalCluster) Interface {
 	return &Clientset{
 		scopedClientset: c.scopedClientset,
 		cluster:         name,
@@ -66,7 +67,7 @@ type Interface interface {
 // version included in a Clientset.
 type Clientset struct {
 	*scopedClientset
-	cluster string
+	cluster logicalcluster.LogicalCluster
 }
 
 // scopedClientset contains the clients for groups. Each group has exactly one

--- a/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1alpha1/metrics_client.go
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1alpha1/metrics_client.go
@@ -21,6 +21,7 @@ package v1alpha1
 import (
 	"net/http"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	rest "k8s.io/client-go/rest"
 	v1alpha1 "k8s.io/metrics/pkg/apis/metrics/v1alpha1"
 	"k8s.io/metrics/pkg/client/clientset/versioned/scheme"
@@ -35,7 +36,7 @@ type MetricsV1alpha1Interface interface {
 // MetricsV1alpha1Client is used to interact with features provided by the metrics.k8s.io group.
 type MetricsV1alpha1Client struct {
 	restClient rest.Interface
-	cluster    string
+	cluster    logicalcluster.LogicalCluster
 }
 
 func (c *MetricsV1alpha1Client) NodeMetricses() NodeMetricsInterface {
@@ -91,7 +92,7 @@ func New(c rest.Interface) *MetricsV1alpha1Client {
 }
 
 // NewWithCluster creates a new MetricsV1alpha1Client for the given RESTClient and cluster.
-func NewWithCluster(c rest.Interface, cluster string) *MetricsV1alpha1Client {
+func NewWithCluster(c rest.Interface, cluster logicalcluster.LogicalCluster) *MetricsV1alpha1Client {
 	return &MetricsV1alpha1Client{restClient: c, cluster: cluster}
 }
 

--- a/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1alpha1/nodemetrics.go
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1alpha1/nodemetrics.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
@@ -46,7 +47,7 @@ type NodeMetricsInterface interface {
 // nodeMetricses implements NodeMetricsInterface
 type nodeMetricses struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 }
 
 // newNodeMetricses returns a NodeMetricses

--- a/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1alpha1/podmetrics.go
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1alpha1/podmetrics.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
@@ -46,7 +47,7 @@ type PodMetricsInterface interface {
 // podMetricses implements PodMetricsInterface
 type podMetricses struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 	ns      string
 }
 

--- a/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1/metrics_client.go
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1/metrics_client.go
@@ -21,6 +21,7 @@ package v1beta1
 import (
 	"net/http"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	rest "k8s.io/client-go/rest"
 	v1beta1 "k8s.io/metrics/pkg/apis/metrics/v1beta1"
 	"k8s.io/metrics/pkg/client/clientset/versioned/scheme"
@@ -35,7 +36,7 @@ type MetricsV1beta1Interface interface {
 // MetricsV1beta1Client is used to interact with features provided by the metrics.k8s.io group.
 type MetricsV1beta1Client struct {
 	restClient rest.Interface
-	cluster    string
+	cluster    logicalcluster.LogicalCluster
 }
 
 func (c *MetricsV1beta1Client) NodeMetricses() NodeMetricsInterface {
@@ -91,7 +92,7 @@ func New(c rest.Interface) *MetricsV1beta1Client {
 }
 
 // NewWithCluster creates a new MetricsV1beta1Client for the given RESTClient and cluster.
-func NewWithCluster(c rest.Interface, cluster string) *MetricsV1beta1Client {
+func NewWithCluster(c rest.Interface, cluster logicalcluster.LogicalCluster) *MetricsV1beta1Client {
 	return &MetricsV1beta1Client{restClient: c, cluster: cluster}
 }
 

--- a/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1/nodemetrics.go
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1/nodemetrics.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
@@ -46,7 +47,7 @@ type NodeMetricsInterface interface {
 // nodeMetricses implements NodeMetricsInterface
 type nodeMetricses struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 }
 
 // newNodeMetricses returns a NodeMetricses

--- a/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1/podmetrics.go
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1/podmetrics.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
@@ -46,7 +47,7 @@ type PodMetricsInterface interface {
 // podMetricses implements PodMetricsInterface
 type podMetricses struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 	ns      string
 }
 

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/clientset.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/clientset.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"net/http"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
 	flowcontrol "k8s.io/client-go/util/flowcontrol"
@@ -30,7 +31,7 @@ import (
 )
 
 type ClusterInterface interface {
-	Cluster(name string) Interface
+	Cluster(name logicalcluster.LogicalCluster) Interface
 }
 
 type Cluster struct {
@@ -38,7 +39,7 @@ type Cluster struct {
 }
 
 // Cluster sets the cluster for a Clientset.
-func (c *Cluster) Cluster(name string) Interface {
+func (c *Cluster) Cluster(name logicalcluster.LogicalCluster) Interface {
 	return &Clientset{
 		scopedClientset: c.scopedClientset,
 		cluster:         name,
@@ -66,7 +67,7 @@ type Interface interface {
 // version included in a Clientset.
 type Clientset struct {
 	*scopedClientset
-	cluster string
+	cluster logicalcluster.LogicalCluster
 }
 
 // scopedClientset contains the clients for groups. Each group has exactly one

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1alpha1/fischer.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1alpha1/fischer.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
@@ -52,7 +53,7 @@ type FischerInterface interface {
 // fischers implements FischerInterface
 type fischers struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 }
 
 // newFischers returns a Fischers

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1alpha1/flunder.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1alpha1/flunder.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
@@ -53,7 +54,7 @@ type FlunderInterface interface {
 // flunders implements FlunderInterface
 type flunders struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 	ns      string
 }
 

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1alpha1/wardle_client.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1alpha1/wardle_client.go
@@ -21,6 +21,7 @@ package v1alpha1
 import (
 	"net/http"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	rest "k8s.io/client-go/rest"
 	v1alpha1 "k8s.io/sample-apiserver/pkg/apis/wardle/v1alpha1"
 	"k8s.io/sample-apiserver/pkg/generated/clientset/versioned/scheme"
@@ -35,7 +36,7 @@ type WardleV1alpha1Interface interface {
 // WardleV1alpha1Client is used to interact with features provided by the wardle.example.com group.
 type WardleV1alpha1Client struct {
 	restClient rest.Interface
-	cluster    string
+	cluster    logicalcluster.LogicalCluster
 }
 
 func (c *WardleV1alpha1Client) Fischers() FischerInterface {
@@ -91,7 +92,7 @@ func New(c rest.Interface) *WardleV1alpha1Client {
 }
 
 // NewWithCluster creates a new WardleV1alpha1Client for the given RESTClient and cluster.
-func NewWithCluster(c rest.Interface, cluster string) *WardleV1alpha1Client {
+func NewWithCluster(c rest.Interface, cluster logicalcluster.LogicalCluster) *WardleV1alpha1Client {
 	return &WardleV1alpha1Client{restClient: c, cluster: cluster}
 }
 

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1beta1/flunder.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1beta1/flunder.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
@@ -53,7 +54,7 @@ type FlunderInterface interface {
 // flunders implements FlunderInterface
 type flunders struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 	ns      string
 }
 

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1beta1/wardle_client.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1beta1/wardle_client.go
@@ -21,6 +21,7 @@ package v1beta1
 import (
 	"net/http"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	rest "k8s.io/client-go/rest"
 	v1beta1 "k8s.io/sample-apiserver/pkg/apis/wardle/v1beta1"
 	"k8s.io/sample-apiserver/pkg/generated/clientset/versioned/scheme"
@@ -34,7 +35,7 @@ type WardleV1beta1Interface interface {
 // WardleV1beta1Client is used to interact with features provided by the wardle.example.com group.
 type WardleV1beta1Client struct {
 	restClient rest.Interface
-	cluster    string
+	cluster    logicalcluster.LogicalCluster
 }
 
 func (c *WardleV1beta1Client) Flunders(namespace string) FlunderInterface {
@@ -86,7 +87,7 @@ func New(c rest.Interface) *WardleV1beta1Client {
 }
 
 // NewWithCluster creates a new WardleV1beta1Client for the given RESTClient and cluster.
-func NewWithCluster(c rest.Interface, cluster string) *WardleV1beta1Client {
+func NewWithCluster(c rest.Interface, cluster logicalcluster.LogicalCluster) *WardleV1beta1Client {
 	return &WardleV1beta1Client{restClient: c, cluster: cluster}
 }
 

--- a/staging/src/k8s.io/sample-controller/pkg/generated/clientset/versioned/clientset.go
+++ b/staging/src/k8s.io/sample-controller/pkg/generated/clientset/versioned/clientset.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"net/http"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
 	flowcontrol "k8s.io/client-go/util/flowcontrol"
@@ -29,7 +30,7 @@ import (
 )
 
 type ClusterInterface interface {
-	Cluster(name string) Interface
+	Cluster(name logicalcluster.LogicalCluster) Interface
 }
 
 type Cluster struct {
@@ -37,7 +38,7 @@ type Cluster struct {
 }
 
 // Cluster sets the cluster for a Clientset.
-func (c *Cluster) Cluster(name string) Interface {
+func (c *Cluster) Cluster(name logicalcluster.LogicalCluster) Interface {
 	return &Clientset{
 		scopedClientset: c.scopedClientset,
 		cluster:         name,
@@ -64,7 +65,7 @@ type Interface interface {
 // version included in a Clientset.
 type Clientset struct {
 	*scopedClientset
-	cluster string
+	cluster logicalcluster.LogicalCluster
 }
 
 // scopedClientset contains the clients for groups. Each group has exactly one

--- a/staging/src/k8s.io/sample-controller/pkg/generated/clientset/versioned/typed/samplecontroller/v1alpha1/foo.go
+++ b/staging/src/k8s.io/sample-controller/pkg/generated/clientset/versioned/typed/samplecontroller/v1alpha1/foo.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"time"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
@@ -53,7 +54,7 @@ type FooInterface interface {
 // foos implements FooInterface
 type foos struct {
 	client  rest.Interface
-	cluster string
+	cluster logicalcluster.LogicalCluster
 	ns      string
 }
 

--- a/staging/src/k8s.io/sample-controller/pkg/generated/clientset/versioned/typed/samplecontroller/v1alpha1/samplecontroller_client.go
+++ b/staging/src/k8s.io/sample-controller/pkg/generated/clientset/versioned/typed/samplecontroller/v1alpha1/samplecontroller_client.go
@@ -21,6 +21,7 @@ package v1alpha1
 import (
 	"net/http"
 
+	logicalcluster "github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	rest "k8s.io/client-go/rest"
 	v1alpha1 "k8s.io/sample-controller/pkg/apis/samplecontroller/v1alpha1"
 	"k8s.io/sample-controller/pkg/generated/clientset/versioned/scheme"
@@ -34,7 +35,7 @@ type SamplecontrollerV1alpha1Interface interface {
 // SamplecontrollerV1alpha1Client is used to interact with features provided by the samplecontroller.k8s.io group.
 type SamplecontrollerV1alpha1Client struct {
 	restClient rest.Interface
-	cluster    string
+	cluster    logicalcluster.LogicalCluster
 }
 
 func (c *SamplecontrollerV1alpha1Client) Foos(namespace string) FooInterface {
@@ -86,7 +87,7 @@ func New(c rest.Interface) *SamplecontrollerV1alpha1Client {
 }
 
 // NewWithCluster creates a new SamplecontrollerV1alpha1Client for the given RESTClient and cluster.
-func NewWithCluster(c rest.Interface, cluster string) *SamplecontrollerV1alpha1Client {
+func NewWithCluster(c rest.Interface, cluster logicalcluster.LogicalCluster) *SamplecontrollerV1alpha1Client {
 	return &SamplecontrollerV1alpha1Client{restClient: c, cluster: cluster}
 }
 


### PR DESCRIPTION
- adding type safety
- abstract logical cluster retrival from objects (to prepare for deprecation of `metadata.clusterName`)
- prepare for switch to path semantics on the higher layers (i.e. open the door for multiple levels for orgs)