### PR TITLE
Allow customizable keyfunc

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/informers/externalversions/factory.go
@@ -36,12 +36,15 @@ import (
 type SharedInformerOption func(*sharedInformerFactory) *sharedInformerFactory
 
 type sharedInformerFactory struct {
-	client           versioned.Interface
-	namespace        string
-	tweakListOptions internalinterfaces.TweakListOptionsFunc
-	lock             sync.Mutex
-	defaultResync    time.Duration
-	customResync     map[reflect.Type]time.Duration
+	client                       versioned.Interface
+	namespace                    string
+	tweakListOptions             internalinterfaces.TweakListOptionsFunc
+	lock                         sync.Mutex
+	defaultResync                time.Duration
+	customResync                 map[reflect.Type]time.Duration
+	extraClusterScopedIndexers   cache.Indexers
+	extraNamespaceScopedIndexers cache.Indexers
+	keyFunc                      cache.KeyFunc
 
 	informers map[reflect.Type]cache.SharedIndexInformer
 	// startedInformers is used for tracking which informers have been started.
@@ -75,6 +78,30 @@ func WithNamespace(namespace string) SharedInformerOption {
 	}
 }
 
+// WithExtraClusterScopedIndexers adds cluster scoped indexers on all informers of the configured SharedInformerFactory
+func WithExtraClusterScopedIndexers(indexers cache.Indexers) SharedInformerOption {
+	return func(factory *sharedInformerFactory) *sharedInformerFactory {
+		factory.extraClusterScopedIndexers = indexers
+		return factory
+	}
+}
+
+// WithExtraNamespaceScopedIndexers adds namespace scoped indexers on all informers of the configured SharedInformerFactory
+func WithExtraNamespaceScopedIndexers(indexers cache.Indexers) SharedInformerOption {
+	return func(factory *sharedInformerFactory) *sharedInformerFactory {
+		factory.extraNamespaceScopedIndexers = indexers
+		return factory
+	}
+}
+
+// WithKeyFunction sets a custom key function for all informers of the configured SharedInformerFactory
+func WithKeyFunction(keyFunc cache.KeyFunc) SharedInformerOption {
+	return func(factory *sharedInformerFactory) *sharedInformerFactory {
+		factory.keyFunc = keyFunc
+		return factory
+	}
+}
+
 // NewSharedInformerFactory constructs a new instance of sharedInformerFactory for all namespaces.
 func NewSharedInformerFactory(client versioned.Interface, defaultResync time.Duration) SharedInformerFactory {
 	return NewSharedInformerFactoryWithOptions(client, defaultResync)
@@ -91,12 +118,14 @@ func NewFilteredSharedInformerFactory(client versioned.Interface, defaultResync 
 // NewSharedInformerFactoryWithOptions constructs a new instance of a SharedInformerFactory with additional options.
 func NewSharedInformerFactoryWithOptions(client versioned.Interface, defaultResync time.Duration, options ...SharedInformerOption) SharedInformerFactory {
 	factory := &sharedInformerFactory{
-		client:           client,
-		namespace:        v1.NamespaceAll,
-		defaultResync:    defaultResync,
-		informers:        make(map[reflect.Type]cache.SharedIndexInformer),
-		startedInformers: make(map[reflect.Type]bool),
-		customResync:     make(map[reflect.Type]time.Duration),
+		client:                       client,
+		namespace:                    v1.NamespaceAll,
+		defaultResync:                defaultResync,
+		informers:                    make(map[reflect.Type]cache.SharedIndexInformer),
+		startedInformers:             make(map[reflect.Type]bool),
+		customResync:                 make(map[reflect.Type]time.Duration),
+		extraClusterScopedIndexers:   cache.Indexers{},
+		extraNamespaceScopedIndexers: cache.Indexers{},
 	}
 
 	// Apply all options
@@ -163,6 +192,21 @@ func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internal
 	f.informers[informerType] = informer
 
 	return informer
+}
+
+// KeyFunction returns any extra cluster scoped indexers set on the factory
+func (f *sharedInformerFactory) ExtraClusterScopedIndexers() cache.Indexers {
+	return f.extraClusterScopedIndexers
+}
+
+// KeyFunction returns any extra namespace scoped indexers set on the factory
+func (f *sharedInformerFactory) ExtraNamespaceScopedIndexers() cache.Indexers {
+	return f.extraNamespaceScopedIndexers
+}
+
+// KeyFunction returns the keyfunction set on the factory
+func (f *sharedInformerFactory) KeyFunction() cache.KeyFunc {
+	return f.keyFunc
 }
 
 // SharedInformerFactory provides shared informers for resources in all known

--- a/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/informers/externalversions/internalinterfaces/factory_interfaces.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/informers/externalversions/internalinterfaces/factory_interfaces.go
@@ -34,6 +34,9 @@ type NewInformerFunc func(versioned.Interface, time.Duration) cache.SharedIndexI
 type SharedInformerFactory interface {
 	Start(stopCh <-chan struct{})
 	InformerFor(obj runtime.Object, newFunc NewInformerFunc) cache.SharedIndexInformer
+	ExtraClusterScopedIndexers() cache.Indexers
+	ExtraNamespaceScopedIndexers() cache.Indexers
+	KeyFunction() cache.KeyFunc
 }
 
 // TweakListOptionsFunc is a function that transforms a v1.ListOptions.

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/apiextensions/v1/customresourcedefinition.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/apiextensions/v1/customresourcedefinition.go
@@ -55,7 +55,11 @@ func NewCustomResourceDefinitionInformer(client clientset.Interface, resyncPerio
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredCustomResourceDefinitionInformer(client clientset.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredCustomResourceDefinitionInformerWithOptions(client, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredCustomResourceDefinitionInformerWithOptions(client clientset.Interface, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -71,13 +75,22 @@ func NewFilteredCustomResourceDefinitionInformer(client clientset.Interface, res
 			},
 		},
 		&apiextensionsv1.CustomResourceDefinition{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *customResourceDefinitionInformer) defaultInformer(client clientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredCustomResourceDefinitionInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{}
+	for k, v := range f.factory.ExtraClusterScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredCustomResourceDefinitionInformerWithOptions(client,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *customResourceDefinitionInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/factory.go
@@ -36,12 +36,15 @@ import (
 type SharedInformerOption func(*sharedInformerFactory) *sharedInformerFactory
 
 type sharedInformerFactory struct {
-	client           clientset.Interface
-	namespace        string
-	tweakListOptions internalinterfaces.TweakListOptionsFunc
-	lock             sync.Mutex
-	defaultResync    time.Duration
-	customResync     map[reflect.Type]time.Duration
+	client                       clientset.Interface
+	namespace                    string
+	tweakListOptions             internalinterfaces.TweakListOptionsFunc
+	lock                         sync.Mutex
+	defaultResync                time.Duration
+	customResync                 map[reflect.Type]time.Duration
+	extraClusterScopedIndexers   cache.Indexers
+	extraNamespaceScopedIndexers cache.Indexers
+	keyFunc                      cache.KeyFunc
 
 	informers map[reflect.Type]cache.SharedIndexInformer
 	// startedInformers is used for tracking which informers have been started.
@@ -75,6 +78,30 @@ func WithNamespace(namespace string) SharedInformerOption {
 	}
 }
 
+// WithExtraClusterScopedIndexers adds cluster scoped indexers on all informers of the configured SharedInformerFactory
+func WithExtraClusterScopedIndexers(indexers cache.Indexers) SharedInformerOption {
+	return func(factory *sharedInformerFactory) *sharedInformerFactory {
+		factory.extraClusterScopedIndexers = indexers
+		return factory
+	}
+}
+
+// WithExtraNamespaceScopedIndexers adds namespace scoped indexers on all informers of the configured SharedInformerFactory
+func WithExtraNamespaceScopedIndexers(indexers cache.Indexers) SharedInformerOption {
+	return func(factory *sharedInformerFactory) *sharedInformerFactory {
+		factory.extraNamespaceScopedIndexers = indexers
+		return factory
+	}
+}
+
+// WithKeyFunction sets a custom key function for all informers of the configured SharedInformerFactory
+func WithKeyFunction(keyFunc cache.KeyFunc) SharedInformerOption {
+	return func(factory *sharedInformerFactory) *sharedInformerFactory {
+		factory.keyFunc = keyFunc
+		return factory
+	}
+}
+
 // NewSharedInformerFactory constructs a new instance of sharedInformerFactory for all namespaces.
 func NewSharedInformerFactory(client clientset.Interface, defaultResync time.Duration) SharedInformerFactory {
 	return NewSharedInformerFactoryWithOptions(client, defaultResync)
@@ -91,12 +118,14 @@ func NewFilteredSharedInformerFactory(client clientset.Interface, defaultResync 
 // NewSharedInformerFactoryWithOptions constructs a new instance of a SharedInformerFactory with additional options.
 func NewSharedInformerFactoryWithOptions(client clientset.Interface, defaultResync time.Duration, options ...SharedInformerOption) SharedInformerFactory {
 	factory := &sharedInformerFactory{
-		client:           client,
-		namespace:        v1.NamespaceAll,
-		defaultResync:    defaultResync,
-		informers:        make(map[reflect.Type]cache.SharedIndexInformer),
-		startedInformers: make(map[reflect.Type]bool),
-		customResync:     make(map[reflect.Type]time.Duration),
+		client:                       client,
+		namespace:                    v1.NamespaceAll,
+		defaultResync:                defaultResync,
+		informers:                    make(map[reflect.Type]cache.SharedIndexInformer),
+		startedInformers:             make(map[reflect.Type]bool),
+		customResync:                 make(map[reflect.Type]time.Duration),
+		extraClusterScopedIndexers:   cache.Indexers{},
+		extraNamespaceScopedIndexers: cache.Indexers{},
 	}
 
 	// Apply all options
@@ -163,6 +192,21 @@ func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internal
 	f.informers[informerType] = informer
 
 	return informer
+}
+
+// KeyFunction returns any extra cluster scoped indexers set on the factory
+func (f *sharedInformerFactory) ExtraClusterScopedIndexers() cache.Indexers {
+	return f.extraClusterScopedIndexers
+}
+
+// KeyFunction returns any extra namespace scoped indexers set on the factory
+func (f *sharedInformerFactory) ExtraNamespaceScopedIndexers() cache.Indexers {
+	return f.extraNamespaceScopedIndexers
+}
+
+// KeyFunction returns the keyfunction set on the factory
+func (f *sharedInformerFactory) KeyFunction() cache.KeyFunc {
+	return f.keyFunc
 }
 
 // SharedInformerFactory provides shared informers for resources in all known

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/internalinterfaces/factory_interfaces.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/internalinterfaces/factory_interfaces.go
@@ -34,6 +34,9 @@ type NewInformerFunc func(clientset.Interface, time.Duration) cache.SharedIndexI
 type SharedInformerFactory interface {
 	Start(stopCh <-chan struct{})
 	InformerFor(obj runtime.Object, newFunc NewInformerFunc) cache.SharedIndexInformer
+	ExtraClusterScopedIndexers() cache.Indexers
+	ExtraNamespaceScopedIndexers() cache.Indexers
+	KeyFunction() cache.KeyFunc
 }
 
 // TweakListOptionsFunc is a function that transforms a v1.ListOptions.

--- a/staging/src/k8s.io/client-go/applyconfigurations/internal/internal.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/internal/internal.go
@@ -907,12 +907,24 @@ var schemaYAML = typed.YAMLObject(`types:
       type:
         scalar: string
       default: ""
+- name: io.k8s.api.apps.v1.StatefulSetPersistentVolumeClaimRetentionPolicy
+  map:
+    fields:
+    - name: whenDeleted
+      type:
+        scalar: string
+    - name: whenScaled
+      type:
+        scalar: string
 - name: io.k8s.api.apps.v1.StatefulSetSpec
   map:
     fields:
     - name: minReadySeconds
       type:
         scalar: numeric
+    - name: persistentVolumeClaimRetentionPolicy
+      type:
+        namedType: io.k8s.api.apps.v1.StatefulSetPersistentVolumeClaimRetentionPolicy
     - name: podManagementPolicy
       type:
         scalar: string
@@ -949,6 +961,7 @@ var schemaYAML = typed.YAMLObject(`types:
     - name: availableReplicas
       type:
         scalar: numeric
+      default: 0
     - name: collisionCount
       type:
         scalar: numeric
@@ -1194,12 +1207,24 @@ var schemaYAML = typed.YAMLObject(`types:
       type:
         scalar: string
       default: ""
+- name: io.k8s.api.apps.v1beta1.StatefulSetPersistentVolumeClaimRetentionPolicy
+  map:
+    fields:
+    - name: whenDeleted
+      type:
+        scalar: string
+    - name: whenScaled
+      type:
+        scalar: string
 - name: io.k8s.api.apps.v1beta1.StatefulSetSpec
   map:
     fields:
     - name: minReadySeconds
       type:
         scalar: numeric
+    - name: persistentVolumeClaimRetentionPolicy
+      type:
+        namedType: io.k8s.api.apps.v1beta1.StatefulSetPersistentVolumeClaimRetentionPolicy
     - name: podManagementPolicy
       type:
         scalar: string
@@ -1236,6 +1261,7 @@ var schemaYAML = typed.YAMLObject(`types:
     - name: availableReplicas
       type:
         scalar: numeric
+      default: 0
     - name: collisionCount
       type:
         scalar: numeric
@@ -1679,12 +1705,24 @@ var schemaYAML = typed.YAMLObject(`types:
       type:
         scalar: string
       default: ""
+- name: io.k8s.api.apps.v1beta2.StatefulSetPersistentVolumeClaimRetentionPolicy
+  map:
+    fields:
+    - name: whenDeleted
+      type:
+        scalar: string
+    - name: whenScaled
+      type:
+        scalar: string
 - name: io.k8s.api.apps.v1beta2.StatefulSetSpec
   map:
     fields:
     - name: minReadySeconds
       type:
         scalar: numeric
+    - name: persistentVolumeClaimRetentionPolicy
+      type:
+        namedType: io.k8s.api.apps.v1beta2.StatefulSetPersistentVolumeClaimRetentionPolicy
     - name: podManagementPolicy
       type:
         scalar: string
@@ -1721,6 +1759,7 @@ var schemaYAML = typed.YAMLObject(`types:
     - name: availableReplicas
       type:
         scalar: numeric
+      default: 0
     - name: collisionCount
       type:
         scalar: numeric
@@ -1836,16 +1875,362 @@ var schemaYAML = typed.YAMLObject(`types:
     - name: observedGeneration
       type:
         scalar: numeric
-- name: io.k8s.api.autoscaling.v2.HorizontalPodAutoscaler
-  scalar: untyped
-  list:
-    elementType:
-      namedType: __untyped_atomic_
-    elementRelationship: atomic
+- name: io.k8s.api.autoscaling.v2.ContainerResourceMetricSource
   map:
-    elementType:
-      namedType: __untyped_deduced_
-    elementRelationship: separable
+    fields:
+    - name: container
+      type:
+        scalar: string
+      default: ""
+    - name: name
+      type:
+        scalar: string
+      default: ""
+    - name: target
+      type:
+        namedType: io.k8s.api.autoscaling.v2.MetricTarget
+      default: {}
+- name: io.k8s.api.autoscaling.v2.ContainerResourceMetricStatus
+  map:
+    fields:
+    - name: container
+      type:
+        scalar: string
+      default: ""
+    - name: current
+      type:
+        namedType: io.k8s.api.autoscaling.v2.MetricValueStatus
+      default: {}
+    - name: name
+      type:
+        scalar: string
+      default: ""
+- name: io.k8s.api.autoscaling.v2.CrossVersionObjectReference
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+      default: ""
+    - name: name
+      type:
+        scalar: string
+      default: ""
+- name: io.k8s.api.autoscaling.v2.ExternalMetricSource
+  map:
+    fields:
+    - name: metric
+      type:
+        namedType: io.k8s.api.autoscaling.v2.MetricIdentifier
+      default: {}
+    - name: target
+      type:
+        namedType: io.k8s.api.autoscaling.v2.MetricTarget
+      default: {}
+- name: io.k8s.api.autoscaling.v2.ExternalMetricStatus
+  map:
+    fields:
+    - name: current
+      type:
+        namedType: io.k8s.api.autoscaling.v2.MetricValueStatus
+      default: {}
+    - name: metric
+      type:
+        namedType: io.k8s.api.autoscaling.v2.MetricIdentifier
+      default: {}
+- name: io.k8s.api.autoscaling.v2.HPAScalingPolicy
+  map:
+    fields:
+    - name: periodSeconds
+      type:
+        scalar: numeric
+      default: 0
+    - name: type
+      type:
+        scalar: string
+      default: ""
+    - name: value
+      type:
+        scalar: numeric
+      default: 0
+- name: io.k8s.api.autoscaling.v2.HPAScalingRules
+  map:
+    fields:
+    - name: policies
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.autoscaling.v2.HPAScalingPolicy
+          elementRelationship: atomic
+    - name: selectPolicy
+      type:
+        scalar: string
+    - name: stabilizationWindowSeconds
+      type:
+        scalar: numeric
+- name: io.k8s.api.autoscaling.v2.HorizontalPodAutoscaler
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+      default: {}
+    - name: spec
+      type:
+        namedType: io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerSpec
+      default: {}
+    - name: status
+      type:
+        namedType: io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerStatus
+      default: {}
+- name: io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerBehavior
+  map:
+    fields:
+    - name: scaleDown
+      type:
+        namedType: io.k8s.api.autoscaling.v2.HPAScalingRules
+    - name: scaleUp
+      type:
+        namedType: io.k8s.api.autoscaling.v2.HPAScalingRules
+- name: io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerCondition
+  map:
+    fields:
+    - name: lastTransitionTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+      default: {}
+    - name: message
+      type:
+        scalar: string
+    - name: reason
+      type:
+        scalar: string
+    - name: status
+      type:
+        scalar: string
+      default: ""
+    - name: type
+      type:
+        scalar: string
+      default: ""
+- name: io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerSpec
+  map:
+    fields:
+    - name: behavior
+      type:
+        namedType: io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerBehavior
+    - name: maxReplicas
+      type:
+        scalar: numeric
+      default: 0
+    - name: metrics
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.autoscaling.v2.MetricSpec
+          elementRelationship: atomic
+    - name: minReplicas
+      type:
+        scalar: numeric
+    - name: scaleTargetRef
+      type:
+        namedType: io.k8s.api.autoscaling.v2.CrossVersionObjectReference
+      default: {}
+- name: io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerStatus
+  map:
+    fields:
+    - name: conditions
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerCondition
+          elementRelationship: associative
+          keys:
+          - type
+    - name: currentMetrics
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.autoscaling.v2.MetricStatus
+          elementRelationship: atomic
+    - name: currentReplicas
+      type:
+        scalar: numeric
+    - name: desiredReplicas
+      type:
+        scalar: numeric
+      default: 0
+    - name: lastScaleTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: observedGeneration
+      type:
+        scalar: numeric
+- name: io.k8s.api.autoscaling.v2.MetricIdentifier
+  map:
+    fields:
+    - name: name
+      type:
+        scalar: string
+      default: ""
+    - name: selector
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector
+- name: io.k8s.api.autoscaling.v2.MetricSpec
+  map:
+    fields:
+    - name: containerResource
+      type:
+        namedType: io.k8s.api.autoscaling.v2.ContainerResourceMetricSource
+    - name: external
+      type:
+        namedType: io.k8s.api.autoscaling.v2.ExternalMetricSource
+    - name: object
+      type:
+        namedType: io.k8s.api.autoscaling.v2.ObjectMetricSource
+    - name: pods
+      type:
+        namedType: io.k8s.api.autoscaling.v2.PodsMetricSource
+    - name: resource
+      type:
+        namedType: io.k8s.api.autoscaling.v2.ResourceMetricSource
+    - name: type
+      type:
+        scalar: string
+      default: ""
+- name: io.k8s.api.autoscaling.v2.MetricStatus
+  map:
+    fields:
+    - name: containerResource
+      type:
+        namedType: io.k8s.api.autoscaling.v2.ContainerResourceMetricStatus
+    - name: external
+      type:
+        namedType: io.k8s.api.autoscaling.v2.ExternalMetricStatus
+    - name: object
+      type:
+        namedType: io.k8s.api.autoscaling.v2.ObjectMetricStatus
+    - name: pods
+      type:
+        namedType: io.k8s.api.autoscaling.v2.PodsMetricStatus
+    - name: resource
+      type:
+        namedType: io.k8s.api.autoscaling.v2.ResourceMetricStatus
+    - name: type
+      type:
+        scalar: string
+      default: ""
+- name: io.k8s.api.autoscaling.v2.MetricTarget
+  map:
+    fields:
+    - name: averageUtilization
+      type:
+        scalar: numeric
+    - name: averageValue
+      type:
+        namedType: io.k8s.apimachinery.pkg.api.resource.Quantity
+    - name: type
+      type:
+        scalar: string
+      default: ""
+    - name: value
+      type:
+        namedType: io.k8s.apimachinery.pkg.api.resource.Quantity
+- name: io.k8s.api.autoscaling.v2.MetricValueStatus
+  map:
+    fields:
+    - name: averageUtilization
+      type:
+        scalar: numeric
+    - name: averageValue
+      type:
+        namedType: io.k8s.apimachinery.pkg.api.resource.Quantity
+    - name: value
+      type:
+        namedType: io.k8s.apimachinery.pkg.api.resource.Quantity
+- name: io.k8s.api.autoscaling.v2.ObjectMetricSource
+  map:
+    fields:
+    - name: describedObject
+      type:
+        namedType: io.k8s.api.autoscaling.v2.CrossVersionObjectReference
+      default: {}
+    - name: metric
+      type:
+        namedType: io.k8s.api.autoscaling.v2.MetricIdentifier
+      default: {}
+    - name: target
+      type:
+        namedType: io.k8s.api.autoscaling.v2.MetricTarget
+      default: {}
+- name: io.k8s.api.autoscaling.v2.ObjectMetricStatus
+  map:
+    fields:
+    - name: current
+      type:
+        namedType: io.k8s.api.autoscaling.v2.MetricValueStatus
+      default: {}
+    - name: describedObject
+      type:
+        namedType: io.k8s.api.autoscaling.v2.CrossVersionObjectReference
+      default: {}
+    - name: metric
+      type:
+        namedType: io.k8s.api.autoscaling.v2.MetricIdentifier
+      default: {}
+- name: io.k8s.api.autoscaling.v2.PodsMetricSource
+  map:
+    fields:
+    - name: metric
+      type:
+        namedType: io.k8s.api.autoscaling.v2.MetricIdentifier
+      default: {}
+    - name: target
+      type:
+        namedType: io.k8s.api.autoscaling.v2.MetricTarget
+      default: {}
+- name: io.k8s.api.autoscaling.v2.PodsMetricStatus
+  map:
+    fields:
+    - name: current
+      type:
+        namedType: io.k8s.api.autoscaling.v2.MetricValueStatus
+      default: {}
+    - name: metric
+      type:
+        namedType: io.k8s.api.autoscaling.v2.MetricIdentifier
+      default: {}
+- name: io.k8s.api.autoscaling.v2.ResourceMetricSource
+  map:
+    fields:
+    - name: name
+      type:
+        scalar: string
+      default: ""
+    - name: target
+      type:
+        namedType: io.k8s.api.autoscaling.v2.MetricTarget
+      default: {}
+- name: io.k8s.api.autoscaling.v2.ResourceMetricStatus
+  map:
+    fields:
+    - name: current
+      type:
+        namedType: io.k8s.api.autoscaling.v2.MetricValueStatus
+      default: {}
+    - name: name
+      type:
+        scalar: string
+      default: ""
 - name: io.k8s.api.autoscaling.v2beta1.ContainerResourceMetricSource
   map:
     fields:
@@ -2676,6 +3061,9 @@ var schemaYAML = typed.YAMLObject(`types:
             namedType: io.k8s.api.batch.v1.JobCondition
           elementRelationship: atomic
     - name: failed
+      type:
+        scalar: numeric
+    - name: ready
       type:
         scalar: numeric
     - name: startTime
@@ -3885,7 +4273,10 @@ var schemaYAML = typed.YAMLObject(`types:
         list:
           elementType:
             namedType: io.k8s.api.core.v1.ContainerPort
-          elementRelationship: atomic
+          elementRelationship: associative
+          keys:
+          - containerPort
+          - protocol
     - name: readinessProbe
       type:
         namedType: io.k8s.api.core.v1.Probe
@@ -4123,6 +4514,17 @@ var schemaYAML = typed.YAMLObject(`types:
     - name: readOnly
       type:
         scalar: boolean
+- name: io.k8s.api.core.v1.GRPCAction
+  map:
+    fields:
+    - name: port
+      type:
+        scalar: numeric
+      default: 0
+    - name: service
+      type:
+        scalar: string
+      default: ""
 - name: io.k8s.api.core.v1.GitRepoVolumeSource
   map:
     fields:
@@ -4200,18 +4602,6 @@ var schemaYAML = typed.YAMLObject(`types:
       type:
         scalar: string
       default: ""
-- name: io.k8s.api.core.v1.Handler
-  map:
-    fields:
-    - name: exec
-      type:
-        namedType: io.k8s.api.core.v1.ExecAction
-    - name: httpGet
-      type:
-        namedType: io.k8s.api.core.v1.HTTPGetAction
-    - name: tcpSocket
-      type:
-        namedType: io.k8s.api.core.v1.TCPSocketAction
 - name: io.k8s.api.core.v1.HostAlias
   map:
     fields:
@@ -4337,10 +4727,22 @@ var schemaYAML = typed.YAMLObject(`types:
     fields:
     - name: postStart
       type:
-        namedType: io.k8s.api.core.v1.Handler
+        namedType: io.k8s.api.core.v1.LifecycleHandler
     - name: preStop
       type:
-        namedType: io.k8s.api.core.v1.Handler
+        namedType: io.k8s.api.core.v1.LifecycleHandler
+- name: io.k8s.api.core.v1.LifecycleHandler
+  map:
+    fields:
+    - name: exec
+      type:
+        namedType: io.k8s.api.core.v1.ExecAction
+    - name: httpGet
+      type:
+        namedType: io.k8s.api.core.v1.HTTPGetAction
+    - name: tcpSocket
+      type:
+        namedType: io.k8s.api.core.v1.TCPSocketAction
 - name: io.k8s.api.core.v1.LimitRange
   map:
     fields:
@@ -4936,6 +5338,11 @@ var schemaYAML = typed.YAMLObject(`types:
           elementType:
             scalar: string
           elementRelationship: atomic
+    - name: allocatedResources
+      type:
+        map:
+          elementType:
+            namedType: io.k8s.apimachinery.pkg.api.resource.Quantity
     - name: capacity
       type:
         map:
@@ -4950,6 +5357,9 @@ var schemaYAML = typed.YAMLObject(`types:
           keys:
           - type
     - name: phase
+      type:
+        scalar: string
+    - name: resizeStatus
       type:
         scalar: string
 - name: io.k8s.api.core.v1.PersistentVolumeClaimTemplate
@@ -5227,6 +5637,13 @@ var schemaYAML = typed.YAMLObject(`types:
     - name: ip
       type:
         scalar: string
+- name: io.k8s.api.core.v1.PodOS
+  map:
+    fields:
+    - name: name
+      type:
+        scalar: string
+      default: ""
 - name: io.k8s.api.core.v1.PodReadinessGate
   map:
     fields:
@@ -5355,6 +5772,9 @@ var schemaYAML = typed.YAMLObject(`types:
           elementType:
             scalar: string
           elementRelationship: atomic
+    - name: os
+      type:
+        namedType: io.k8s.api.core.v1.PodOS
     - name: overhead
       type:
         map:
@@ -5564,6 +5984,9 @@ var schemaYAML = typed.YAMLObject(`types:
     - name: failureThreshold
       type:
         scalar: numeric
+    - name: grpc
+      type:
+        namedType: io.k8s.api.core.v1.GRPCAction
     - name: httpGet
       type:
         namedType: io.k8s.api.core.v1.HTTPGetAction
@@ -8405,26 +8828,314 @@ var schemaYAML = typed.YAMLObject(`types:
       type:
         scalar: string
       default: ""
+- name: io.k8s.api.flowcontrol.v1beta2.FlowDistinguisherMethod
+  map:
+    fields:
+    - name: type
+      type:
+        scalar: string
+      default: ""
 - name: io.k8s.api.flowcontrol.v1beta2.FlowSchema
-  scalar: untyped
-  list:
-    elementType:
-      namedType: __untyped_atomic_
-    elementRelationship: atomic
   map:
-    elementType:
-      namedType: __untyped_deduced_
-    elementRelationship: separable
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+      default: {}
+    - name: spec
+      type:
+        namedType: io.k8s.api.flowcontrol.v1beta2.FlowSchemaSpec
+      default: {}
+    - name: status
+      type:
+        namedType: io.k8s.api.flowcontrol.v1beta2.FlowSchemaStatus
+      default: {}
+- name: io.k8s.api.flowcontrol.v1beta2.FlowSchemaCondition
+  map:
+    fields:
+    - name: lastTransitionTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+      default: {}
+    - name: message
+      type:
+        scalar: string
+    - name: reason
+      type:
+        scalar: string
+    - name: status
+      type:
+        scalar: string
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.api.flowcontrol.v1beta2.FlowSchemaSpec
+  map:
+    fields:
+    - name: distinguisherMethod
+      type:
+        namedType: io.k8s.api.flowcontrol.v1beta2.FlowDistinguisherMethod
+    - name: matchingPrecedence
+      type:
+        scalar: numeric
+      default: 0
+    - name: priorityLevelConfiguration
+      type:
+        namedType: io.k8s.api.flowcontrol.v1beta2.PriorityLevelConfigurationReference
+      default: {}
+    - name: rules
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.flowcontrol.v1beta2.PolicyRulesWithSubjects
+          elementRelationship: atomic
+- name: io.k8s.api.flowcontrol.v1beta2.FlowSchemaStatus
+  map:
+    fields:
+    - name: conditions
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.flowcontrol.v1beta2.FlowSchemaCondition
+          elementRelationship: associative
+          keys:
+          - type
+- name: io.k8s.api.flowcontrol.v1beta2.GroupSubject
+  map:
+    fields:
+    - name: name
+      type:
+        scalar: string
+      default: ""
+- name: io.k8s.api.flowcontrol.v1beta2.LimitResponse
+  map:
+    fields:
+    - name: queuing
+      type:
+        namedType: io.k8s.api.flowcontrol.v1beta2.QueuingConfiguration
+    - name: type
+      type:
+        scalar: string
+      default: ""
+    unions:
+    - discriminator: type
+      fields:
+      - fieldName: queuing
+        discriminatorValue: Queuing
+- name: io.k8s.api.flowcontrol.v1beta2.LimitedPriorityLevelConfiguration
+  map:
+    fields:
+    - name: assuredConcurrencyShares
+      type:
+        scalar: numeric
+      default: 0
+    - name: limitResponse
+      type:
+        namedType: io.k8s.api.flowcontrol.v1beta2.LimitResponse
+      default: {}
+- name: io.k8s.api.flowcontrol.v1beta2.NonResourcePolicyRule
+  map:
+    fields:
+    - name: nonResourceURLs
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: associative
+    - name: verbs
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: associative
+- name: io.k8s.api.flowcontrol.v1beta2.PolicyRulesWithSubjects
+  map:
+    fields:
+    - name: nonResourceRules
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.flowcontrol.v1beta2.NonResourcePolicyRule
+          elementRelationship: atomic
+    - name: resourceRules
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.flowcontrol.v1beta2.ResourcePolicyRule
+          elementRelationship: atomic
+    - name: subjects
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.flowcontrol.v1beta2.Subject
+          elementRelationship: atomic
 - name: io.k8s.api.flowcontrol.v1beta2.PriorityLevelConfiguration
-  scalar: untyped
-  list:
-    elementType:
-      namedType: __untyped_atomic_
-    elementRelationship: atomic
   map:
-    elementType:
-      namedType: __untyped_deduced_
-    elementRelationship: separable
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+      default: {}
+    - name: spec
+      type:
+        namedType: io.k8s.api.flowcontrol.v1beta2.PriorityLevelConfigurationSpec
+      default: {}
+    - name: status
+      type:
+        namedType: io.k8s.api.flowcontrol.v1beta2.PriorityLevelConfigurationStatus
+      default: {}
+- name: io.k8s.api.flowcontrol.v1beta2.PriorityLevelConfigurationCondition
+  map:
+    fields:
+    - name: lastTransitionTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+      default: {}
+    - name: message
+      type:
+        scalar: string
+    - name: reason
+      type:
+        scalar: string
+    - name: status
+      type:
+        scalar: string
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.api.flowcontrol.v1beta2.PriorityLevelConfigurationReference
+  map:
+    fields:
+    - name: name
+      type:
+        scalar: string
+      default: ""
+- name: io.k8s.api.flowcontrol.v1beta2.PriorityLevelConfigurationSpec
+  map:
+    fields:
+    - name: limited
+      type:
+        namedType: io.k8s.api.flowcontrol.v1beta2.LimitedPriorityLevelConfiguration
+    - name: type
+      type:
+        scalar: string
+      default: ""
+    unions:
+    - discriminator: type
+      fields:
+      - fieldName: limited
+        discriminatorValue: Limited
+- name: io.k8s.api.flowcontrol.v1beta2.PriorityLevelConfigurationStatus
+  map:
+    fields:
+    - name: conditions
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.flowcontrol.v1beta2.PriorityLevelConfigurationCondition
+          elementRelationship: associative
+          keys:
+          - type
+- name: io.k8s.api.flowcontrol.v1beta2.QueuingConfiguration
+  map:
+    fields:
+    - name: handSize
+      type:
+        scalar: numeric
+      default: 0
+    - name: queueLengthLimit
+      type:
+        scalar: numeric
+      default: 0
+    - name: queues
+      type:
+        scalar: numeric
+      default: 0
+- name: io.k8s.api.flowcontrol.v1beta2.ResourcePolicyRule
+  map:
+    fields:
+    - name: apiGroups
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: associative
+    - name: clusterScope
+      type:
+        scalar: boolean
+    - name: namespaces
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: associative
+    - name: resources
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: associative
+    - name: verbs
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: associative
+- name: io.k8s.api.flowcontrol.v1beta2.ServiceAccountSubject
+  map:
+    fields:
+    - name: name
+      type:
+        scalar: string
+      default: ""
+    - name: namespace
+      type:
+        scalar: string
+      default: ""
+- name: io.k8s.api.flowcontrol.v1beta2.Subject
+  map:
+    fields:
+    - name: group
+      type:
+        namedType: io.k8s.api.flowcontrol.v1beta2.GroupSubject
+    - name: kind
+      type:
+        scalar: string
+      default: ""
+    - name: serviceAccount
+      type:
+        namedType: io.k8s.api.flowcontrol.v1beta2.ServiceAccountSubject
+    - name: user
+      type:
+        namedType: io.k8s.api.flowcontrol.v1beta2.UserSubject
+    unions:
+    - discriminator: kind
+      fields:
+      - fieldName: group
+        discriminatorValue: Group
+      - fieldName: serviceAccount
+        discriminatorValue: ServiceAccount
+      - fieldName: user
+        discriminatorValue: User
+- name: io.k8s.api.flowcontrol.v1beta2.UserSubject
+  map:
+    fields:
+    - name: name
+      type:
+        scalar: string
+      default: ""
 - name: io.k8s.api.imagepolicy.v1alpha1.ImageReview
   map:
     fields:

--- a/staging/src/k8s.io/client-go/informers/admissionregistration/v1/mutatingwebhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/informers/admissionregistration/v1/mutatingwebhookconfiguration.go
@@ -55,7 +55,11 @@ func NewMutatingWebhookConfigurationInformer(client kubernetes.Interface, resync
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredMutatingWebhookConfigurationInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredMutatingWebhookConfigurationInformerWithOptions(client, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredMutatingWebhookConfigurationInformerWithOptions(client kubernetes.Interface, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -71,13 +75,22 @@ func NewFilteredMutatingWebhookConfigurationInformer(client kubernetes.Interface
 			},
 		},
 		&admissionregistrationv1.MutatingWebhookConfiguration{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *mutatingWebhookConfigurationInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredMutatingWebhookConfigurationInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{}
+	for k, v := range f.factory.ExtraClusterScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredMutatingWebhookConfigurationInformerWithOptions(client,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *mutatingWebhookConfigurationInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/admissionregistration/v1/validatingwebhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/informers/admissionregistration/v1/validatingwebhookconfiguration.go
@@ -55,7 +55,11 @@ func NewValidatingWebhookConfigurationInformer(client kubernetes.Interface, resy
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredValidatingWebhookConfigurationInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredValidatingWebhookConfigurationInformerWithOptions(client, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredValidatingWebhookConfigurationInformerWithOptions(client kubernetes.Interface, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -71,13 +75,22 @@ func NewFilteredValidatingWebhookConfigurationInformer(client kubernetes.Interfa
 			},
 		},
 		&admissionregistrationv1.ValidatingWebhookConfiguration{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *validatingWebhookConfigurationInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredValidatingWebhookConfigurationInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{}
+	for k, v := range f.factory.ExtraClusterScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredValidatingWebhookConfigurationInformerWithOptions(client,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *validatingWebhookConfigurationInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/admissionregistration/v1beta1/validatingwebhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/informers/admissionregistration/v1beta1/validatingwebhookconfiguration.go
@@ -55,7 +55,11 @@ func NewValidatingWebhookConfigurationInformer(client kubernetes.Interface, resy
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredValidatingWebhookConfigurationInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredValidatingWebhookConfigurationInformerWithOptions(client, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredValidatingWebhookConfigurationInformerWithOptions(client kubernetes.Interface, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -71,13 +75,22 @@ func NewFilteredValidatingWebhookConfigurationInformer(client kubernetes.Interfa
 			},
 		},
 		&admissionregistrationv1beta1.ValidatingWebhookConfiguration{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *validatingWebhookConfigurationInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredValidatingWebhookConfigurationInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{}
+	for k, v := range f.factory.ExtraClusterScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredValidatingWebhookConfigurationInformerWithOptions(client,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *validatingWebhookConfigurationInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/apiserverinternal/v1alpha1/storageversion.go
+++ b/staging/src/k8s.io/client-go/informers/apiserverinternal/v1alpha1/storageversion.go
@@ -55,7 +55,11 @@ func NewStorageVersionInformer(client kubernetes.Interface, resyncPeriod time.Du
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredStorageVersionInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredStorageVersionInformerWithOptions(client, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredStorageVersionInformerWithOptions(client kubernetes.Interface, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -71,13 +75,22 @@ func NewFilteredStorageVersionInformer(client kubernetes.Interface, resyncPeriod
 			},
 		},
 		&apiserverinternalv1alpha1.StorageVersion{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *storageVersionInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredStorageVersionInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{}
+	for k, v := range f.factory.ExtraClusterScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredStorageVersionInformerWithOptions(client,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *storageVersionInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/apps/v1/controllerrevision.go
+++ b/staging/src/k8s.io/client-go/informers/apps/v1/controllerrevision.go
@@ -56,7 +56,11 @@ func NewControllerRevisionInformer(client kubernetes.Interface, namespace string
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredControllerRevisionInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredControllerRevisionInformerWithOptions(client, namespace, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredControllerRevisionInformerWithOptions(client kubernetes.Interface, namespace string, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -72,13 +76,22 @@ func NewFilteredControllerRevisionInformer(client kubernetes.Interface, namespac
 			},
 		},
 		&appsv1.ControllerRevision{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *controllerRevisionInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredControllerRevisionInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}
+	for k, v := range f.factory.ExtraNamespaceScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredControllerRevisionInformerWithOptions(client, f.namespace,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *controllerRevisionInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/apps/v1/daemonset.go
+++ b/staging/src/k8s.io/client-go/informers/apps/v1/daemonset.go
@@ -56,7 +56,11 @@ func NewDaemonSetInformer(client kubernetes.Interface, namespace string, resyncP
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredDaemonSetInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredDaemonSetInformerWithOptions(client, namespace, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredDaemonSetInformerWithOptions(client kubernetes.Interface, namespace string, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -72,13 +76,22 @@ func NewFilteredDaemonSetInformer(client kubernetes.Interface, namespace string,
 			},
 		},
 		&appsv1.DaemonSet{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *daemonSetInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredDaemonSetInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}
+	for k, v := range f.factory.ExtraNamespaceScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredDaemonSetInformerWithOptions(client, f.namespace,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *daemonSetInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/apps/v1/deployment.go
+++ b/staging/src/k8s.io/client-go/informers/apps/v1/deployment.go
@@ -56,7 +56,11 @@ func NewDeploymentInformer(client kubernetes.Interface, namespace string, resync
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredDeploymentInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredDeploymentInformerWithOptions(client, namespace, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredDeploymentInformerWithOptions(client kubernetes.Interface, namespace string, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -72,13 +76,22 @@ func NewFilteredDeploymentInformer(client kubernetes.Interface, namespace string
 			},
 		},
 		&appsv1.Deployment{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *deploymentInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredDeploymentInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}
+	for k, v := range f.factory.ExtraNamespaceScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredDeploymentInformerWithOptions(client, f.namespace,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *deploymentInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/apps/v1/replicaset.go
+++ b/staging/src/k8s.io/client-go/informers/apps/v1/replicaset.go
@@ -56,7 +56,11 @@ func NewReplicaSetInformer(client kubernetes.Interface, namespace string, resync
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredReplicaSetInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredReplicaSetInformerWithOptions(client, namespace, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredReplicaSetInformerWithOptions(client kubernetes.Interface, namespace string, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -72,13 +76,22 @@ func NewFilteredReplicaSetInformer(client kubernetes.Interface, namespace string
 			},
 		},
 		&appsv1.ReplicaSet{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *replicaSetInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredReplicaSetInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}
+	for k, v := range f.factory.ExtraNamespaceScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredReplicaSetInformerWithOptions(client, f.namespace,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *replicaSetInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/apps/v1/statefulset.go
+++ b/staging/src/k8s.io/client-go/informers/apps/v1/statefulset.go
@@ -56,7 +56,11 @@ func NewStatefulSetInformer(client kubernetes.Interface, namespace string, resyn
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredStatefulSetInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredStatefulSetInformerWithOptions(client, namespace, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredStatefulSetInformerWithOptions(client kubernetes.Interface, namespace string, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -72,13 +76,22 @@ func NewFilteredStatefulSetInformer(client kubernetes.Interface, namespace strin
 			},
 		},
 		&appsv1.StatefulSet{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *statefulSetInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredStatefulSetInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}
+	for k, v := range f.factory.ExtraNamespaceScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredStatefulSetInformerWithOptions(client, f.namespace,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *statefulSetInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/apps/v1beta1/controllerrevision.go
+++ b/staging/src/k8s.io/client-go/informers/apps/v1beta1/controllerrevision.go
@@ -56,7 +56,11 @@ func NewControllerRevisionInformer(client kubernetes.Interface, namespace string
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredControllerRevisionInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredControllerRevisionInformerWithOptions(client, namespace, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredControllerRevisionInformerWithOptions(client kubernetes.Interface, namespace string, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -72,13 +76,22 @@ func NewFilteredControllerRevisionInformer(client kubernetes.Interface, namespac
 			},
 		},
 		&appsv1beta1.ControllerRevision{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *controllerRevisionInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredControllerRevisionInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}
+	for k, v := range f.factory.ExtraNamespaceScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredControllerRevisionInformerWithOptions(client, f.namespace,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *controllerRevisionInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/apps/v1beta1/deployment.go
+++ b/staging/src/k8s.io/client-go/informers/apps/v1beta1/deployment.go
@@ -56,7 +56,11 @@ func NewDeploymentInformer(client kubernetes.Interface, namespace string, resync
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredDeploymentInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredDeploymentInformerWithOptions(client, namespace, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredDeploymentInformerWithOptions(client kubernetes.Interface, namespace string, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -72,13 +76,22 @@ func NewFilteredDeploymentInformer(client kubernetes.Interface, namespace string
 			},
 		},
 		&appsv1beta1.Deployment{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *deploymentInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredDeploymentInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}
+	for k, v := range f.factory.ExtraNamespaceScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredDeploymentInformerWithOptions(client, f.namespace,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *deploymentInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/apps/v1beta1/statefulset.go
+++ b/staging/src/k8s.io/client-go/informers/apps/v1beta1/statefulset.go
@@ -56,7 +56,11 @@ func NewStatefulSetInformer(client kubernetes.Interface, namespace string, resyn
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredStatefulSetInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredStatefulSetInformerWithOptions(client, namespace, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredStatefulSetInformerWithOptions(client kubernetes.Interface, namespace string, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -72,13 +76,22 @@ func NewFilteredStatefulSetInformer(client kubernetes.Interface, namespace strin
 			},
 		},
 		&appsv1beta1.StatefulSet{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *statefulSetInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredStatefulSetInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}
+	for k, v := range f.factory.ExtraNamespaceScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredStatefulSetInformerWithOptions(client, f.namespace,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *statefulSetInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/apps/v1beta2/controllerrevision.go
+++ b/staging/src/k8s.io/client-go/informers/apps/v1beta2/controllerrevision.go
@@ -56,7 +56,11 @@ func NewControllerRevisionInformer(client kubernetes.Interface, namespace string
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredControllerRevisionInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredControllerRevisionInformerWithOptions(client, namespace, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredControllerRevisionInformerWithOptions(client kubernetes.Interface, namespace string, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -72,13 +76,22 @@ func NewFilteredControllerRevisionInformer(client kubernetes.Interface, namespac
 			},
 		},
 		&appsv1beta2.ControllerRevision{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *controllerRevisionInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredControllerRevisionInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}
+	for k, v := range f.factory.ExtraNamespaceScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredControllerRevisionInformerWithOptions(client, f.namespace,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *controllerRevisionInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/apps/v1beta2/daemonset.go
+++ b/staging/src/k8s.io/client-go/informers/apps/v1beta2/daemonset.go
@@ -56,7 +56,11 @@ func NewDaemonSetInformer(client kubernetes.Interface, namespace string, resyncP
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredDaemonSetInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredDaemonSetInformerWithOptions(client, namespace, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredDaemonSetInformerWithOptions(client kubernetes.Interface, namespace string, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -72,13 +76,22 @@ func NewFilteredDaemonSetInformer(client kubernetes.Interface, namespace string,
 			},
 		},
 		&appsv1beta2.DaemonSet{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *daemonSetInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredDaemonSetInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}
+	for k, v := range f.factory.ExtraNamespaceScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredDaemonSetInformerWithOptions(client, f.namespace,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *daemonSetInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/apps/v1beta2/deployment.go
+++ b/staging/src/k8s.io/client-go/informers/apps/v1beta2/deployment.go
@@ -56,7 +56,11 @@ func NewDeploymentInformer(client kubernetes.Interface, namespace string, resync
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredDeploymentInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredDeploymentInformerWithOptions(client, namespace, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredDeploymentInformerWithOptions(client kubernetes.Interface, namespace string, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -72,13 +76,22 @@ func NewFilteredDeploymentInformer(client kubernetes.Interface, namespace string
 			},
 		},
 		&appsv1beta2.Deployment{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *deploymentInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredDeploymentInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}
+	for k, v := range f.factory.ExtraNamespaceScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredDeploymentInformerWithOptions(client, f.namespace,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *deploymentInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/apps/v1beta2/replicaset.go
+++ b/staging/src/k8s.io/client-go/informers/apps/v1beta2/replicaset.go
@@ -56,7 +56,11 @@ func NewReplicaSetInformer(client kubernetes.Interface, namespace string, resync
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredReplicaSetInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredReplicaSetInformerWithOptions(client, namespace, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredReplicaSetInformerWithOptions(client kubernetes.Interface, namespace string, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -72,13 +76,22 @@ func NewFilteredReplicaSetInformer(client kubernetes.Interface, namespace string
 			},
 		},
 		&appsv1beta2.ReplicaSet{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *replicaSetInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredReplicaSetInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}
+	for k, v := range f.factory.ExtraNamespaceScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredReplicaSetInformerWithOptions(client, f.namespace,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *replicaSetInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/apps/v1beta2/statefulset.go
+++ b/staging/src/k8s.io/client-go/informers/apps/v1beta2/statefulset.go
@@ -56,7 +56,11 @@ func NewStatefulSetInformer(client kubernetes.Interface, namespace string, resyn
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredStatefulSetInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredStatefulSetInformerWithOptions(client, namespace, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredStatefulSetInformerWithOptions(client kubernetes.Interface, namespace string, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -72,13 +76,22 @@ func NewFilteredStatefulSetInformer(client kubernetes.Interface, namespace strin
 			},
 		},
 		&appsv1beta2.StatefulSet{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *statefulSetInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredStatefulSetInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}
+	for k, v := range f.factory.ExtraNamespaceScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredStatefulSetInformerWithOptions(client, f.namespace,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *statefulSetInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/autoscaling/v1/horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/informers/autoscaling/v1/horizontalpodautoscaler.go
@@ -56,7 +56,11 @@ func NewHorizontalPodAutoscalerInformer(client kubernetes.Interface, namespace s
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredHorizontalPodAutoscalerInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredHorizontalPodAutoscalerInformerWithOptions(client, namespace, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredHorizontalPodAutoscalerInformerWithOptions(client kubernetes.Interface, namespace string, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -72,13 +76,22 @@ func NewFilteredHorizontalPodAutoscalerInformer(client kubernetes.Interface, nam
 			},
 		},
 		&autoscalingv1.HorizontalPodAutoscaler{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *horizontalPodAutoscalerInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredHorizontalPodAutoscalerInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}
+	for k, v := range f.factory.ExtraNamespaceScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredHorizontalPodAutoscalerInformerWithOptions(client, f.namespace,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *horizontalPodAutoscalerInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/autoscaling/v2/horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/informers/autoscaling/v2/horizontalpodautoscaler.go
@@ -56,7 +56,11 @@ func NewHorizontalPodAutoscalerInformer(client kubernetes.Interface, namespace s
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredHorizontalPodAutoscalerInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredHorizontalPodAutoscalerInformerWithOptions(client, namespace, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredHorizontalPodAutoscalerInformerWithOptions(client kubernetes.Interface, namespace string, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -72,13 +76,22 @@ func NewFilteredHorizontalPodAutoscalerInformer(client kubernetes.Interface, nam
 			},
 		},
 		&autoscalingv2.HorizontalPodAutoscaler{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *horizontalPodAutoscalerInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredHorizontalPodAutoscalerInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}
+	for k, v := range f.factory.ExtraNamespaceScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredHorizontalPodAutoscalerInformerWithOptions(client, f.namespace,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *horizontalPodAutoscalerInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/autoscaling/v2beta2/horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/informers/autoscaling/v2beta2/horizontalpodautoscaler.go
@@ -56,7 +56,11 @@ func NewHorizontalPodAutoscalerInformer(client kubernetes.Interface, namespace s
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredHorizontalPodAutoscalerInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredHorizontalPodAutoscalerInformerWithOptions(client, namespace, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredHorizontalPodAutoscalerInformerWithOptions(client kubernetes.Interface, namespace string, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -72,13 +76,22 @@ func NewFilteredHorizontalPodAutoscalerInformer(client kubernetes.Interface, nam
 			},
 		},
 		&autoscalingv2beta2.HorizontalPodAutoscaler{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *horizontalPodAutoscalerInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredHorizontalPodAutoscalerInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}
+	for k, v := range f.factory.ExtraNamespaceScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredHorizontalPodAutoscalerInformerWithOptions(client, f.namespace,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *horizontalPodAutoscalerInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/batch/v1/cronjob.go
+++ b/staging/src/k8s.io/client-go/informers/batch/v1/cronjob.go
@@ -56,7 +56,11 @@ func NewCronJobInformer(client kubernetes.Interface, namespace string, resyncPer
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredCronJobInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredCronJobInformerWithOptions(client, namespace, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredCronJobInformerWithOptions(client kubernetes.Interface, namespace string, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -72,13 +76,22 @@ func NewFilteredCronJobInformer(client kubernetes.Interface, namespace string, r
 			},
 		},
 		&batchv1.CronJob{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *cronJobInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredCronJobInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}
+	for k, v := range f.factory.ExtraNamespaceScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredCronJobInformerWithOptions(client, f.namespace,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *cronJobInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/batch/v1/job.go
+++ b/staging/src/k8s.io/client-go/informers/batch/v1/job.go
@@ -56,7 +56,11 @@ func NewJobInformer(client kubernetes.Interface, namespace string, resyncPeriod 
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredJobInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredJobInformerWithOptions(client, namespace, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredJobInformerWithOptions(client kubernetes.Interface, namespace string, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -72,13 +76,22 @@ func NewFilteredJobInformer(client kubernetes.Interface, namespace string, resyn
 			},
 		},
 		&batchv1.Job{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *jobInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredJobInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}
+	for k, v := range f.factory.ExtraNamespaceScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredJobInformerWithOptions(client, f.namespace,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *jobInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/batch/v1beta1/cronjob.go
+++ b/staging/src/k8s.io/client-go/informers/batch/v1beta1/cronjob.go
@@ -56,7 +56,11 @@ func NewCronJobInformer(client kubernetes.Interface, namespace string, resyncPer
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredCronJobInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredCronJobInformerWithOptions(client, namespace, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredCronJobInformerWithOptions(client kubernetes.Interface, namespace string, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -72,13 +76,22 @@ func NewFilteredCronJobInformer(client kubernetes.Interface, namespace string, r
 			},
 		},
 		&batchv1beta1.CronJob{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *cronJobInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredCronJobInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}
+	for k, v := range f.factory.ExtraNamespaceScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredCronJobInformerWithOptions(client, f.namespace,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *cronJobInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/certificates/v1/certificatesigningrequest.go
+++ b/staging/src/k8s.io/client-go/informers/certificates/v1/certificatesigningrequest.go
@@ -55,7 +55,11 @@ func NewCertificateSigningRequestInformer(client kubernetes.Interface, resyncPer
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredCertificateSigningRequestInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredCertificateSigningRequestInformerWithOptions(client, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredCertificateSigningRequestInformerWithOptions(client kubernetes.Interface, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -71,13 +75,22 @@ func NewFilteredCertificateSigningRequestInformer(client kubernetes.Interface, r
 			},
 		},
 		&certificatesv1.CertificateSigningRequest{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *certificateSigningRequestInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredCertificateSigningRequestInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{}
+	for k, v := range f.factory.ExtraClusterScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredCertificateSigningRequestInformerWithOptions(client,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *certificateSigningRequestInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/certificates/v1beta1/certificatesigningrequest.go
+++ b/staging/src/k8s.io/client-go/informers/certificates/v1beta1/certificatesigningrequest.go
@@ -55,7 +55,11 @@ func NewCertificateSigningRequestInformer(client kubernetes.Interface, resyncPer
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredCertificateSigningRequestInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredCertificateSigningRequestInformerWithOptions(client, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredCertificateSigningRequestInformerWithOptions(client kubernetes.Interface, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -71,13 +75,22 @@ func NewFilteredCertificateSigningRequestInformer(client kubernetes.Interface, r
 			},
 		},
 		&certificatesv1beta1.CertificateSigningRequest{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *certificateSigningRequestInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredCertificateSigningRequestInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{}
+	for k, v := range f.factory.ExtraClusterScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredCertificateSigningRequestInformerWithOptions(client,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *certificateSigningRequestInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/coordination/v1/lease.go
+++ b/staging/src/k8s.io/client-go/informers/coordination/v1/lease.go
@@ -56,7 +56,11 @@ func NewLeaseInformer(client kubernetes.Interface, namespace string, resyncPerio
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredLeaseInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredLeaseInformerWithOptions(client, namespace, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredLeaseInformerWithOptions(client kubernetes.Interface, namespace string, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -72,13 +76,22 @@ func NewFilteredLeaseInformer(client kubernetes.Interface, namespace string, res
 			},
 		},
 		&coordinationv1.Lease{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *leaseInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredLeaseInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}
+	for k, v := range f.factory.ExtraNamespaceScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredLeaseInformerWithOptions(client, f.namespace,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *leaseInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/coordination/v1beta1/lease.go
+++ b/staging/src/k8s.io/client-go/informers/coordination/v1beta1/lease.go
@@ -56,7 +56,11 @@ func NewLeaseInformer(client kubernetes.Interface, namespace string, resyncPerio
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredLeaseInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredLeaseInformerWithOptions(client, namespace, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredLeaseInformerWithOptions(client kubernetes.Interface, namespace string, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -72,13 +76,22 @@ func NewFilteredLeaseInformer(client kubernetes.Interface, namespace string, res
 			},
 		},
 		&coordinationv1beta1.Lease{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *leaseInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredLeaseInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}
+	for k, v := range f.factory.ExtraNamespaceScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredLeaseInformerWithOptions(client, f.namespace,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *leaseInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/core/v1/componentstatus.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/componentstatus.go
@@ -55,7 +55,11 @@ func NewComponentStatusInformer(client kubernetes.Interface, resyncPeriod time.D
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredComponentStatusInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredComponentStatusInformerWithOptions(client, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredComponentStatusInformerWithOptions(client kubernetes.Interface, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -71,13 +75,22 @@ func NewFilteredComponentStatusInformer(client kubernetes.Interface, resyncPerio
 			},
 		},
 		&corev1.ComponentStatus{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *componentStatusInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredComponentStatusInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{}
+	for k, v := range f.factory.ExtraClusterScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredComponentStatusInformerWithOptions(client,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *componentStatusInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/core/v1/configmap.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/configmap.go
@@ -56,7 +56,11 @@ func NewConfigMapInformer(client kubernetes.Interface, namespace string, resyncP
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredConfigMapInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredConfigMapInformerWithOptions(client, namespace, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredConfigMapInformerWithOptions(client kubernetes.Interface, namespace string, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -72,13 +76,22 @@ func NewFilteredConfigMapInformer(client kubernetes.Interface, namespace string,
 			},
 		},
 		&corev1.ConfigMap{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *configMapInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredConfigMapInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}
+	for k, v := range f.factory.ExtraNamespaceScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredConfigMapInformerWithOptions(client, f.namespace,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *configMapInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/core/v1/event.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/event.go
@@ -56,7 +56,11 @@ func NewEventInformer(client kubernetes.Interface, namespace string, resyncPerio
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredEventInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredEventInformerWithOptions(client, namespace, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredEventInformerWithOptions(client kubernetes.Interface, namespace string, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -72,13 +76,22 @@ func NewFilteredEventInformer(client kubernetes.Interface, namespace string, res
 			},
 		},
 		&corev1.Event{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *eventInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredEventInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}
+	for k, v := range f.factory.ExtraNamespaceScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredEventInformerWithOptions(client, f.namespace,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *eventInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/core/v1/limitrange.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/limitrange.go
@@ -56,7 +56,11 @@ func NewLimitRangeInformer(client kubernetes.Interface, namespace string, resync
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredLimitRangeInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredLimitRangeInformerWithOptions(client, namespace, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredLimitRangeInformerWithOptions(client kubernetes.Interface, namespace string, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -72,13 +76,22 @@ func NewFilteredLimitRangeInformer(client kubernetes.Interface, namespace string
 			},
 		},
 		&corev1.LimitRange{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *limitRangeInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredLimitRangeInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}
+	for k, v := range f.factory.ExtraNamespaceScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredLimitRangeInformerWithOptions(client, f.namespace,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *limitRangeInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/core/v1/namespace.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/namespace.go
@@ -55,7 +55,11 @@ func NewNamespaceInformer(client kubernetes.Interface, resyncPeriod time.Duratio
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredNamespaceInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredNamespaceInformerWithOptions(client, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredNamespaceInformerWithOptions(client kubernetes.Interface, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -71,13 +75,22 @@ func NewFilteredNamespaceInformer(client kubernetes.Interface, resyncPeriod time
 			},
 		},
 		&corev1.Namespace{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *namespaceInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredNamespaceInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{}
+	for k, v := range f.factory.ExtraClusterScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredNamespaceInformerWithOptions(client,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *namespaceInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/core/v1/node.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/node.go
@@ -55,7 +55,11 @@ func NewNodeInformer(client kubernetes.Interface, resyncPeriod time.Duration, in
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredNodeInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredNodeInformerWithOptions(client, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredNodeInformerWithOptions(client kubernetes.Interface, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -71,13 +75,22 @@ func NewFilteredNodeInformer(client kubernetes.Interface, resyncPeriod time.Dura
 			},
 		},
 		&corev1.Node{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *nodeInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredNodeInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{}
+	for k, v := range f.factory.ExtraClusterScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredNodeInformerWithOptions(client,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *nodeInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/core/v1/persistentvolume.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/persistentvolume.go
@@ -55,7 +55,11 @@ func NewPersistentVolumeInformer(client kubernetes.Interface, resyncPeriod time.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredPersistentVolumeInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredPersistentVolumeInformerWithOptions(client, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredPersistentVolumeInformerWithOptions(client kubernetes.Interface, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -71,13 +75,22 @@ func NewFilteredPersistentVolumeInformer(client kubernetes.Interface, resyncPeri
 			},
 		},
 		&corev1.PersistentVolume{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *persistentVolumeInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredPersistentVolumeInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{}
+	for k, v := range f.factory.ExtraClusterScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredPersistentVolumeInformerWithOptions(client,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *persistentVolumeInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/core/v1/pod.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/pod.go
@@ -56,7 +56,11 @@ func NewPodInformer(client kubernetes.Interface, namespace string, resyncPeriod 
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredPodInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredPodInformerWithOptions(client, namespace, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredPodInformerWithOptions(client kubernetes.Interface, namespace string, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -72,13 +76,22 @@ func NewFilteredPodInformer(client kubernetes.Interface, namespace string, resyn
 			},
 		},
 		&corev1.Pod{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *podInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredPodInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}
+	for k, v := range f.factory.ExtraNamespaceScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredPodInformerWithOptions(client, f.namespace,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *podInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/core/v1/podtemplate.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/podtemplate.go
@@ -56,7 +56,11 @@ func NewPodTemplateInformer(client kubernetes.Interface, namespace string, resyn
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredPodTemplateInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredPodTemplateInformerWithOptions(client, namespace, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredPodTemplateInformerWithOptions(client kubernetes.Interface, namespace string, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -72,13 +76,22 @@ func NewFilteredPodTemplateInformer(client kubernetes.Interface, namespace strin
 			},
 		},
 		&corev1.PodTemplate{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *podTemplateInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredPodTemplateInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}
+	for k, v := range f.factory.ExtraNamespaceScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredPodTemplateInformerWithOptions(client, f.namespace,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *podTemplateInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/core/v1/replicationcontroller.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/replicationcontroller.go
@@ -56,7 +56,11 @@ func NewReplicationControllerInformer(client kubernetes.Interface, namespace str
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredReplicationControllerInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredReplicationControllerInformerWithOptions(client, namespace, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredReplicationControllerInformerWithOptions(client kubernetes.Interface, namespace string, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -72,13 +76,22 @@ func NewFilteredReplicationControllerInformer(client kubernetes.Interface, names
 			},
 		},
 		&corev1.ReplicationController{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *replicationControllerInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredReplicationControllerInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}
+	for k, v := range f.factory.ExtraNamespaceScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredReplicationControllerInformerWithOptions(client, f.namespace,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *replicationControllerInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/core/v1/resourcequota.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/resourcequota.go
@@ -56,7 +56,11 @@ func NewResourceQuotaInformer(client kubernetes.Interface, namespace string, res
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredResourceQuotaInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredResourceQuotaInformerWithOptions(client, namespace, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredResourceQuotaInformerWithOptions(client kubernetes.Interface, namespace string, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -72,13 +76,22 @@ func NewFilteredResourceQuotaInformer(client kubernetes.Interface, namespace str
 			},
 		},
 		&corev1.ResourceQuota{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *resourceQuotaInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredResourceQuotaInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}
+	for k, v := range f.factory.ExtraNamespaceScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredResourceQuotaInformerWithOptions(client, f.namespace,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *resourceQuotaInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/core/v1/secret.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/secret.go
@@ -56,7 +56,11 @@ func NewSecretInformer(client kubernetes.Interface, namespace string, resyncPeri
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredSecretInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredSecretInformerWithOptions(client, namespace, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredSecretInformerWithOptions(client kubernetes.Interface, namespace string, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -72,13 +76,22 @@ func NewFilteredSecretInformer(client kubernetes.Interface, namespace string, re
 			},
 		},
 		&corev1.Secret{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *secretInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredSecretInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}
+	for k, v := range f.factory.ExtraNamespaceScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredSecretInformerWithOptions(client, f.namespace,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *secretInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/core/v1/service.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/service.go
@@ -56,7 +56,11 @@ func NewServiceInformer(client kubernetes.Interface, namespace string, resyncPer
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredServiceInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredServiceInformerWithOptions(client, namespace, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredServiceInformerWithOptions(client kubernetes.Interface, namespace string, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -72,13 +76,22 @@ func NewFilteredServiceInformer(client kubernetes.Interface, namespace string, r
 			},
 		},
 		&corev1.Service{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *serviceInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredServiceInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}
+	for k, v := range f.factory.ExtraNamespaceScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredServiceInformerWithOptions(client, f.namespace,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *serviceInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/discovery/v1/endpointslice.go
+++ b/staging/src/k8s.io/client-go/informers/discovery/v1/endpointslice.go
@@ -56,7 +56,11 @@ func NewEndpointSliceInformer(client kubernetes.Interface, namespace string, res
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredEndpointSliceInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredEndpointSliceInformerWithOptions(client, namespace, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredEndpointSliceInformerWithOptions(client kubernetes.Interface, namespace string, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -72,13 +76,22 @@ func NewFilteredEndpointSliceInformer(client kubernetes.Interface, namespace str
 			},
 		},
 		&discoveryv1.EndpointSlice{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *endpointSliceInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredEndpointSliceInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}
+	for k, v := range f.factory.ExtraNamespaceScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredEndpointSliceInformerWithOptions(client, f.namespace,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *endpointSliceInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/events/v1/event.go
+++ b/staging/src/k8s.io/client-go/informers/events/v1/event.go
@@ -56,7 +56,11 @@ func NewEventInformer(client kubernetes.Interface, namespace string, resyncPerio
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredEventInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredEventInformerWithOptions(client, namespace, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredEventInformerWithOptions(client kubernetes.Interface, namespace string, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -72,13 +76,22 @@ func NewFilteredEventInformer(client kubernetes.Interface, namespace string, res
 			},
 		},
 		&eventsv1.Event{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *eventInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredEventInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}
+	for k, v := range f.factory.ExtraNamespaceScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredEventInformerWithOptions(client, f.namespace,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *eventInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/events/v1beta1/event.go
+++ b/staging/src/k8s.io/client-go/informers/events/v1beta1/event.go
@@ -56,7 +56,11 @@ func NewEventInformer(client kubernetes.Interface, namespace string, resyncPerio
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredEventInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredEventInformerWithOptions(client, namespace, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredEventInformerWithOptions(client kubernetes.Interface, namespace string, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -72,13 +76,22 @@ func NewFilteredEventInformer(client kubernetes.Interface, namespace string, res
 			},
 		},
 		&eventsv1beta1.Event{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *eventInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredEventInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}
+	for k, v := range f.factory.ExtraNamespaceScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredEventInformerWithOptions(client, f.namespace,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *eventInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/extensions/v1beta1/daemonset.go
+++ b/staging/src/k8s.io/client-go/informers/extensions/v1beta1/daemonset.go
@@ -56,7 +56,11 @@ func NewDaemonSetInformer(client kubernetes.Interface, namespace string, resyncP
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredDaemonSetInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredDaemonSetInformerWithOptions(client, namespace, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredDaemonSetInformerWithOptions(client kubernetes.Interface, namespace string, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -72,13 +76,22 @@ func NewFilteredDaemonSetInformer(client kubernetes.Interface, namespace string,
 			},
 		},
 		&extensionsv1beta1.DaemonSet{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *daemonSetInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredDaemonSetInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}
+	for k, v := range f.factory.ExtraNamespaceScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredDaemonSetInformerWithOptions(client, f.namespace,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *daemonSetInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/extensions/v1beta1/deployment.go
+++ b/staging/src/k8s.io/client-go/informers/extensions/v1beta1/deployment.go
@@ -56,7 +56,11 @@ func NewDeploymentInformer(client kubernetes.Interface, namespace string, resync
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredDeploymentInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredDeploymentInformerWithOptions(client, namespace, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredDeploymentInformerWithOptions(client kubernetes.Interface, namespace string, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -72,13 +76,22 @@ func NewFilteredDeploymentInformer(client kubernetes.Interface, namespace string
 			},
 		},
 		&extensionsv1beta1.Deployment{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *deploymentInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredDeploymentInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}
+	for k, v := range f.factory.ExtraNamespaceScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredDeploymentInformerWithOptions(client, f.namespace,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *deploymentInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/extensions/v1beta1/ingress.go
+++ b/staging/src/k8s.io/client-go/informers/extensions/v1beta1/ingress.go
@@ -56,7 +56,11 @@ func NewIngressInformer(client kubernetes.Interface, namespace string, resyncPer
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredIngressInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredIngressInformerWithOptions(client, namespace, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredIngressInformerWithOptions(client kubernetes.Interface, namespace string, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -72,13 +76,22 @@ func NewFilteredIngressInformer(client kubernetes.Interface, namespace string, r
 			},
 		},
 		&extensionsv1beta1.Ingress{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *ingressInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredIngressInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}
+	for k, v := range f.factory.ExtraNamespaceScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredIngressInformerWithOptions(client, f.namespace,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *ingressInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/extensions/v1beta1/networkpolicy.go
+++ b/staging/src/k8s.io/client-go/informers/extensions/v1beta1/networkpolicy.go
@@ -56,7 +56,11 @@ func NewNetworkPolicyInformer(client kubernetes.Interface, namespace string, res
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredNetworkPolicyInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredNetworkPolicyInformerWithOptions(client, namespace, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredNetworkPolicyInformerWithOptions(client kubernetes.Interface, namespace string, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -72,13 +76,22 @@ func NewFilteredNetworkPolicyInformer(client kubernetes.Interface, namespace str
 			},
 		},
 		&extensionsv1beta1.NetworkPolicy{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *networkPolicyInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredNetworkPolicyInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}
+	for k, v := range f.factory.ExtraNamespaceScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredNetworkPolicyInformerWithOptions(client, f.namespace,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *networkPolicyInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/extensions/v1beta1/replicaset.go
+++ b/staging/src/k8s.io/client-go/informers/extensions/v1beta1/replicaset.go
@@ -56,7 +56,11 @@ func NewReplicaSetInformer(client kubernetes.Interface, namespace string, resync
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredReplicaSetInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredReplicaSetInformerWithOptions(client, namespace, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredReplicaSetInformerWithOptions(client kubernetes.Interface, namespace string, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -72,13 +76,22 @@ func NewFilteredReplicaSetInformer(client kubernetes.Interface, namespace string
 			},
 		},
 		&extensionsv1beta1.ReplicaSet{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *replicaSetInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredReplicaSetInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}
+	for k, v := range f.factory.ExtraNamespaceScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredReplicaSetInformerWithOptions(client, f.namespace,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *replicaSetInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/factory.go
+++ b/staging/src/k8s.io/client-go/informers/factory.go
@@ -53,12 +53,15 @@ import (
 type SharedInformerOption func(*sharedInformerFactory) *sharedInformerFactory
 
 type sharedInformerFactory struct {
-	client           kubernetes.Interface
-	namespace        string
-	tweakListOptions internalinterfaces.TweakListOptionsFunc
-	lock             sync.Mutex
-	defaultResync    time.Duration
-	customResync     map[reflect.Type]time.Duration
+	client                       kubernetes.Interface
+	namespace                    string
+	tweakListOptions             internalinterfaces.TweakListOptionsFunc
+	lock                         sync.Mutex
+	defaultResync                time.Duration
+	customResync                 map[reflect.Type]time.Duration
+	extraClusterScopedIndexers   cache.Indexers
+	extraNamespaceScopedIndexers cache.Indexers
+	keyFunc                      cache.KeyFunc
 
 	informers map[reflect.Type]cache.SharedIndexInformer
 	// startedInformers is used for tracking which informers have been started.
@@ -92,6 +95,30 @@ func WithNamespace(namespace string) SharedInformerOption {
 	}
 }
 
+// WithExtraClusterScopedIndexers adds cluster scoped indexers on all informers of the configured SharedInformerFactory
+func WithExtraClusterScopedIndexers(indexers cache.Indexers) SharedInformerOption {
+	return func(factory *sharedInformerFactory) *sharedInformerFactory {
+		factory.extraClusterScopedIndexers = indexers
+		return factory
+	}
+}
+
+// WithExtraNamespaceScopedIndexers adds namespace scoped indexers on all informers of the configured SharedInformerFactory
+func WithExtraNamespaceScopedIndexers(indexers cache.Indexers) SharedInformerOption {
+	return func(factory *sharedInformerFactory) *sharedInformerFactory {
+		factory.extraNamespaceScopedIndexers = indexers
+		return factory
+	}
+}
+
+// WithKeyFunction sets a custom key function for all informers of the configured SharedInformerFactory
+func WithKeyFunction(keyFunc cache.KeyFunc) SharedInformerOption {
+	return func(factory *sharedInformerFactory) *sharedInformerFactory {
+		factory.keyFunc = keyFunc
+		return factory
+	}
+}
+
 // NewSharedInformerFactory constructs a new instance of sharedInformerFactory for all namespaces.
 func NewSharedInformerFactory(client kubernetes.Interface, defaultResync time.Duration) SharedInformerFactory {
 	return NewSharedInformerFactoryWithOptions(client, defaultResync)
@@ -108,12 +135,14 @@ func NewFilteredSharedInformerFactory(client kubernetes.Interface, defaultResync
 // NewSharedInformerFactoryWithOptions constructs a new instance of a SharedInformerFactory with additional options.
 func NewSharedInformerFactoryWithOptions(client kubernetes.Interface, defaultResync time.Duration, options ...SharedInformerOption) SharedInformerFactory {
 	factory := &sharedInformerFactory{
-		client:           client,
-		namespace:        v1.NamespaceAll,
-		defaultResync:    defaultResync,
-		informers:        make(map[reflect.Type]cache.SharedIndexInformer),
-		startedInformers: make(map[reflect.Type]bool),
-		customResync:     make(map[reflect.Type]time.Duration),
+		client:                       client,
+		namespace:                    v1.NamespaceAll,
+		defaultResync:                defaultResync,
+		informers:                    make(map[reflect.Type]cache.SharedIndexInformer),
+		startedInformers:             make(map[reflect.Type]bool),
+		customResync:                 make(map[reflect.Type]time.Duration),
+		extraClusterScopedIndexers:   cache.Indexers{},
+		extraNamespaceScopedIndexers: cache.Indexers{},
 	}
 
 	// Apply all options
@@ -180,6 +209,21 @@ func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internal
 	f.informers[informerType] = informer
 
 	return informer
+}
+
+// KeyFunction returns any extra cluster scoped indexers set on the factory
+func (f *sharedInformerFactory) ExtraClusterScopedIndexers() cache.Indexers {
+	return f.extraClusterScopedIndexers
+}
+
+// KeyFunction returns any extra namespace scoped indexers set on the factory
+func (f *sharedInformerFactory) ExtraNamespaceScopedIndexers() cache.Indexers {
+	return f.extraNamespaceScopedIndexers
+}
+
+// KeyFunction returns the keyfunction set on the factory
+func (f *sharedInformerFactory) KeyFunction() cache.KeyFunc {
+	return f.keyFunc
 }
 
 // SharedInformerFactory provides shared informers for resources in all known

--- a/staging/src/k8s.io/client-go/informers/flowcontrol/v1alpha1/flowschema.go
+++ b/staging/src/k8s.io/client-go/informers/flowcontrol/v1alpha1/flowschema.go
@@ -55,7 +55,11 @@ func NewFlowSchemaInformer(client kubernetes.Interface, resyncPeriod time.Durati
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredFlowSchemaInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredFlowSchemaInformerWithOptions(client, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredFlowSchemaInformerWithOptions(client kubernetes.Interface, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -71,13 +75,22 @@ func NewFilteredFlowSchemaInformer(client kubernetes.Interface, resyncPeriod tim
 			},
 		},
 		&flowcontrolv1alpha1.FlowSchema{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *flowSchemaInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredFlowSchemaInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{}
+	for k, v := range f.factory.ExtraClusterScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredFlowSchemaInformerWithOptions(client,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *flowSchemaInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/flowcontrol/v1alpha1/prioritylevelconfiguration.go
+++ b/staging/src/k8s.io/client-go/informers/flowcontrol/v1alpha1/prioritylevelconfiguration.go
@@ -55,7 +55,11 @@ func NewPriorityLevelConfigurationInformer(client kubernetes.Interface, resyncPe
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredPriorityLevelConfigurationInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredPriorityLevelConfigurationInformerWithOptions(client, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredPriorityLevelConfigurationInformerWithOptions(client kubernetes.Interface, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -71,13 +75,22 @@ func NewFilteredPriorityLevelConfigurationInformer(client kubernetes.Interface, 
 			},
 		},
 		&flowcontrolv1alpha1.PriorityLevelConfiguration{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *priorityLevelConfigurationInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredPriorityLevelConfigurationInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{}
+	for k, v := range f.factory.ExtraClusterScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredPriorityLevelConfigurationInformerWithOptions(client,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *priorityLevelConfigurationInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/flowcontrol/v1beta1/flowschema.go
+++ b/staging/src/k8s.io/client-go/informers/flowcontrol/v1beta1/flowschema.go
@@ -55,7 +55,11 @@ func NewFlowSchemaInformer(client kubernetes.Interface, resyncPeriod time.Durati
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredFlowSchemaInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredFlowSchemaInformerWithOptions(client, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredFlowSchemaInformerWithOptions(client kubernetes.Interface, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -71,13 +75,22 @@ func NewFilteredFlowSchemaInformer(client kubernetes.Interface, resyncPeriod tim
 			},
 		},
 		&flowcontrolv1beta1.FlowSchema{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *flowSchemaInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredFlowSchemaInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{}
+	for k, v := range f.factory.ExtraClusterScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredFlowSchemaInformerWithOptions(client,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *flowSchemaInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/flowcontrol/v1beta1/prioritylevelconfiguration.go
+++ b/staging/src/k8s.io/client-go/informers/flowcontrol/v1beta1/prioritylevelconfiguration.go
@@ -55,7 +55,11 @@ func NewPriorityLevelConfigurationInformer(client kubernetes.Interface, resyncPe
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredPriorityLevelConfigurationInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredPriorityLevelConfigurationInformerWithOptions(client, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredPriorityLevelConfigurationInformerWithOptions(client kubernetes.Interface, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -71,13 +75,22 @@ func NewFilteredPriorityLevelConfigurationInformer(client kubernetes.Interface, 
 			},
 		},
 		&flowcontrolv1beta1.PriorityLevelConfiguration{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *priorityLevelConfigurationInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredPriorityLevelConfigurationInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{}
+	for k, v := range f.factory.ExtraClusterScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredPriorityLevelConfigurationInformerWithOptions(client,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *priorityLevelConfigurationInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/flowcontrol/v1beta2/prioritylevelconfiguration.go
+++ b/staging/src/k8s.io/client-go/informers/flowcontrol/v1beta2/prioritylevelconfiguration.go
@@ -55,7 +55,11 @@ func NewPriorityLevelConfigurationInformer(client kubernetes.Interface, resyncPe
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredPriorityLevelConfigurationInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredPriorityLevelConfigurationInformerWithOptions(client, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredPriorityLevelConfigurationInformerWithOptions(client kubernetes.Interface, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -71,13 +75,22 @@ func NewFilteredPriorityLevelConfigurationInformer(client kubernetes.Interface, 
 			},
 		},
 		&flowcontrolv1beta2.PriorityLevelConfiguration{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *priorityLevelConfigurationInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredPriorityLevelConfigurationInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{}
+	for k, v := range f.factory.ExtraClusterScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredPriorityLevelConfigurationInformerWithOptions(client,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *priorityLevelConfigurationInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/internalinterfaces/factory_interfaces.go
+++ b/staging/src/k8s.io/client-go/informers/internalinterfaces/factory_interfaces.go
@@ -34,6 +34,9 @@ type NewInformerFunc func(kubernetes.Interface, time.Duration) cache.SharedIndex
 type SharedInformerFactory interface {
 	Start(stopCh <-chan struct{})
 	InformerFor(obj runtime.Object, newFunc NewInformerFunc) cache.SharedIndexInformer
+	ExtraClusterScopedIndexers() cache.Indexers
+	ExtraNamespaceScopedIndexers() cache.Indexers
+	KeyFunction() cache.KeyFunc
 }
 
 // TweakListOptionsFunc is a function that transforms a v1.ListOptions.

--- a/staging/src/k8s.io/client-go/informers/networking/v1/ingress.go
+++ b/staging/src/k8s.io/client-go/informers/networking/v1/ingress.go
@@ -56,7 +56,11 @@ func NewIngressInformer(client kubernetes.Interface, namespace string, resyncPer
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredIngressInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredIngressInformerWithOptions(client, namespace, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredIngressInformerWithOptions(client kubernetes.Interface, namespace string, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -72,13 +76,22 @@ func NewFilteredIngressInformer(client kubernetes.Interface, namespace string, r
 			},
 		},
 		&networkingv1.Ingress{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *ingressInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredIngressInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}
+	for k, v := range f.factory.ExtraNamespaceScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredIngressInformerWithOptions(client, f.namespace,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *ingressInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/networking/v1/ingressclass.go
+++ b/staging/src/k8s.io/client-go/informers/networking/v1/ingressclass.go
@@ -55,7 +55,11 @@ func NewIngressClassInformer(client kubernetes.Interface, resyncPeriod time.Dura
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredIngressClassInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredIngressClassInformerWithOptions(client, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredIngressClassInformerWithOptions(client kubernetes.Interface, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -71,13 +75,22 @@ func NewFilteredIngressClassInformer(client kubernetes.Interface, resyncPeriod t
 			},
 		},
 		&networkingv1.IngressClass{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *ingressClassInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredIngressClassInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{}
+	for k, v := range f.factory.ExtraClusterScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredIngressClassInformerWithOptions(client,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *ingressClassInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/networking/v1/networkpolicy.go
+++ b/staging/src/k8s.io/client-go/informers/networking/v1/networkpolicy.go
@@ -56,7 +56,11 @@ func NewNetworkPolicyInformer(client kubernetes.Interface, namespace string, res
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredNetworkPolicyInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredNetworkPolicyInformerWithOptions(client, namespace, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredNetworkPolicyInformerWithOptions(client kubernetes.Interface, namespace string, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -72,13 +76,22 @@ func NewFilteredNetworkPolicyInformer(client kubernetes.Interface, namespace str
 			},
 		},
 		&networkingv1.NetworkPolicy{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *networkPolicyInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredNetworkPolicyInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}
+	for k, v := range f.factory.ExtraNamespaceScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredNetworkPolicyInformerWithOptions(client, f.namespace,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *networkPolicyInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/networking/v1beta1/ingressclass.go
+++ b/staging/src/k8s.io/client-go/informers/networking/v1beta1/ingressclass.go
@@ -55,7 +55,11 @@ func NewIngressClassInformer(client kubernetes.Interface, resyncPeriod time.Dura
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredIngressClassInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredIngressClassInformerWithOptions(client, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredIngressClassInformerWithOptions(client kubernetes.Interface, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -71,13 +75,22 @@ func NewFilteredIngressClassInformer(client kubernetes.Interface, resyncPeriod t
 			},
 		},
 		&networkingv1beta1.IngressClass{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *ingressClassInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredIngressClassInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{}
+	for k, v := range f.factory.ExtraClusterScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredIngressClassInformerWithOptions(client,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *ingressClassInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/node/v1/runtimeclass.go
+++ b/staging/src/k8s.io/client-go/informers/node/v1/runtimeclass.go
@@ -55,7 +55,11 @@ func NewRuntimeClassInformer(client kubernetes.Interface, resyncPeriod time.Dura
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredRuntimeClassInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredRuntimeClassInformerWithOptions(client, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredRuntimeClassInformerWithOptions(client kubernetes.Interface, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -71,13 +75,22 @@ func NewFilteredRuntimeClassInformer(client kubernetes.Interface, resyncPeriod t
 			},
 		},
 		&nodev1.RuntimeClass{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *runtimeClassInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredRuntimeClassInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{}
+	for k, v := range f.factory.ExtraClusterScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredRuntimeClassInformerWithOptions(client,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *runtimeClassInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/node/v1beta1/runtimeclass.go
+++ b/staging/src/k8s.io/client-go/informers/node/v1beta1/runtimeclass.go
@@ -55,7 +55,11 @@ func NewRuntimeClassInformer(client kubernetes.Interface, resyncPeriod time.Dura
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredRuntimeClassInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredRuntimeClassInformerWithOptions(client, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredRuntimeClassInformerWithOptions(client kubernetes.Interface, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -71,13 +75,22 @@ func NewFilteredRuntimeClassInformer(client kubernetes.Interface, resyncPeriod t
 			},
 		},
 		&nodev1beta1.RuntimeClass{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *runtimeClassInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredRuntimeClassInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{}
+	for k, v := range f.factory.ExtraClusterScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredRuntimeClassInformerWithOptions(client,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *runtimeClassInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/policy/v1/poddisruptionbudget.go
+++ b/staging/src/k8s.io/client-go/informers/policy/v1/poddisruptionbudget.go
@@ -56,7 +56,11 @@ func NewPodDisruptionBudgetInformer(client kubernetes.Interface, namespace strin
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredPodDisruptionBudgetInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredPodDisruptionBudgetInformerWithOptions(client, namespace, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredPodDisruptionBudgetInformerWithOptions(client kubernetes.Interface, namespace string, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -72,13 +76,22 @@ func NewFilteredPodDisruptionBudgetInformer(client kubernetes.Interface, namespa
 			},
 		},
 		&policyv1.PodDisruptionBudget{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *podDisruptionBudgetInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredPodDisruptionBudgetInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}
+	for k, v := range f.factory.ExtraNamespaceScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredPodDisruptionBudgetInformerWithOptions(client, f.namespace,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *podDisruptionBudgetInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/policy/v1beta1/poddisruptionbudget.go
+++ b/staging/src/k8s.io/client-go/informers/policy/v1beta1/poddisruptionbudget.go
@@ -56,7 +56,11 @@ func NewPodDisruptionBudgetInformer(client kubernetes.Interface, namespace strin
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredPodDisruptionBudgetInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredPodDisruptionBudgetInformerWithOptions(client, namespace, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredPodDisruptionBudgetInformerWithOptions(client kubernetes.Interface, namespace string, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -72,13 +76,22 @@ func NewFilteredPodDisruptionBudgetInformer(client kubernetes.Interface, namespa
 			},
 		},
 		&policyv1beta1.PodDisruptionBudget{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *podDisruptionBudgetInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredPodDisruptionBudgetInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}
+	for k, v := range f.factory.ExtraNamespaceScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredPodDisruptionBudgetInformerWithOptions(client, f.namespace,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *podDisruptionBudgetInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/policy/v1beta1/podsecuritypolicy.go
+++ b/staging/src/k8s.io/client-go/informers/policy/v1beta1/podsecuritypolicy.go
@@ -55,7 +55,11 @@ func NewPodSecurityPolicyInformer(client kubernetes.Interface, resyncPeriod time
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredPodSecurityPolicyInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredPodSecurityPolicyInformerWithOptions(client, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredPodSecurityPolicyInformerWithOptions(client kubernetes.Interface, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -71,13 +75,22 @@ func NewFilteredPodSecurityPolicyInformer(client kubernetes.Interface, resyncPer
 			},
 		},
 		&policyv1beta1.PodSecurityPolicy{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *podSecurityPolicyInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredPodSecurityPolicyInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{}
+	for k, v := range f.factory.ExtraClusterScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredPodSecurityPolicyInformerWithOptions(client,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *podSecurityPolicyInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/rbac/v1/clusterrole.go
+++ b/staging/src/k8s.io/client-go/informers/rbac/v1/clusterrole.go
@@ -55,7 +55,11 @@ func NewClusterRoleInformer(client kubernetes.Interface, resyncPeriod time.Durat
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredClusterRoleInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredClusterRoleInformerWithOptions(client, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredClusterRoleInformerWithOptions(client kubernetes.Interface, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -71,13 +75,22 @@ func NewFilteredClusterRoleInformer(client kubernetes.Interface, resyncPeriod ti
 			},
 		},
 		&rbacv1.ClusterRole{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *clusterRoleInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredClusterRoleInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{}
+	for k, v := range f.factory.ExtraClusterScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredClusterRoleInformerWithOptions(client,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *clusterRoleInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/rbac/v1/clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/informers/rbac/v1/clusterrolebinding.go
@@ -55,7 +55,11 @@ func NewClusterRoleBindingInformer(client kubernetes.Interface, resyncPeriod tim
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredClusterRoleBindingInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredClusterRoleBindingInformerWithOptions(client, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredClusterRoleBindingInformerWithOptions(client kubernetes.Interface, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -71,13 +75,22 @@ func NewFilteredClusterRoleBindingInformer(client kubernetes.Interface, resyncPe
 			},
 		},
 		&rbacv1.ClusterRoleBinding{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *clusterRoleBindingInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredClusterRoleBindingInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{}
+	for k, v := range f.factory.ExtraClusterScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredClusterRoleBindingInformerWithOptions(client,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *clusterRoleBindingInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/rbac/v1/role.go
+++ b/staging/src/k8s.io/client-go/informers/rbac/v1/role.go
@@ -56,7 +56,11 @@ func NewRoleInformer(client kubernetes.Interface, namespace string, resyncPeriod
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredRoleInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredRoleInformerWithOptions(client, namespace, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredRoleInformerWithOptions(client kubernetes.Interface, namespace string, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -72,13 +76,22 @@ func NewFilteredRoleInformer(client kubernetes.Interface, namespace string, resy
 			},
 		},
 		&rbacv1.Role{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *roleInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredRoleInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}
+	for k, v := range f.factory.ExtraNamespaceScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredRoleInformerWithOptions(client, f.namespace,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *roleInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/rbac/v1/rolebinding.go
+++ b/staging/src/k8s.io/client-go/informers/rbac/v1/rolebinding.go
@@ -56,7 +56,11 @@ func NewRoleBindingInformer(client kubernetes.Interface, namespace string, resyn
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredRoleBindingInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredRoleBindingInformerWithOptions(client, namespace, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredRoleBindingInformerWithOptions(client kubernetes.Interface, namespace string, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -72,13 +76,22 @@ func NewFilteredRoleBindingInformer(client kubernetes.Interface, namespace strin
 			},
 		},
 		&rbacv1.RoleBinding{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *roleBindingInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredRoleBindingInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}
+	for k, v := range f.factory.ExtraNamespaceScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredRoleBindingInformerWithOptions(client, f.namespace,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *roleBindingInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/rbac/v1alpha1/clusterrole.go
+++ b/staging/src/k8s.io/client-go/informers/rbac/v1alpha1/clusterrole.go
@@ -55,7 +55,11 @@ func NewClusterRoleInformer(client kubernetes.Interface, resyncPeriod time.Durat
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredClusterRoleInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredClusterRoleInformerWithOptions(client, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredClusterRoleInformerWithOptions(client kubernetes.Interface, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -71,13 +75,22 @@ func NewFilteredClusterRoleInformer(client kubernetes.Interface, resyncPeriod ti
 			},
 		},
 		&rbacv1alpha1.ClusterRole{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *clusterRoleInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredClusterRoleInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{}
+	for k, v := range f.factory.ExtraClusterScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredClusterRoleInformerWithOptions(client,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *clusterRoleInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/rbac/v1alpha1/clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/informers/rbac/v1alpha1/clusterrolebinding.go
@@ -55,7 +55,11 @@ func NewClusterRoleBindingInformer(client kubernetes.Interface, resyncPeriod tim
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredClusterRoleBindingInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredClusterRoleBindingInformerWithOptions(client, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredClusterRoleBindingInformerWithOptions(client kubernetes.Interface, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -71,13 +75,22 @@ func NewFilteredClusterRoleBindingInformer(client kubernetes.Interface, resyncPe
 			},
 		},
 		&rbacv1alpha1.ClusterRoleBinding{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *clusterRoleBindingInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredClusterRoleBindingInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{}
+	for k, v := range f.factory.ExtraClusterScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredClusterRoleBindingInformerWithOptions(client,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *clusterRoleBindingInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/rbac/v1alpha1/role.go
+++ b/staging/src/k8s.io/client-go/informers/rbac/v1alpha1/role.go
@@ -56,7 +56,11 @@ func NewRoleInformer(client kubernetes.Interface, namespace string, resyncPeriod
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredRoleInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredRoleInformerWithOptions(client, namespace, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredRoleInformerWithOptions(client kubernetes.Interface, namespace string, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -72,13 +76,22 @@ func NewFilteredRoleInformer(client kubernetes.Interface, namespace string, resy
 			},
 		},
 		&rbacv1alpha1.Role{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *roleInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredRoleInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}
+	for k, v := range f.factory.ExtraNamespaceScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredRoleInformerWithOptions(client, f.namespace,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *roleInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/rbac/v1alpha1/rolebinding.go
+++ b/staging/src/k8s.io/client-go/informers/rbac/v1alpha1/rolebinding.go
@@ -56,7 +56,11 @@ func NewRoleBindingInformer(client kubernetes.Interface, namespace string, resyn
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredRoleBindingInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredRoleBindingInformerWithOptions(client, namespace, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredRoleBindingInformerWithOptions(client kubernetes.Interface, namespace string, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -72,13 +76,22 @@ func NewFilteredRoleBindingInformer(client kubernetes.Interface, namespace strin
 			},
 		},
 		&rbacv1alpha1.RoleBinding{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *roleBindingInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredRoleBindingInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}
+	for k, v := range f.factory.ExtraNamespaceScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredRoleBindingInformerWithOptions(client, f.namespace,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *roleBindingInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/rbac/v1beta1/clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/informers/rbac/v1beta1/clusterrolebinding.go
@@ -55,7 +55,11 @@ func NewClusterRoleBindingInformer(client kubernetes.Interface, resyncPeriod tim
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredClusterRoleBindingInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredClusterRoleBindingInformerWithOptions(client, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredClusterRoleBindingInformerWithOptions(client kubernetes.Interface, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -71,13 +75,22 @@ func NewFilteredClusterRoleBindingInformer(client kubernetes.Interface, resyncPe
 			},
 		},
 		&rbacv1beta1.ClusterRoleBinding{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *clusterRoleBindingInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredClusterRoleBindingInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{}
+	for k, v := range f.factory.ExtraClusterScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredClusterRoleBindingInformerWithOptions(client,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *clusterRoleBindingInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/rbac/v1beta1/rolebinding.go
+++ b/staging/src/k8s.io/client-go/informers/rbac/v1beta1/rolebinding.go
@@ -56,7 +56,11 @@ func NewRoleBindingInformer(client kubernetes.Interface, namespace string, resyn
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredRoleBindingInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredRoleBindingInformerWithOptions(client, namespace, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredRoleBindingInformerWithOptions(client kubernetes.Interface, namespace string, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -72,13 +76,22 @@ func NewFilteredRoleBindingInformer(client kubernetes.Interface, namespace strin
 			},
 		},
 		&rbacv1beta1.RoleBinding{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *roleBindingInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredRoleBindingInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}
+	for k, v := range f.factory.ExtraNamespaceScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredRoleBindingInformerWithOptions(client, f.namespace,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *roleBindingInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/scheduling/v1/priorityclass.go
+++ b/staging/src/k8s.io/client-go/informers/scheduling/v1/priorityclass.go
@@ -55,7 +55,11 @@ func NewPriorityClassInformer(client kubernetes.Interface, resyncPeriod time.Dur
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredPriorityClassInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredPriorityClassInformerWithOptions(client, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredPriorityClassInformerWithOptions(client kubernetes.Interface, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -71,13 +75,22 @@ func NewFilteredPriorityClassInformer(client kubernetes.Interface, resyncPeriod 
 			},
 		},
 		&schedulingv1.PriorityClass{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *priorityClassInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredPriorityClassInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{}
+	for k, v := range f.factory.ExtraClusterScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredPriorityClassInformerWithOptions(client,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *priorityClassInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/scheduling/v1beta1/priorityclass.go
+++ b/staging/src/k8s.io/client-go/informers/scheduling/v1beta1/priorityclass.go
@@ -55,7 +55,11 @@ func NewPriorityClassInformer(client kubernetes.Interface, resyncPeriod time.Dur
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredPriorityClassInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredPriorityClassInformerWithOptions(client, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredPriorityClassInformerWithOptions(client kubernetes.Interface, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -71,13 +75,22 @@ func NewFilteredPriorityClassInformer(client kubernetes.Interface, resyncPeriod 
 			},
 		},
 		&schedulingv1beta1.PriorityClass{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *priorityClassInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredPriorityClassInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{}
+	for k, v := range f.factory.ExtraClusterScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredPriorityClassInformerWithOptions(client,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *priorityClassInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/storage/v1/csidriver.go
+++ b/staging/src/k8s.io/client-go/informers/storage/v1/csidriver.go
@@ -55,7 +55,11 @@ func NewCSIDriverInformer(client kubernetes.Interface, resyncPeriod time.Duratio
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredCSIDriverInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredCSIDriverInformerWithOptions(client, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredCSIDriverInformerWithOptions(client kubernetes.Interface, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -71,13 +75,22 @@ func NewFilteredCSIDriverInformer(client kubernetes.Interface, resyncPeriod time
 			},
 		},
 		&storagev1.CSIDriver{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *cSIDriverInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredCSIDriverInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{}
+	for k, v := range f.factory.ExtraClusterScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredCSIDriverInformerWithOptions(client,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *cSIDriverInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/storage/v1/csinode.go
+++ b/staging/src/k8s.io/client-go/informers/storage/v1/csinode.go
@@ -55,7 +55,11 @@ func NewCSINodeInformer(client kubernetes.Interface, resyncPeriod time.Duration,
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredCSINodeInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredCSINodeInformerWithOptions(client, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredCSINodeInformerWithOptions(client kubernetes.Interface, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -71,13 +75,22 @@ func NewFilteredCSINodeInformer(client kubernetes.Interface, resyncPeriod time.D
 			},
 		},
 		&storagev1.CSINode{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *cSINodeInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredCSINodeInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{}
+	for k, v := range f.factory.ExtraClusterScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredCSINodeInformerWithOptions(client,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *cSINodeInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/storage/v1/storageclass.go
+++ b/staging/src/k8s.io/client-go/informers/storage/v1/storageclass.go
@@ -55,7 +55,11 @@ func NewStorageClassInformer(client kubernetes.Interface, resyncPeriod time.Dura
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredStorageClassInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredStorageClassInformerWithOptions(client, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredStorageClassInformerWithOptions(client kubernetes.Interface, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -71,13 +75,22 @@ func NewFilteredStorageClassInformer(client kubernetes.Interface, resyncPeriod t
 			},
 		},
 		&storagev1.StorageClass{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *storageClassInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredStorageClassInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{}
+	for k, v := range f.factory.ExtraClusterScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredStorageClassInformerWithOptions(client,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *storageClassInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/storage/v1/volumeattachment.go
+++ b/staging/src/k8s.io/client-go/informers/storage/v1/volumeattachment.go
@@ -55,7 +55,11 @@ func NewVolumeAttachmentInformer(client kubernetes.Interface, resyncPeriod time.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredVolumeAttachmentInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredVolumeAttachmentInformerWithOptions(client, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredVolumeAttachmentInformerWithOptions(client kubernetes.Interface, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -71,13 +75,22 @@ func NewFilteredVolumeAttachmentInformer(client kubernetes.Interface, resyncPeri
 			},
 		},
 		&storagev1.VolumeAttachment{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *volumeAttachmentInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredVolumeAttachmentInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{}
+	for k, v := range f.factory.ExtraClusterScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredVolumeAttachmentInformerWithOptions(client,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *volumeAttachmentInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/storage/v1alpha1/csistoragecapacity.go
+++ b/staging/src/k8s.io/client-go/informers/storage/v1alpha1/csistoragecapacity.go
@@ -56,7 +56,11 @@ func NewCSIStorageCapacityInformer(client kubernetes.Interface, namespace string
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredCSIStorageCapacityInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredCSIStorageCapacityInformerWithOptions(client, namespace, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredCSIStorageCapacityInformerWithOptions(client kubernetes.Interface, namespace string, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -72,13 +76,22 @@ func NewFilteredCSIStorageCapacityInformer(client kubernetes.Interface, namespac
 			},
 		},
 		&storagev1alpha1.CSIStorageCapacity{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *cSIStorageCapacityInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredCSIStorageCapacityInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}
+	for k, v := range f.factory.ExtraNamespaceScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredCSIStorageCapacityInformerWithOptions(client, f.namespace,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *cSIStorageCapacityInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/storage/v1alpha1/volumeattachment.go
+++ b/staging/src/k8s.io/client-go/informers/storage/v1alpha1/volumeattachment.go
@@ -55,7 +55,11 @@ func NewVolumeAttachmentInformer(client kubernetes.Interface, resyncPeriod time.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredVolumeAttachmentInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredVolumeAttachmentInformerWithOptions(client, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredVolumeAttachmentInformerWithOptions(client kubernetes.Interface, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -71,13 +75,22 @@ func NewFilteredVolumeAttachmentInformer(client kubernetes.Interface, resyncPeri
 			},
 		},
 		&storagev1alpha1.VolumeAttachment{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *volumeAttachmentInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredVolumeAttachmentInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{}
+	for k, v := range f.factory.ExtraClusterScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredVolumeAttachmentInformerWithOptions(client,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *volumeAttachmentInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/storage/v1beta1/csinode.go
+++ b/staging/src/k8s.io/client-go/informers/storage/v1beta1/csinode.go
@@ -55,7 +55,11 @@ func NewCSINodeInformer(client kubernetes.Interface, resyncPeriod time.Duration,
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredCSINodeInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredCSINodeInformerWithOptions(client, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredCSINodeInformerWithOptions(client kubernetes.Interface, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -71,13 +75,22 @@ func NewFilteredCSINodeInformer(client kubernetes.Interface, resyncPeriod time.D
 			},
 		},
 		&storagev1beta1.CSINode{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *cSINodeInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredCSINodeInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{}
+	for k, v := range f.factory.ExtraClusterScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredCSINodeInformerWithOptions(client,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *cSINodeInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/storage/v1beta1/csistoragecapacity.go
+++ b/staging/src/k8s.io/client-go/informers/storage/v1beta1/csistoragecapacity.go
@@ -56,7 +56,11 @@ func NewCSIStorageCapacityInformer(client kubernetes.Interface, namespace string
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredCSIStorageCapacityInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredCSIStorageCapacityInformerWithOptions(client, namespace, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredCSIStorageCapacityInformerWithOptions(client kubernetes.Interface, namespace string, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -72,13 +76,22 @@ func NewFilteredCSIStorageCapacityInformer(client kubernetes.Interface, namespac
 			},
 		},
 		&storagev1beta1.CSIStorageCapacity{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *cSIStorageCapacityInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredCSIStorageCapacityInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}
+	for k, v := range f.factory.ExtraNamespaceScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredCSIStorageCapacityInformerWithOptions(client, f.namespace,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *cSIStorageCapacityInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/storage/v1beta1/volumeattachment.go
+++ b/staging/src/k8s.io/client-go/informers/storage/v1beta1/volumeattachment.go
@@ -55,7 +55,11 @@ func NewVolumeAttachmentInformer(client kubernetes.Interface, resyncPeriod time.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredVolumeAttachmentInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredVolumeAttachmentInformerWithOptions(client, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredVolumeAttachmentInformerWithOptions(client kubernetes.Interface, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -71,13 +75,22 @@ func NewFilteredVolumeAttachmentInformer(client kubernetes.Interface, resyncPeri
 			},
 		},
 		&storagev1beta1.VolumeAttachment{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *volumeAttachmentInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredVolumeAttachmentInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{}
+	for k, v := range f.factory.ExtraClusterScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredVolumeAttachmentInformerWithOptions(client,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *volumeAttachmentInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/tools/cache/shared_informer.go
+++ b/staging/src/k8s.io/client-go/tools/cache/shared_informer.go
@@ -190,12 +190,24 @@ type SharedIndexInformer interface {
 	GetIndexer() Indexer
 }
 
-// NewSharedInformer creates a new instance for the listwatcher.
+// NewSharedInformer delegates to NewSharedIndexInformerWithOptions to
+// create a new instance for the listwatcher.
 func NewSharedInformer(lw ListerWatcher, exampleObject runtime.Object, defaultEventHandlerResyncPeriod time.Duration) SharedInformer {
-	return NewSharedIndexInformer(lw, exampleObject, defaultEventHandlerResyncPeriod, Indexers{})
+	return NewSharedIndexInformerWithOptions(lw, exampleObject, WithResyncPeriod(defaultEventHandlerResyncPeriod))
 }
 
-// NewSharedIndexInformer creates a new instance for the listwatcher.
+// NewSharedIndexInformer delegates to NewSharedIndexInformerWithOptions
+// to create a new instance for the listwatcher.
+func NewSharedIndexInformer(lw ListerWatcher, exampleObject runtime.Object, defaultEventHandlerResyncPeriod time.Duration, indexers Indexers) SharedIndexInformer {
+	return NewSharedIndexInformerWithOptions(
+		lw,
+		exampleObject,
+		WithResyncPeriod(defaultEventHandlerResyncPeriod),
+		WithIndexers(indexers),
+	)
+}
+
+// NewSharedIndexInformerWithOptions creates a new instance for the listwatcher.
 // The created informer will not do resyncs if the given
 // defaultEventHandlerResyncPeriod is zero.  Otherwise: for each
 // handler that with a non-zero requested resync period, whether added
@@ -207,19 +219,54 @@ func NewSharedInformer(lw ListerWatcher, exampleObject runtime.Object, defaultEv
 // requested before the informer starts and the
 // defaultEventHandlerResyncPeriod given here and (b) the constant
 // `minimumResyncPeriod` defined in this file.
-func NewSharedIndexInformer(lw ListerWatcher, exampleObject runtime.Object, defaultEventHandlerResyncPeriod time.Duration, indexers Indexers) SharedIndexInformer {
+func NewSharedIndexInformerWithOptions(lw ListerWatcher, exampleObject runtime.Object, opts ...SharedInformerOption) SharedIndexInformer {
 	realClock := &clock.RealClock{}
 	sharedIndexInformer := &sharedIndexInformer{
-		processor:                       &sharedProcessor{clock: realClock},
-		indexer:                         NewIndexer(DeletionHandlingMetaNamespaceKeyFunc, indexers),
-		listerWatcher:                   lw,
-		objectType:                      exampleObject,
-		resyncCheckPeriod:               defaultEventHandlerResyncPeriod,
-		defaultEventHandlerResyncPeriod: defaultEventHandlerResyncPeriod,
-		cacheMutationDetector:           NewCacheMutationDetector(fmt.Sprintf("%T", exampleObject)),
-		clock:                           realClock,
+		processor:             &sharedProcessor{clock: realClock},
+		listerWatcher:         lw,
+		objectType:            exampleObject,
+		cacheMutationDetector: NewCacheMutationDetector(fmt.Sprintf("%T", exampleObject)),
+		clock:                 realClock,
 	}
+
+	for _, opt := range opts {
+		opt(sharedIndexInformer)
+	}
+
+	if sharedIndexInformer.keyFunc == nil {
+		sharedIndexInformer.keyFunc = DeletionHandlingMetaNamespaceKeyFunc
+	}
+	if sharedIndexInformer.indexers == nil {
+		sharedIndexInformer.indexers = Indexers{}
+	}
+	sharedIndexInformer.indexer = NewIndexer(sharedIndexInformer.keyFunc, sharedIndexInformer.indexers)
+
 	return sharedIndexInformer
+}
+
+// SharedInformerOption defines the functional option type for the SharedInformer
+type SharedInformerOption func(*sharedIndexInformer)
+
+// WithResyncPeriod sets a custom resync period for the informer
+func WithResyncPeriod(t time.Duration) SharedInformerOption {
+	return func(s *sharedIndexInformer) {
+		s.resyncCheckPeriod = t
+		s.defaultEventHandlerResyncPeriod = t
+	}
+}
+
+// WithKeyFunction sets the key function for an informer
+func WithKeyFunction(k KeyFunc) SharedInformerOption {
+	return func(s *sharedIndexInformer) {
+		s.keyFunc = k
+	}
+}
+
+// WithIndexers sets the indexers for the informer
+func WithIndexers(ind Indexers) SharedInformerOption {
+	return func(s *sharedIndexInformer) {
+		s.indexers = ind
+	}
 }
 
 // InformerSynced is a function that can be used to determine if an informer has synced.  This is useful for determining if caches have synced.
@@ -287,6 +334,9 @@ func WaitForCacheSync(stopCh <-chan struct{}, cacheSyncs ...InformerSynced) bool
 type sharedIndexInformer struct {
 	indexer    Indexer
 	controller Controller
+
+	keyFunc  KeyFunc
+	indexers Indexers
 
 	processor             *sharedProcessor
 	cacheMutationDetector MutationDetector
@@ -373,6 +423,7 @@ func (s *sharedIndexInformer) Run(stopCh <-chan struct{}) {
 		return
 	}
 	fifo := NewDeltaFIFOWithOptions(DeltaFIFOOptions{
+		KeyFunction:           s.keyFunc,
 		KnownObjects:          s.indexer,
 		EmitDeltaTypeReplaced: true,
 	})

--- a/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/factoryinterface.go
+++ b/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/factoryinterface.go
@@ -63,8 +63,10 @@ func (g *factoryInterfaceGenerator) GenerateType(c *generator.Context, t *types.
 	klog.V(5).Infof("processing type %v", t)
 
 	m := map[string]interface{}{
+		"cacheIndexers":            c.Universe.Type(cacheIndexers),
 		"cacheSharedIndexInformer": c.Universe.Type(cacheSharedIndexInformer),
 		"clientSetPackage":         c.Universe.Type(types.Name{Package: g.clientSetPackage, Name: "Interface"}),
+		"cacheKeyFunc":             c.Universe.Type(cacheKeyFunc),
 		"runtimeObject":            c.Universe.Type(runtimeObject),
 		"timeDuration":             c.Universe.Type(timeDuration),
 		"v1ListOptions":            c.Universe.Type(v1ListOptions),
@@ -83,6 +85,9 @@ type NewInformerFunc func({{.clientSetPackage|raw}}, {{.timeDuration|raw}}) cach
 type SharedInformerFactory interface {
 	Start(stopCh <-chan struct{})
 	InformerFor(obj {{.runtimeObject|raw}}, newFunc NewInformerFunc) {{.cacheSharedIndexInformer|raw}}
+	ExtraClusterScopedIndexers() {{.cacheIndexers|raw}}
+	ExtraNamespaceScopedIndexers() {{.cacheIndexers|raw}}
+	KeyFunction() {{.cacheKeyFunc|raw}}
 }
 
 // TweakListOptionsFunc is a function that transforms a {{.v1ListOptions|raw}}.

--- a/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/types.go
+++ b/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/types.go
@@ -19,15 +19,21 @@ package generators
 import "k8s.io/gengo/types"
 
 var (
-	apiScheme                   = types.Name{Package: "k8s.io/kubernetes/pkg/api/legacyscheme", Name: "Scheme"}
-	cacheGenericLister          = types.Name{Package: "k8s.io/client-go/tools/cache", Name: "GenericLister"}
-	cacheIndexers               = types.Name{Package: "k8s.io/client-go/tools/cache", Name: "Indexers"}
+	apiScheme                 = types.Name{Package: "k8s.io/kubernetes/pkg/api/legacyscheme", Name: "Scheme"}
+	cacheGenericLister        = types.Name{Package: "k8s.io/client-go/tools/cache", Name: "GenericLister"}
+	cacheIndexers             = types.Name{Package: "k8s.io/client-go/tools/cache", Name: "Indexers"}
+	cacheSharedInformerOption = types.Name{Package: "k8s.io/client-go/tools/cache", Name: "SharedInformerOption"}
+	cacheWithIndexers         = types.Name{Package: "k8s.io/client-go/tools/cache", Name: "WithIndexers"}
+	cacheWithKeyFunction      = types.Name{Package: "k8s.io/client-go/tools/cache", Name: "WithKeyFunction"}
+	cacheWithResyncPeriod     = types.Name{Package: "k8s.io/client-go/tools/cache", Name: "WithResyncPeriod"}
+
 	cacheListWatch              = types.Name{Package: "k8s.io/client-go/tools/cache", Name: "ListWatch"}
 	cacheMetaNamespaceIndexFunc = types.Name{Package: "k8s.io/client-go/tools/cache", Name: "MetaNamespaceIndexFunc"}
 	cacheNamespaceIndex         = types.Name{Package: "k8s.io/client-go/tools/cache", Name: "NamespaceIndex"}
 	cacheNewGenericLister       = types.Name{Package: "k8s.io/client-go/tools/cache", Name: "NewGenericLister"}
 	cacheNewSharedIndexInformer = types.Name{Package: "k8s.io/client-go/tools/cache", Name: "NewSharedIndexInformer"}
 	cacheSharedIndexInformer    = types.Name{Package: "k8s.io/client-go/tools/cache", Name: "SharedIndexInformer"}
+	cacheKeyFunc                = types.Name{Package: "k8s.io/client-go/tools/cache", Name: "KeyFunc"}
 	listOptions                 = types.Name{Package: "k8s.io/kubernetes/pkg/apis/core", Name: "ListOptions"}
 	reflectType                 = types.Name{Package: "reflect", Name: "Type"}
 	runtimeObject               = types.Name{Package: "k8s.io/apimachinery/pkg/runtime", Name: "Object"}

--- a/staging/src/k8s.io/code-generator/examples/HyphenGroup/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/code-generator/examples/HyphenGroup/informers/externalversions/factory.go
@@ -36,12 +36,15 @@ import (
 type SharedInformerOption func(*sharedInformerFactory) *sharedInformerFactory
 
 type sharedInformerFactory struct {
-	client           versioned.Interface
-	namespace        string
-	tweakListOptions internalinterfaces.TweakListOptionsFunc
-	lock             sync.Mutex
-	defaultResync    time.Duration
-	customResync     map[reflect.Type]time.Duration
+	client                       versioned.Interface
+	namespace                    string
+	tweakListOptions             internalinterfaces.TweakListOptionsFunc
+	lock                         sync.Mutex
+	defaultResync                time.Duration
+	customResync                 map[reflect.Type]time.Duration
+	extraClusterScopedIndexers   cache.Indexers
+	extraNamespaceScopedIndexers cache.Indexers
+	keyFunc                      cache.KeyFunc
 
 	informers map[reflect.Type]cache.SharedIndexInformer
 	// startedInformers is used for tracking which informers have been started.
@@ -75,6 +78,30 @@ func WithNamespace(namespace string) SharedInformerOption {
 	}
 }
 
+// WithExtraClusterScopedIndexers adds cluster scoped indexers on all informers of the configured SharedInformerFactory
+func WithExtraClusterScopedIndexers(indexers cache.Indexers) SharedInformerOption {
+	return func(factory *sharedInformerFactory) *sharedInformerFactory {
+		factory.extraClusterScopedIndexers = indexers
+		return factory
+	}
+}
+
+// WithExtraNamespaceScopedIndexers adds namespace scoped indexers on all informers of the configured SharedInformerFactory
+func WithExtraNamespaceScopedIndexers(indexers cache.Indexers) SharedInformerOption {
+	return func(factory *sharedInformerFactory) *sharedInformerFactory {
+		factory.extraNamespaceScopedIndexers = indexers
+		return factory
+	}
+}
+
+// WithKeyFunction sets a custom key function for all informers of the configured SharedInformerFactory
+func WithKeyFunction(keyFunc cache.KeyFunc) SharedInformerOption {
+	return func(factory *sharedInformerFactory) *sharedInformerFactory {
+		factory.keyFunc = keyFunc
+		return factory
+	}
+}
+
 // NewSharedInformerFactory constructs a new instance of sharedInformerFactory for all namespaces.
 func NewSharedInformerFactory(client versioned.Interface, defaultResync time.Duration) SharedInformerFactory {
 	return NewSharedInformerFactoryWithOptions(client, defaultResync)
@@ -91,12 +118,14 @@ func NewFilteredSharedInformerFactory(client versioned.Interface, defaultResync 
 // NewSharedInformerFactoryWithOptions constructs a new instance of a SharedInformerFactory with additional options.
 func NewSharedInformerFactoryWithOptions(client versioned.Interface, defaultResync time.Duration, options ...SharedInformerOption) SharedInformerFactory {
 	factory := &sharedInformerFactory{
-		client:           client,
-		namespace:        v1.NamespaceAll,
-		defaultResync:    defaultResync,
-		informers:        make(map[reflect.Type]cache.SharedIndexInformer),
-		startedInformers: make(map[reflect.Type]bool),
-		customResync:     make(map[reflect.Type]time.Duration),
+		client:                       client,
+		namespace:                    v1.NamespaceAll,
+		defaultResync:                defaultResync,
+		informers:                    make(map[reflect.Type]cache.SharedIndexInformer),
+		startedInformers:             make(map[reflect.Type]bool),
+		customResync:                 make(map[reflect.Type]time.Duration),
+		extraClusterScopedIndexers:   cache.Indexers{},
+		extraNamespaceScopedIndexers: cache.Indexers{},
 	}
 
 	// Apply all options
@@ -163,6 +192,21 @@ func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internal
 	f.informers[informerType] = informer
 
 	return informer
+}
+
+// KeyFunction returns any extra cluster scoped indexers set on the factory
+func (f *sharedInformerFactory) ExtraClusterScopedIndexers() cache.Indexers {
+	return f.extraClusterScopedIndexers
+}
+
+// KeyFunction returns any extra namespace scoped indexers set on the factory
+func (f *sharedInformerFactory) ExtraNamespaceScopedIndexers() cache.Indexers {
+	return f.extraNamespaceScopedIndexers
+}
+
+// KeyFunction returns the keyfunction set on the factory
+func (f *sharedInformerFactory) KeyFunction() cache.KeyFunc {
+	return f.keyFunc
 }
 
 // SharedInformerFactory provides shared informers for resources in all known

--- a/staging/src/k8s.io/code-generator/examples/HyphenGroup/informers/externalversions/internalinterfaces/factory_interfaces.go
+++ b/staging/src/k8s.io/code-generator/examples/HyphenGroup/informers/externalversions/internalinterfaces/factory_interfaces.go
@@ -34,6 +34,9 @@ type NewInformerFunc func(versioned.Interface, time.Duration) cache.SharedIndexI
 type SharedInformerFactory interface {
 	Start(stopCh <-chan struct{})
 	InformerFor(obj runtime.Object, newFunc NewInformerFunc) cache.SharedIndexInformer
+	ExtraClusterScopedIndexers() cache.Indexers
+	ExtraNamespaceScopedIndexers() cache.Indexers
+	KeyFunction() cache.KeyFunc
 }
 
 // TweakListOptionsFunc is a function that transforms a v1.ListOptions.

--- a/staging/src/k8s.io/code-generator/examples/MixedCase/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/code-generator/examples/MixedCase/informers/externalversions/factory.go
@@ -36,12 +36,15 @@ import (
 type SharedInformerOption func(*sharedInformerFactory) *sharedInformerFactory
 
 type sharedInformerFactory struct {
-	client           versioned.Interface
-	namespace        string
-	tweakListOptions internalinterfaces.TweakListOptionsFunc
-	lock             sync.Mutex
-	defaultResync    time.Duration
-	customResync     map[reflect.Type]time.Duration
+	client                       versioned.Interface
+	namespace                    string
+	tweakListOptions             internalinterfaces.TweakListOptionsFunc
+	lock                         sync.Mutex
+	defaultResync                time.Duration
+	customResync                 map[reflect.Type]time.Duration
+	extraClusterScopedIndexers   cache.Indexers
+	extraNamespaceScopedIndexers cache.Indexers
+	keyFunc                      cache.KeyFunc
 
 	informers map[reflect.Type]cache.SharedIndexInformer
 	// startedInformers is used for tracking which informers have been started.
@@ -75,6 +78,30 @@ func WithNamespace(namespace string) SharedInformerOption {
 	}
 }
 
+// WithExtraClusterScopedIndexers adds cluster scoped indexers on all informers of the configured SharedInformerFactory
+func WithExtraClusterScopedIndexers(indexers cache.Indexers) SharedInformerOption {
+	return func(factory *sharedInformerFactory) *sharedInformerFactory {
+		factory.extraClusterScopedIndexers = indexers
+		return factory
+	}
+}
+
+// WithExtraNamespaceScopedIndexers adds namespace scoped indexers on all informers of the configured SharedInformerFactory
+func WithExtraNamespaceScopedIndexers(indexers cache.Indexers) SharedInformerOption {
+	return func(factory *sharedInformerFactory) *sharedInformerFactory {
+		factory.extraNamespaceScopedIndexers = indexers
+		return factory
+	}
+}
+
+// WithKeyFunction sets a custom key function for all informers of the configured SharedInformerFactory
+func WithKeyFunction(keyFunc cache.KeyFunc) SharedInformerOption {
+	return func(factory *sharedInformerFactory) *sharedInformerFactory {
+		factory.keyFunc = keyFunc
+		return factory
+	}
+}
+
 // NewSharedInformerFactory constructs a new instance of sharedInformerFactory for all namespaces.
 func NewSharedInformerFactory(client versioned.Interface, defaultResync time.Duration) SharedInformerFactory {
 	return NewSharedInformerFactoryWithOptions(client, defaultResync)
@@ -91,12 +118,14 @@ func NewFilteredSharedInformerFactory(client versioned.Interface, defaultResync 
 // NewSharedInformerFactoryWithOptions constructs a new instance of a SharedInformerFactory with additional options.
 func NewSharedInformerFactoryWithOptions(client versioned.Interface, defaultResync time.Duration, options ...SharedInformerOption) SharedInformerFactory {
 	factory := &sharedInformerFactory{
-		client:           client,
-		namespace:        v1.NamespaceAll,
-		defaultResync:    defaultResync,
-		informers:        make(map[reflect.Type]cache.SharedIndexInformer),
-		startedInformers: make(map[reflect.Type]bool),
-		customResync:     make(map[reflect.Type]time.Duration),
+		client:                       client,
+		namespace:                    v1.NamespaceAll,
+		defaultResync:                defaultResync,
+		informers:                    make(map[reflect.Type]cache.SharedIndexInformer),
+		startedInformers:             make(map[reflect.Type]bool),
+		customResync:                 make(map[reflect.Type]time.Duration),
+		extraClusterScopedIndexers:   cache.Indexers{},
+		extraNamespaceScopedIndexers: cache.Indexers{},
 	}
 
 	// Apply all options
@@ -163,6 +192,21 @@ func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internal
 	f.informers[informerType] = informer
 
 	return informer
+}
+
+// KeyFunction returns any extra cluster scoped indexers set on the factory
+func (f *sharedInformerFactory) ExtraClusterScopedIndexers() cache.Indexers {
+	return f.extraClusterScopedIndexers
+}
+
+// KeyFunction returns any extra namespace scoped indexers set on the factory
+func (f *sharedInformerFactory) ExtraNamespaceScopedIndexers() cache.Indexers {
+	return f.extraNamespaceScopedIndexers
+}
+
+// KeyFunction returns the keyfunction set on the factory
+func (f *sharedInformerFactory) KeyFunction() cache.KeyFunc {
+	return f.keyFunc
 }
 
 // SharedInformerFactory provides shared informers for resources in all known

--- a/staging/src/k8s.io/code-generator/examples/MixedCase/informers/externalversions/internalinterfaces/factory_interfaces.go
+++ b/staging/src/k8s.io/code-generator/examples/MixedCase/informers/externalversions/internalinterfaces/factory_interfaces.go
@@ -34,6 +34,9 @@ type NewInformerFunc func(versioned.Interface, time.Duration) cache.SharedIndexI
 type SharedInformerFactory interface {
 	Start(stopCh <-chan struct{})
 	InformerFor(obj runtime.Object, newFunc NewInformerFunc) cache.SharedIndexInformer
+	ExtraClusterScopedIndexers() cache.Indexers
+	ExtraNamespaceScopedIndexers() cache.Indexers
+	KeyFunction() cache.KeyFunc
 }
 
 // TweakListOptionsFunc is a function that transforms a v1.ListOptions.

--- a/staging/src/k8s.io/code-generator/examples/apiserver/informers/externalversions/example2/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/informers/externalversions/example2/v1/testtype.go
@@ -56,7 +56,11 @@ func NewTestTypeInformer(client versioned.Interface, namespace string, resyncPer
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredTestTypeInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredTestTypeInformerWithOptions(client, namespace, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredTestTypeInformerWithOptions(client versioned.Interface, namespace string, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -72,13 +76,22 @@ func NewFilteredTestTypeInformer(client versioned.Interface, namespace string, r
 			},
 		},
 		&example2v1.TestType{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *testTypeInformer) defaultInformer(client versioned.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredTestTypeInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}
+	for k, v := range f.factory.ExtraNamespaceScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredTestTypeInformerWithOptions(client, f.namespace,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *testTypeInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/code-generator/examples/apiserver/informers/externalversions/example3.io/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/informers/externalversions/example3.io/v1/testtype.go
@@ -56,7 +56,11 @@ func NewTestTypeInformer(client versioned.Interface, namespace string, resyncPer
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredTestTypeInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredTestTypeInformerWithOptions(client, namespace, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredTestTypeInformerWithOptions(client versioned.Interface, namespace string, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -72,13 +76,22 @@ func NewFilteredTestTypeInformer(client versioned.Interface, namespace string, r
 			},
 		},
 		&example3iov1.TestType{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *testTypeInformer) defaultInformer(client versioned.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredTestTypeInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}
+	for k, v := range f.factory.ExtraNamespaceScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredTestTypeInformerWithOptions(client, f.namespace,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *testTypeInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/code-generator/examples/apiserver/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/informers/externalversions/factory.go
@@ -38,12 +38,15 @@ import (
 type SharedInformerOption func(*sharedInformerFactory) *sharedInformerFactory
 
 type sharedInformerFactory struct {
-	client           versioned.Interface
-	namespace        string
-	tweakListOptions internalinterfaces.TweakListOptionsFunc
-	lock             sync.Mutex
-	defaultResync    time.Duration
-	customResync     map[reflect.Type]time.Duration
+	client                       versioned.Interface
+	namespace                    string
+	tweakListOptions             internalinterfaces.TweakListOptionsFunc
+	lock                         sync.Mutex
+	defaultResync                time.Duration
+	customResync                 map[reflect.Type]time.Duration
+	extraClusterScopedIndexers   cache.Indexers
+	extraNamespaceScopedIndexers cache.Indexers
+	keyFunc                      cache.KeyFunc
 
 	informers map[reflect.Type]cache.SharedIndexInformer
 	// startedInformers is used for tracking which informers have been started.
@@ -77,6 +80,30 @@ func WithNamespace(namespace string) SharedInformerOption {
 	}
 }
 
+// WithExtraClusterScopedIndexers adds cluster scoped indexers on all informers of the configured SharedInformerFactory
+func WithExtraClusterScopedIndexers(indexers cache.Indexers) SharedInformerOption {
+	return func(factory *sharedInformerFactory) *sharedInformerFactory {
+		factory.extraClusterScopedIndexers = indexers
+		return factory
+	}
+}
+
+// WithExtraNamespaceScopedIndexers adds namespace scoped indexers on all informers of the configured SharedInformerFactory
+func WithExtraNamespaceScopedIndexers(indexers cache.Indexers) SharedInformerOption {
+	return func(factory *sharedInformerFactory) *sharedInformerFactory {
+		factory.extraNamespaceScopedIndexers = indexers
+		return factory
+	}
+}
+
+// WithKeyFunction sets a custom key function for all informers of the configured SharedInformerFactory
+func WithKeyFunction(keyFunc cache.KeyFunc) SharedInformerOption {
+	return func(factory *sharedInformerFactory) *sharedInformerFactory {
+		factory.keyFunc = keyFunc
+		return factory
+	}
+}
+
 // NewSharedInformerFactory constructs a new instance of sharedInformerFactory for all namespaces.
 func NewSharedInformerFactory(client versioned.Interface, defaultResync time.Duration) SharedInformerFactory {
 	return NewSharedInformerFactoryWithOptions(client, defaultResync)
@@ -93,12 +120,14 @@ func NewFilteredSharedInformerFactory(client versioned.Interface, defaultResync 
 // NewSharedInformerFactoryWithOptions constructs a new instance of a SharedInformerFactory with additional options.
 func NewSharedInformerFactoryWithOptions(client versioned.Interface, defaultResync time.Duration, options ...SharedInformerOption) SharedInformerFactory {
 	factory := &sharedInformerFactory{
-		client:           client,
-		namespace:        v1.NamespaceAll,
-		defaultResync:    defaultResync,
-		informers:        make(map[reflect.Type]cache.SharedIndexInformer),
-		startedInformers: make(map[reflect.Type]bool),
-		customResync:     make(map[reflect.Type]time.Duration),
+		client:                       client,
+		namespace:                    v1.NamespaceAll,
+		defaultResync:                defaultResync,
+		informers:                    make(map[reflect.Type]cache.SharedIndexInformer),
+		startedInformers:             make(map[reflect.Type]bool),
+		customResync:                 make(map[reflect.Type]time.Duration),
+		extraClusterScopedIndexers:   cache.Indexers{},
+		extraNamespaceScopedIndexers: cache.Indexers{},
 	}
 
 	// Apply all options
@@ -165,6 +194,21 @@ func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internal
 	f.informers[informerType] = informer
 
 	return informer
+}
+
+// KeyFunction returns any extra cluster scoped indexers set on the factory
+func (f *sharedInformerFactory) ExtraClusterScopedIndexers() cache.Indexers {
+	return f.extraClusterScopedIndexers
+}
+
+// KeyFunction returns any extra namespace scoped indexers set on the factory
+func (f *sharedInformerFactory) ExtraNamespaceScopedIndexers() cache.Indexers {
+	return f.extraNamespaceScopedIndexers
+}
+
+// KeyFunction returns the keyfunction set on the factory
+func (f *sharedInformerFactory) KeyFunction() cache.KeyFunc {
+	return f.keyFunc
 }
 
 // SharedInformerFactory provides shared informers for resources in all known

--- a/staging/src/k8s.io/code-generator/examples/apiserver/informers/externalversions/internalinterfaces/factory_interfaces.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/informers/externalversions/internalinterfaces/factory_interfaces.go
@@ -34,6 +34,9 @@ type NewInformerFunc func(versioned.Interface, time.Duration) cache.SharedIndexI
 type SharedInformerFactory interface {
 	Start(stopCh <-chan struct{})
 	InformerFor(obj runtime.Object, newFunc NewInformerFunc) cache.SharedIndexInformer
+	ExtraClusterScopedIndexers() cache.Indexers
+	ExtraNamespaceScopedIndexers() cache.Indexers
+	KeyFunction() cache.KeyFunc
 }
 
 // TweakListOptionsFunc is a function that transforms a v1.ListOptions.

--- a/staging/src/k8s.io/code-generator/examples/apiserver/informers/internalversion/example/internalversion/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/informers/internalversion/example/internalversion/testtype.go
@@ -56,7 +56,11 @@ func NewTestTypeInformer(client clientsetinternalversion.Interface, namespace st
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredTestTypeInformer(client clientsetinternalversion.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredTestTypeInformerWithOptions(client, namespace, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredTestTypeInformerWithOptions(client clientsetinternalversion.Interface, namespace string, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -72,13 +76,22 @@ func NewFilteredTestTypeInformer(client clientsetinternalversion.Interface, name
 			},
 		},
 		&example.TestType{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *testTypeInformer) defaultInformer(client clientsetinternalversion.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredTestTypeInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}
+	for k, v := range f.factory.ExtraNamespaceScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredTestTypeInformerWithOptions(client, f.namespace,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *testTypeInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/code-generator/examples/apiserver/informers/internalversion/example3.io/internalversion/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/informers/internalversion/example3.io/internalversion/testtype.go
@@ -56,7 +56,11 @@ func NewTestTypeInformer(client clientsetinternalversion.Interface, namespace st
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredTestTypeInformer(client clientsetinternalversion.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredTestTypeInformerWithOptions(client, namespace, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredTestTypeInformerWithOptions(client clientsetinternalversion.Interface, namespace string, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -72,13 +76,22 @@ func NewFilteredTestTypeInformer(client clientsetinternalversion.Interface, name
 			},
 		},
 		&example3io.TestType{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *testTypeInformer) defaultInformer(client clientsetinternalversion.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredTestTypeInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}
+	for k, v := range f.factory.ExtraNamespaceScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredTestTypeInformerWithOptions(client, f.namespace,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *testTypeInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/code-generator/examples/apiserver/informers/internalversion/factory.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/informers/internalversion/factory.go
@@ -38,12 +38,15 @@ import (
 type SharedInformerOption func(*sharedInformerFactory) *sharedInformerFactory
 
 type sharedInformerFactory struct {
-	client           internalversion.Interface
-	namespace        string
-	tweakListOptions internalinterfaces.TweakListOptionsFunc
-	lock             sync.Mutex
-	defaultResync    time.Duration
-	customResync     map[reflect.Type]time.Duration
+	client                       internalversion.Interface
+	namespace                    string
+	tweakListOptions             internalinterfaces.TweakListOptionsFunc
+	lock                         sync.Mutex
+	defaultResync                time.Duration
+	customResync                 map[reflect.Type]time.Duration
+	extraClusterScopedIndexers   cache.Indexers
+	extraNamespaceScopedIndexers cache.Indexers
+	keyFunc                      cache.KeyFunc
 
 	informers map[reflect.Type]cache.SharedIndexInformer
 	// startedInformers is used for tracking which informers have been started.
@@ -77,6 +80,30 @@ func WithNamespace(namespace string) SharedInformerOption {
 	}
 }
 
+// WithExtraClusterScopedIndexers adds cluster scoped indexers on all informers of the configured SharedInformerFactory
+func WithExtraClusterScopedIndexers(indexers cache.Indexers) SharedInformerOption {
+	return func(factory *sharedInformerFactory) *sharedInformerFactory {
+		factory.extraClusterScopedIndexers = indexers
+		return factory
+	}
+}
+
+// WithExtraNamespaceScopedIndexers adds namespace scoped indexers on all informers of the configured SharedInformerFactory
+func WithExtraNamespaceScopedIndexers(indexers cache.Indexers) SharedInformerOption {
+	return func(factory *sharedInformerFactory) *sharedInformerFactory {
+		factory.extraNamespaceScopedIndexers = indexers
+		return factory
+	}
+}
+
+// WithKeyFunction sets a custom key function for all informers of the configured SharedInformerFactory
+func WithKeyFunction(keyFunc cache.KeyFunc) SharedInformerOption {
+	return func(factory *sharedInformerFactory) *sharedInformerFactory {
+		factory.keyFunc = keyFunc
+		return factory
+	}
+}
+
 // NewSharedInformerFactory constructs a new instance of sharedInformerFactory for all namespaces.
 func NewSharedInformerFactory(client internalversion.Interface, defaultResync time.Duration) SharedInformerFactory {
 	return NewSharedInformerFactoryWithOptions(client, defaultResync)
@@ -93,12 +120,14 @@ func NewFilteredSharedInformerFactory(client internalversion.Interface, defaultR
 // NewSharedInformerFactoryWithOptions constructs a new instance of a SharedInformerFactory with additional options.
 func NewSharedInformerFactoryWithOptions(client internalversion.Interface, defaultResync time.Duration, options ...SharedInformerOption) SharedInformerFactory {
 	factory := &sharedInformerFactory{
-		client:           client,
-		namespace:        v1.NamespaceAll,
-		defaultResync:    defaultResync,
-		informers:        make(map[reflect.Type]cache.SharedIndexInformer),
-		startedInformers: make(map[reflect.Type]bool),
-		customResync:     make(map[reflect.Type]time.Duration),
+		client:                       client,
+		namespace:                    v1.NamespaceAll,
+		defaultResync:                defaultResync,
+		informers:                    make(map[reflect.Type]cache.SharedIndexInformer),
+		startedInformers:             make(map[reflect.Type]bool),
+		customResync:                 make(map[reflect.Type]time.Duration),
+		extraClusterScopedIndexers:   cache.Indexers{},
+		extraNamespaceScopedIndexers: cache.Indexers{},
 	}
 
 	// Apply all options
@@ -165,6 +194,21 @@ func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internal
 	f.informers[informerType] = informer
 
 	return informer
+}
+
+// KeyFunction returns any extra cluster scoped indexers set on the factory
+func (f *sharedInformerFactory) ExtraClusterScopedIndexers() cache.Indexers {
+	return f.extraClusterScopedIndexers
+}
+
+// KeyFunction returns any extra namespace scoped indexers set on the factory
+func (f *sharedInformerFactory) ExtraNamespaceScopedIndexers() cache.Indexers {
+	return f.extraNamespaceScopedIndexers
+}
+
+// KeyFunction returns the keyfunction set on the factory
+func (f *sharedInformerFactory) KeyFunction() cache.KeyFunc {
+	return f.keyFunc
 }
 
 // SharedInformerFactory provides shared informers for resources in all known

--- a/staging/src/k8s.io/code-generator/examples/apiserver/informers/internalversion/internalinterfaces/factory_interfaces.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/informers/internalversion/internalinterfaces/factory_interfaces.go
@@ -34,6 +34,9 @@ type NewInformerFunc func(internalversion.Interface, time.Duration) cache.Shared
 type SharedInformerFactory interface {
 	Start(stopCh <-chan struct{})
 	InformerFor(obj runtime.Object, newFunc NewInformerFunc) cache.SharedIndexInformer
+	ExtraClusterScopedIndexers() cache.Indexers
+	ExtraNamespaceScopedIndexers() cache.Indexers
+	KeyFunction() cache.KeyFunc
 }
 
 // TweakListOptionsFunc is a function that transforms a v1.ListOptions.

--- a/staging/src/k8s.io/code-generator/examples/crd/informers/externalversions/example2/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/informers/externalversions/example2/v1/testtype.go
@@ -56,7 +56,11 @@ func NewTestTypeInformer(client versioned.Interface, namespace string, resyncPer
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredTestTypeInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredTestTypeInformerWithOptions(client, namespace, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredTestTypeInformerWithOptions(client versioned.Interface, namespace string, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -72,13 +76,22 @@ func NewFilteredTestTypeInformer(client versioned.Interface, namespace string, r
 			},
 		},
 		&example2v1.TestType{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *testTypeInformer) defaultInformer(client versioned.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredTestTypeInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}
+	for k, v := range f.factory.ExtraNamespaceScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredTestTypeInformerWithOptions(client, f.namespace,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *testTypeInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/code-generator/examples/crd/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/informers/externalversions/factory.go
@@ -37,12 +37,15 @@ import (
 type SharedInformerOption func(*sharedInformerFactory) *sharedInformerFactory
 
 type sharedInformerFactory struct {
-	client           versioned.Interface
-	namespace        string
-	tweakListOptions internalinterfaces.TweakListOptionsFunc
-	lock             sync.Mutex
-	defaultResync    time.Duration
-	customResync     map[reflect.Type]time.Duration
+	client                       versioned.Interface
+	namespace                    string
+	tweakListOptions             internalinterfaces.TweakListOptionsFunc
+	lock                         sync.Mutex
+	defaultResync                time.Duration
+	customResync                 map[reflect.Type]time.Duration
+	extraClusterScopedIndexers   cache.Indexers
+	extraNamespaceScopedIndexers cache.Indexers
+	keyFunc                      cache.KeyFunc
 
 	informers map[reflect.Type]cache.SharedIndexInformer
 	// startedInformers is used for tracking which informers have been started.
@@ -76,6 +79,30 @@ func WithNamespace(namespace string) SharedInformerOption {
 	}
 }
 
+// WithExtraClusterScopedIndexers adds cluster scoped indexers on all informers of the configured SharedInformerFactory
+func WithExtraClusterScopedIndexers(indexers cache.Indexers) SharedInformerOption {
+	return func(factory *sharedInformerFactory) *sharedInformerFactory {
+		factory.extraClusterScopedIndexers = indexers
+		return factory
+	}
+}
+
+// WithExtraNamespaceScopedIndexers adds namespace scoped indexers on all informers of the configured SharedInformerFactory
+func WithExtraNamespaceScopedIndexers(indexers cache.Indexers) SharedInformerOption {
+	return func(factory *sharedInformerFactory) *sharedInformerFactory {
+		factory.extraNamespaceScopedIndexers = indexers
+		return factory
+	}
+}
+
+// WithKeyFunction sets a custom key function for all informers of the configured SharedInformerFactory
+func WithKeyFunction(keyFunc cache.KeyFunc) SharedInformerOption {
+	return func(factory *sharedInformerFactory) *sharedInformerFactory {
+		factory.keyFunc = keyFunc
+		return factory
+	}
+}
+
 // NewSharedInformerFactory constructs a new instance of sharedInformerFactory for all namespaces.
 func NewSharedInformerFactory(client versioned.Interface, defaultResync time.Duration) SharedInformerFactory {
 	return NewSharedInformerFactoryWithOptions(client, defaultResync)
@@ -92,12 +119,14 @@ func NewFilteredSharedInformerFactory(client versioned.Interface, defaultResync 
 // NewSharedInformerFactoryWithOptions constructs a new instance of a SharedInformerFactory with additional options.
 func NewSharedInformerFactoryWithOptions(client versioned.Interface, defaultResync time.Duration, options ...SharedInformerOption) SharedInformerFactory {
 	factory := &sharedInformerFactory{
-		client:           client,
-		namespace:        v1.NamespaceAll,
-		defaultResync:    defaultResync,
-		informers:        make(map[reflect.Type]cache.SharedIndexInformer),
-		startedInformers: make(map[reflect.Type]bool),
-		customResync:     make(map[reflect.Type]time.Duration),
+		client:                       client,
+		namespace:                    v1.NamespaceAll,
+		defaultResync:                defaultResync,
+		informers:                    make(map[reflect.Type]cache.SharedIndexInformer),
+		startedInformers:             make(map[reflect.Type]bool),
+		customResync:                 make(map[reflect.Type]time.Duration),
+		extraClusterScopedIndexers:   cache.Indexers{},
+		extraNamespaceScopedIndexers: cache.Indexers{},
 	}
 
 	// Apply all options
@@ -164,6 +193,21 @@ func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internal
 	f.informers[informerType] = informer
 
 	return informer
+}
+
+// KeyFunction returns any extra cluster scoped indexers set on the factory
+func (f *sharedInformerFactory) ExtraClusterScopedIndexers() cache.Indexers {
+	return f.extraClusterScopedIndexers
+}
+
+// KeyFunction returns any extra namespace scoped indexers set on the factory
+func (f *sharedInformerFactory) ExtraNamespaceScopedIndexers() cache.Indexers {
+	return f.extraNamespaceScopedIndexers
+}
+
+// KeyFunction returns the keyfunction set on the factory
+func (f *sharedInformerFactory) KeyFunction() cache.KeyFunc {
+	return f.keyFunc
 }
 
 // SharedInformerFactory provides shared informers for resources in all known

--- a/staging/src/k8s.io/code-generator/examples/crd/informers/externalversions/internalinterfaces/factory_interfaces.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/informers/externalversions/internalinterfaces/factory_interfaces.go
@@ -34,6 +34,9 @@ type NewInformerFunc func(versioned.Interface, time.Duration) cache.SharedIndexI
 type SharedInformerFactory interface {
 	Start(stopCh <-chan struct{})
 	InformerFor(obj runtime.Object, newFunc NewInformerFunc) cache.SharedIndexInformer
+	ExtraClusterScopedIndexers() cache.Indexers
+	ExtraNamespaceScopedIndexers() cache.Indexers
+	KeyFunction() cache.KeyFunc
 }
 
 // TweakListOptionsFunc is a function that transforms a v1.ListOptions.

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/informers/externalversions/apiregistration/v1/apiservice.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/informers/externalversions/apiregistration/v1/apiservice.go
@@ -55,7 +55,11 @@ func NewAPIServiceInformer(client clientset.Interface, resyncPeriod time.Duratio
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredAPIServiceInformer(client clientset.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredAPIServiceInformerWithOptions(client, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredAPIServiceInformerWithOptions(client clientset.Interface, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -71,13 +75,22 @@ func NewFilteredAPIServiceInformer(client clientset.Interface, resyncPeriod time
 			},
 		},
 		&apiregistrationv1.APIService{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *aPIServiceInformer) defaultInformer(client clientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredAPIServiceInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{}
+	for k, v := range f.factory.ExtraClusterScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredAPIServiceInformerWithOptions(client,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *aPIServiceInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/informers/externalversions/apiregistration/v1beta1/apiservice.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/informers/externalversions/apiregistration/v1beta1/apiservice.go
@@ -55,7 +55,11 @@ func NewAPIServiceInformer(client clientset.Interface, resyncPeriod time.Duratio
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredAPIServiceInformer(client clientset.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredAPIServiceInformerWithOptions(client, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredAPIServiceInformerWithOptions(client clientset.Interface, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -71,13 +75,22 @@ func NewFilteredAPIServiceInformer(client clientset.Interface, resyncPeriod time
 			},
 		},
 		&apiregistrationv1beta1.APIService{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *aPIServiceInformer) defaultInformer(client clientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredAPIServiceInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{}
+	for k, v := range f.factory.ExtraClusterScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredAPIServiceInformerWithOptions(client,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *aPIServiceInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/informers/externalversions/factory.go
@@ -36,12 +36,15 @@ import (
 type SharedInformerOption func(*sharedInformerFactory) *sharedInformerFactory
 
 type sharedInformerFactory struct {
-	client           clientset.Interface
-	namespace        string
-	tweakListOptions internalinterfaces.TweakListOptionsFunc
-	lock             sync.Mutex
-	defaultResync    time.Duration
-	customResync     map[reflect.Type]time.Duration
+	client                       clientset.Interface
+	namespace                    string
+	tweakListOptions             internalinterfaces.TweakListOptionsFunc
+	lock                         sync.Mutex
+	defaultResync                time.Duration
+	customResync                 map[reflect.Type]time.Duration
+	extraClusterScopedIndexers   cache.Indexers
+	extraNamespaceScopedIndexers cache.Indexers
+	keyFunc                      cache.KeyFunc
 
 	informers map[reflect.Type]cache.SharedIndexInformer
 	// startedInformers is used for tracking which informers have been started.
@@ -75,6 +78,30 @@ func WithNamespace(namespace string) SharedInformerOption {
 	}
 }
 
+// WithExtraClusterScopedIndexers adds cluster scoped indexers on all informers of the configured SharedInformerFactory
+func WithExtraClusterScopedIndexers(indexers cache.Indexers) SharedInformerOption {
+	return func(factory *sharedInformerFactory) *sharedInformerFactory {
+		factory.extraClusterScopedIndexers = indexers
+		return factory
+	}
+}
+
+// WithExtraNamespaceScopedIndexers adds namespace scoped indexers on all informers of the configured SharedInformerFactory
+func WithExtraNamespaceScopedIndexers(indexers cache.Indexers) SharedInformerOption {
+	return func(factory *sharedInformerFactory) *sharedInformerFactory {
+		factory.extraNamespaceScopedIndexers = indexers
+		return factory
+	}
+}
+
+// WithKeyFunction sets a custom key function for all informers of the configured SharedInformerFactory
+func WithKeyFunction(keyFunc cache.KeyFunc) SharedInformerOption {
+	return func(factory *sharedInformerFactory) *sharedInformerFactory {
+		factory.keyFunc = keyFunc
+		return factory
+	}
+}
+
 // NewSharedInformerFactory constructs a new instance of sharedInformerFactory for all namespaces.
 func NewSharedInformerFactory(client clientset.Interface, defaultResync time.Duration) SharedInformerFactory {
 	return NewSharedInformerFactoryWithOptions(client, defaultResync)
@@ -91,12 +118,14 @@ func NewFilteredSharedInformerFactory(client clientset.Interface, defaultResync 
 // NewSharedInformerFactoryWithOptions constructs a new instance of a SharedInformerFactory with additional options.
 func NewSharedInformerFactoryWithOptions(client clientset.Interface, defaultResync time.Duration, options ...SharedInformerOption) SharedInformerFactory {
 	factory := &sharedInformerFactory{
-		client:           client,
-		namespace:        v1.NamespaceAll,
-		defaultResync:    defaultResync,
-		informers:        make(map[reflect.Type]cache.SharedIndexInformer),
-		startedInformers: make(map[reflect.Type]bool),
-		customResync:     make(map[reflect.Type]time.Duration),
+		client:                       client,
+		namespace:                    v1.NamespaceAll,
+		defaultResync:                defaultResync,
+		informers:                    make(map[reflect.Type]cache.SharedIndexInformer),
+		startedInformers:             make(map[reflect.Type]bool),
+		customResync:                 make(map[reflect.Type]time.Duration),
+		extraClusterScopedIndexers:   cache.Indexers{},
+		extraNamespaceScopedIndexers: cache.Indexers{},
 	}
 
 	// Apply all options
@@ -163,6 +192,21 @@ func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internal
 	f.informers[informerType] = informer
 
 	return informer
+}
+
+// KeyFunction returns any extra cluster scoped indexers set on the factory
+func (f *sharedInformerFactory) ExtraClusterScopedIndexers() cache.Indexers {
+	return f.extraClusterScopedIndexers
+}
+
+// KeyFunction returns any extra namespace scoped indexers set on the factory
+func (f *sharedInformerFactory) ExtraNamespaceScopedIndexers() cache.Indexers {
+	return f.extraNamespaceScopedIndexers
+}
+
+// KeyFunction returns the keyfunction set on the factory
+func (f *sharedInformerFactory) KeyFunction() cache.KeyFunc {
+	return f.keyFunc
 }
 
 // SharedInformerFactory provides shared informers for resources in all known

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/informers/externalversions/internalinterfaces/factory_interfaces.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/informers/externalversions/internalinterfaces/factory_interfaces.go
@@ -34,6 +34,9 @@ type NewInformerFunc func(clientset.Interface, time.Duration) cache.SharedIndexI
 type SharedInformerFactory interface {
 	Start(stopCh <-chan struct{})
 	InformerFor(obj runtime.Object, newFunc NewInformerFunc) cache.SharedIndexInformer
+	ExtraClusterScopedIndexers() cache.Indexers
+	ExtraNamespaceScopedIndexers() cache.Indexers
+	KeyFunction() cache.KeyFunc
 }
 
 // TweakListOptionsFunc is a function that transforms a v1.ListOptions.

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/informers/externalversions/factory.go
@@ -36,12 +36,15 @@ import (
 type SharedInformerOption func(*sharedInformerFactory) *sharedInformerFactory
 
 type sharedInformerFactory struct {
-	client           versioned.Interface
-	namespace        string
-	tweakListOptions internalinterfaces.TweakListOptionsFunc
-	lock             sync.Mutex
-	defaultResync    time.Duration
-	customResync     map[reflect.Type]time.Duration
+	client                       versioned.Interface
+	namespace                    string
+	tweakListOptions             internalinterfaces.TweakListOptionsFunc
+	lock                         sync.Mutex
+	defaultResync                time.Duration
+	customResync                 map[reflect.Type]time.Duration
+	extraClusterScopedIndexers   cache.Indexers
+	extraNamespaceScopedIndexers cache.Indexers
+	keyFunc                      cache.KeyFunc
 
 	informers map[reflect.Type]cache.SharedIndexInformer
 	// startedInformers is used for tracking which informers have been started.
@@ -75,6 +78,30 @@ func WithNamespace(namespace string) SharedInformerOption {
 	}
 }
 
+// WithExtraClusterScopedIndexers adds cluster scoped indexers on all informers of the configured SharedInformerFactory
+func WithExtraClusterScopedIndexers(indexers cache.Indexers) SharedInformerOption {
+	return func(factory *sharedInformerFactory) *sharedInformerFactory {
+		factory.extraClusterScopedIndexers = indexers
+		return factory
+	}
+}
+
+// WithExtraNamespaceScopedIndexers adds namespace scoped indexers on all informers of the configured SharedInformerFactory
+func WithExtraNamespaceScopedIndexers(indexers cache.Indexers) SharedInformerOption {
+	return func(factory *sharedInformerFactory) *sharedInformerFactory {
+		factory.extraNamespaceScopedIndexers = indexers
+		return factory
+	}
+}
+
+// WithKeyFunction sets a custom key function for all informers of the configured SharedInformerFactory
+func WithKeyFunction(keyFunc cache.KeyFunc) SharedInformerOption {
+	return func(factory *sharedInformerFactory) *sharedInformerFactory {
+		factory.keyFunc = keyFunc
+		return factory
+	}
+}
+
 // NewSharedInformerFactory constructs a new instance of sharedInformerFactory for all namespaces.
 func NewSharedInformerFactory(client versioned.Interface, defaultResync time.Duration) SharedInformerFactory {
 	return NewSharedInformerFactoryWithOptions(client, defaultResync)
@@ -91,12 +118,14 @@ func NewFilteredSharedInformerFactory(client versioned.Interface, defaultResync 
 // NewSharedInformerFactoryWithOptions constructs a new instance of a SharedInformerFactory with additional options.
 func NewSharedInformerFactoryWithOptions(client versioned.Interface, defaultResync time.Duration, options ...SharedInformerOption) SharedInformerFactory {
 	factory := &sharedInformerFactory{
-		client:           client,
-		namespace:        v1.NamespaceAll,
-		defaultResync:    defaultResync,
-		informers:        make(map[reflect.Type]cache.SharedIndexInformer),
-		startedInformers: make(map[reflect.Type]bool),
-		customResync:     make(map[reflect.Type]time.Duration),
+		client:                       client,
+		namespace:                    v1.NamespaceAll,
+		defaultResync:                defaultResync,
+		informers:                    make(map[reflect.Type]cache.SharedIndexInformer),
+		startedInformers:             make(map[reflect.Type]bool),
+		customResync:                 make(map[reflect.Type]time.Duration),
+		extraClusterScopedIndexers:   cache.Indexers{},
+		extraNamespaceScopedIndexers: cache.Indexers{},
 	}
 
 	// Apply all options
@@ -163,6 +192,21 @@ func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internal
 	f.informers[informerType] = informer
 
 	return informer
+}
+
+// KeyFunction returns any extra cluster scoped indexers set on the factory
+func (f *sharedInformerFactory) ExtraClusterScopedIndexers() cache.Indexers {
+	return f.extraClusterScopedIndexers
+}
+
+// KeyFunction returns any extra namespace scoped indexers set on the factory
+func (f *sharedInformerFactory) ExtraNamespaceScopedIndexers() cache.Indexers {
+	return f.extraNamespaceScopedIndexers
+}
+
+// KeyFunction returns the keyfunction set on the factory
+func (f *sharedInformerFactory) KeyFunction() cache.KeyFunc {
+	return f.keyFunc
 }
 
 // SharedInformerFactory provides shared informers for resources in all known

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/informers/externalversions/internalinterfaces/factory_interfaces.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/informers/externalversions/internalinterfaces/factory_interfaces.go
@@ -34,6 +34,9 @@ type NewInformerFunc func(versioned.Interface, time.Duration) cache.SharedIndexI
 type SharedInformerFactory interface {
 	Start(stopCh <-chan struct{})
 	InformerFor(obj runtime.Object, newFunc NewInformerFunc) cache.SharedIndexInformer
+	ExtraClusterScopedIndexers() cache.Indexers
+	ExtraNamespaceScopedIndexers() cache.Indexers
+	KeyFunction() cache.KeyFunc
 }
 
 // TweakListOptionsFunc is a function that transforms a v1.ListOptions.

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/informers/externalversions/wardle/v1alpha1/fischer.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/informers/externalversions/wardle/v1alpha1/fischer.go
@@ -55,7 +55,11 @@ func NewFischerInformer(client versioned.Interface, resyncPeriod time.Duration, 
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredFischerInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredFischerInformerWithOptions(client, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredFischerInformerWithOptions(client versioned.Interface, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -71,13 +75,22 @@ func NewFilteredFischerInformer(client versioned.Interface, resyncPeriod time.Du
 			},
 		},
 		&wardlev1alpha1.Fischer{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *fischerInformer) defaultInformer(client versioned.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredFischerInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{}
+	for k, v := range f.factory.ExtraClusterScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredFischerInformerWithOptions(client,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *fischerInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/informers/externalversions/wardle/v1alpha1/flunder.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/informers/externalversions/wardle/v1alpha1/flunder.go
@@ -56,7 +56,11 @@ func NewFlunderInformer(client versioned.Interface, namespace string, resyncPeri
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredFlunderInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredFlunderInformerWithOptions(client, namespace, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredFlunderInformerWithOptions(client versioned.Interface, namespace string, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -72,13 +76,22 @@ func NewFilteredFlunderInformer(client versioned.Interface, namespace string, re
 			},
 		},
 		&wardlev1alpha1.Flunder{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *flunderInformer) defaultInformer(client versioned.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredFlunderInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}
+	for k, v := range f.factory.ExtraNamespaceScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredFlunderInformerWithOptions(client, f.namespace,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *flunderInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/informers/externalversions/wardle/v1beta1/flunder.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/informers/externalversions/wardle/v1beta1/flunder.go
@@ -56,7 +56,11 @@ func NewFlunderInformer(client versioned.Interface, namespace string, resyncPeri
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewFilteredFlunderInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(
+	return NewFilteredFlunderInformerWithOptions(client, namespace, tweakListOptions, cache.WithResyncPeriod(resyncPeriod), cache.WithIndexers(indexers))
+}
+
+func NewFilteredFlunderInformerWithOptions(client versioned.Interface, namespace string, tweakListOptions internalinterfaces.TweakListOptionsFunc, opts ...cache.SharedInformerOption) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -72,13 +76,22 @@ func NewFilteredFlunderInformer(client versioned.Interface, namespace string, re
 			},
 		},
 		&wardlev1beta1.Flunder{},
-		resyncPeriod,
-		indexers,
+		opts...,
 	)
 }
 
 func (f *flunderInformer) defaultInformer(client versioned.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredFlunderInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	indexers := cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}
+	for k, v := range f.factory.ExtraNamespaceScopedIndexers() {
+		indexers[k] = v
+	}
+
+	return NewFilteredFlunderInformerWithOptions(client, f.namespace,
+		f.tweakListOptions,
+		cache.WithResyncPeriod(resyncPeriod),
+		cache.WithIndexers(indexers),
+		cache.WithKeyFunction(f.factory.KeyFunction()),
+	)
 }
 
 func (f *flunderInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/sample-controller/pkg/generated/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/sample-controller/pkg/generated/informers/externalversions/factory.go
@@ -36,12 +36,15 @@ import (
 type SharedInformerOption func(*sharedInformerFactory) *sharedInformerFactory
 
 type sharedInformerFactory struct {
-	client           versioned.Interface
-	namespace        string
-	tweakListOptions internalinterfaces.TweakListOptionsFunc
-	lock             sync.Mutex
-	defaultResync    time.Duration
-	customResync     map[reflect.Type]time.Duration
+	client                       versioned.Interface
+	namespace                    string
+	tweakListOptions             internalinterfaces.TweakListOptionsFunc
+	lock                         sync.Mutex
+	defaultResync                time.Duration
+	customResync                 map[reflect.Type]time.Duration
+	extraClusterScopedIndexers   cache.Indexers
+	extraNamespaceScopedIndexers cache.Indexers
+	keyFunc                      cache.KeyFunc
 
 	informers map[reflect.Type]cache.SharedIndexInformer
 	// startedInformers is used for tracking which informers have been started.
@@ -75,6 +78,30 @@ func WithNamespace(namespace string) SharedInformerOption {
 	}
 }
 
+// WithExtraClusterScopedIndexers adds cluster scoped indexers on all informers of the configured SharedInformerFactory
+func WithExtraClusterScopedIndexers(indexers cache.Indexers) SharedInformerOption {
+	return func(factory *sharedInformerFactory) *sharedInformerFactory {
+		factory.extraClusterScopedIndexers = indexers
+		return factory
+	}
+}
+
+// WithExtraNamespaceScopedIndexers adds namespace scoped indexers on all informers of the configured SharedInformerFactory
+func WithExtraNamespaceScopedIndexers(indexers cache.Indexers) SharedInformerOption {
+	return func(factory *sharedInformerFactory) *sharedInformerFactory {
+		factory.extraNamespaceScopedIndexers = indexers
+		return factory
+	}
+}
+
+// WithKeyFunction sets a custom key function for all informers of the configured SharedInformerFactory
+func WithKeyFunction(keyFunc cache.KeyFunc) SharedInformerOption {
+	return func(factory *sharedInformerFactory) *sharedInformerFactory {
+		factory.keyFunc = keyFunc
+		return factory
+	}
+}
+
 // NewSharedInformerFactory constructs a new instance of sharedInformerFactory for all namespaces.
 func NewSharedInformerFactory(client versioned.Interface, defaultResync time.Duration) SharedInformerFactory {
 	return NewSharedInformerFactoryWithOptions(client, defaultResync)
@@ -91,12 +118,14 @@ func NewFilteredSharedInformerFactory(client versioned.Interface, defaultResync 
 // NewSharedInformerFactoryWithOptions constructs a new instance of a SharedInformerFactory with additional options.
 func NewSharedInformerFactoryWithOptions(client versioned.Interface, defaultResync time.Duration, options ...SharedInformerOption) SharedInformerFactory {
 	factory := &sharedInformerFactory{
-		client:           client,
-		namespace:        v1.NamespaceAll,
-		defaultResync:    defaultResync,
-		informers:        make(map[reflect.Type]cache.SharedIndexInformer),
-		startedInformers: make(map[reflect.Type]bool),
-		customResync:     make(map[reflect.Type]time.Duration),
+		client:                       client,
+		namespace:                    v1.NamespaceAll,
+		defaultResync:                defaultResync,
+		informers:                    make(map[reflect.Type]cache.SharedIndexInformer),
+		startedInformers:             make(map[reflect.Type]bool),
+		customResync:                 make(map[reflect.Type]time.Duration),
+		extraClusterScopedIndexers:   cache.Indexers{},
+		extraNamespaceScopedIndexers: cache.Indexers{},
 	}
 
 	// Apply all options
@@ -163,6 +192,21 @@ func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internal
 	f.informers[informerType] = informer
 
 	return informer
+}
+
+// KeyFunction returns any extra cluster scoped indexers set on the factory
+func (f *sharedInformerFactory) ExtraClusterScopedIndexers() cache.Indexers {
+	return f.extraClusterScopedIndexers
+}
+
+// KeyFunction returns any extra namespace scoped indexers set on the factory
+func (f *sharedInformerFactory) ExtraNamespaceScopedIndexers() cache.Indexers {
+	return f.extraNamespaceScopedIndexers
+}
+
+// KeyFunction returns the keyfunction set on the factory
+func (f *sharedInformerFactory) KeyFunction() cache.KeyFunc {
+	return f.keyFunc
 }
 
 // SharedInformerFactory provides shared informers for resources in all known

--- a/staging/src/k8s.io/sample-controller/pkg/generated/informers/externalversions/internalinterfaces/factory_interfaces.go
+++ b/staging/src/k8s.io/sample-controller/pkg/generated/informers/externalversions/internalinterfaces/factory_interfaces.go
@@ -34,6 +34,9 @@ type NewInformerFunc func(versioned.Interface, time.Duration) cache.SharedIndexI
 type SharedInformerFactory interface {
 	Start(stopCh <-chan struct{})
 	InformerFor(obj runtime.Object, newFunc NewInformerFunc) cache.SharedIndexInformer
+	ExtraClusterScopedIndexers() cache.Indexers
+	ExtraNamespaceScopedIndexers() cache.Indexers
+	KeyFunction() cache.KeyFunc
 }
 
 // TweakListOptionsFunc is a function that transforms a v1.ListOptions.


### PR DESCRIPTION
These changes allow us to use a cluster-aware keyfunction when creating an informer, which enables the creation of cluster-aware listers and informers without additional code changes to kubernetes internals