### PR TITLE
Update resource prefixes for bound CRDs based on APIExport identity

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go
@@ -30,6 +30,7 @@ import (
 
 	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
 
+	"github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 	apiextensionshelpers "k8s.io/apiextensions-apiserver/pkg/apihelpers"
 	apiextensionsinternal "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -48,7 +49,6 @@ import (
 	"k8s.io/apiextensions-apiserver/pkg/registry/customresource"
 	"k8s.io/apiextensions-apiserver/pkg/registry/customresource/tableconvertor"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
-	"github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -903,14 +903,17 @@ func (r *crdHandler) getOrCreateServingInfoFor(crd *apiextensionsv1.CustomResour
 				statusSpec,
 				scaleSpec,
 			),
-			crdConversionRESTOptionsGetter{
-				RESTOptionsGetter:     r.restOptionsGetter,
-				converter:             safeConverter,
-				decoderVersion:        schema.GroupVersion{Group: crd.Spec.Group, Version: v.Name},
-				encoderVersion:        schema.GroupVersion{Group: crd.Spec.Group, Version: storageVersion},
-				structuralSchemas:     structuralSchemas,
-				structuralSchemaGK:    kind.GroupKind(),
-				preserveUnknownFields: crd.Spec.PreserveUnknownFields,
+			apiBindingAwareCRDRESTOptionsGetter{
+				delegate: crdConversionRESTOptionsGetter{
+					RESTOptionsGetter:     r.restOptionsGetter,
+					converter:             safeConverter,
+					decoderVersion:        schema.GroupVersion{Group: crd.Spec.Group, Version: v.Name},
+					encoderVersion:        schema.GroupVersion{Group: crd.Spec.Group, Version: storageVersion},
+					structuralSchemas:     structuralSchemas,
+					structuralSchemaGK:    kind.GroupKind(),
+					preserveUnknownFields: crd.Spec.PreserveUnknownFields,
+				},
+				crd: crd,
 			},
 			crd.Status.AcceptedNames.Categories,
 			table,

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/kcp_rest_options_getter.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/kcp_rest_options_getter.go
@@ -1,0 +1,34 @@
+package apiserver
+
+import (
+	"fmt"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/registry/generic"
+)
+
+type apiBindingAwareCRDRESTOptionsGetter struct {
+	delegate generic.RESTOptionsGetter
+	crd      *apiextensionsv1.CustomResourceDefinition
+}
+
+func (t apiBindingAwareCRDRESTOptionsGetter) GetRESTOptions(resource schema.GroupResource) (generic.RESTOptions, error) {
+	ret, err := t.delegate.GetRESTOptions(resource)
+	if err != nil {
+		return ret, err
+	}
+
+	if _, bound := t.crd.Annotations["apis.kcp.dev/bound-crd"]; !bound {
+		return ret, nil
+	}
+
+	apiIdentity := t.crd.Annotations["apis.kcp.dev/identity"]
+	if apiIdentity == "" {
+		return generic.RESTOptions{}, fmt.Errorf("missing 'apis.kcp.dev/identity' annotation")
+	}
+
+	// Use a : to separate as it is a character that is not valid in CRD.spec.names.plural
+	ret.ResourcePrefix += ":" + apiIdentity
+
+	return ret, err
+}


### PR DESCRIPTION
Needed for https://github.com/kcp-dev/kcp/pull/877