### PR TITLE
Remove lister WithContext methods, better kcp-aware CRD handling

### DIFF
--- a/pkg/controller/replication/conversion.go
+++ b/pkg/controller/replication/conversion.go
@@ -82,10 +82,6 @@ type conversionLister struct {
 }
 
 func (l conversionLister) List(selector labels.Selector) ([]*apps.ReplicaSet, error) {
-	return l.ListWithContext(context.Background(), selector)
-}
-
-func (l conversionLister) ListWithContext(ctx context.Context, selector labels.Selector) ([]*apps.ReplicaSet, error) {
 	rcList, err := l.rcLister.List(selector)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/listers/cr/v1/example.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/listers/cr/v1/example.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1
 
 import (
-	"context"
-
 	v1 "k8s.io/apiextensions-apiserver/examples/client-go/pkg/apis/cr/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,9 +31,6 @@ type ExampleLister interface {
 	// List lists all Examples in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1.Example, err error)
-	// ListWithContext lists all Examples in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.Example, err error)
 	// Examples returns an object that can list and get Examples.
 	Examples(namespace string) ExampleNamespaceLister
 	ExampleListerExpansion
@@ -53,11 +48,6 @@ func NewExampleLister(indexer cache.Indexer) ExampleLister {
 
 // List lists all Examples in the indexer.
 func (s *exampleLister) List(selector labels.Selector) (ret []*v1.Example, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all Examples in the indexer.
-func (s *exampleLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.Example, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.Example))
 	})
@@ -90,11 +80,6 @@ type exampleNamespaceLister struct {
 
 // List lists all Examples in the indexer for a given namespace.
 func (s exampleNamespaceLister) List(selector labels.Selector) (ret []*v1.Example, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all Examples in the indexer for a given namespace.
-func (s exampleNamespaceLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.Example, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.Example))
 	})
@@ -103,11 +88,6 @@ func (s exampleNamespaceLister) ListWithContext(ctx context.Context, selector la
 
 // Get retrieves the Example from the indexer for a given namespace and name.
 func (s exampleNamespaceLister) Get(name string) (*v1.Example, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the Example from the indexer for a given namespace and name.
-func (s exampleNamespaceLister) GetWithContext(ctx context.Context, name string) (*v1.Example, error) {
 	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/kcp_rest_options_getter.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/kcp_rest_options_getter.go
@@ -1,0 +1,34 @@
+package apiserver
+
+import (
+	"fmt"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/registry/generic"
+)
+
+type apiBindingAwareCRDRESTOptionsGetter struct {
+	delegate generic.RESTOptionsGetter
+	crd      *apiextensionsv1.CustomResourceDefinition
+}
+
+func (t apiBindingAwareCRDRESTOptionsGetter) GetRESTOptions(resource schema.GroupResource) (generic.RESTOptions, error) {
+	ret, err := t.delegate.GetRESTOptions(resource)
+	if err != nil {
+		return ret, err
+	}
+
+	if _, bound := t.crd.Annotations["apis.kcp.dev/bound-crd"]; !bound {
+		ret.ResourcePrefix += "/customresources"
+		return ret, nil
+	}
+
+	apiIdentity := t.crd.Annotations["apis.kcp.dev/identity"]
+	if apiIdentity == "" {
+		return generic.RESTOptions{}, fmt.Errorf("missing 'apis.kcp.dev/identity' annotation")
+	}
+
+	ret.ResourcePrefix += "/" + apiIdentity
+
+	return ret, err
+}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/v1/customresourcedefinition.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/v1/customresourcedefinition.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1
 
 import (
-	"context"
-
 	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,15 +31,9 @@ type CustomResourceDefinitionLister interface {
 	// List lists all CustomResourceDefinitions in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1.CustomResourceDefinition, err error)
-	// ListWithContext lists all CustomResourceDefinitions in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.CustomResourceDefinition, err error)
 	// Get retrieves the CustomResourceDefinition from the index for a given name.
 	// Objects returned here must be treated as read-only.
 	Get(name string) (*v1.CustomResourceDefinition, error)
-	// GetWithContext retrieves the CustomResourceDefinition from the index for a given name.
-	// Objects returned here must be treated as read-only.
-	GetWithContext(ctx context.Context, name string) (*v1.CustomResourceDefinition, error)
 	CustomResourceDefinitionListerExpansion
 }
 
@@ -57,11 +49,6 @@ func NewCustomResourceDefinitionLister(indexer cache.Indexer) CustomResourceDefi
 
 // List lists all CustomResourceDefinitions in the indexer.
 func (s *customResourceDefinitionLister) List(selector labels.Selector) (ret []*v1.CustomResourceDefinition, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all CustomResourceDefinitions in the indexer.
-func (s *customResourceDefinitionLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.CustomResourceDefinition, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.CustomResourceDefinition))
 	})
@@ -70,11 +57,6 @@ func (s *customResourceDefinitionLister) ListWithContext(ctx context.Context, se
 
 // Get retrieves the CustomResourceDefinition from the index for a given name.
 func (s *customResourceDefinitionLister) Get(name string) (*v1.CustomResourceDefinition, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the CustomResourceDefinition from the index for a given name.
-func (s *customResourceDefinitionLister) GetWithContext(ctx context.Context, name string) (*v1.CustomResourceDefinition, error) {
 	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/v1beta1/customresourcedefinition.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/v1beta1/customresourcedefinition.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1beta1
 
 import (
-	"context"
-
 	v1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,15 +31,9 @@ type CustomResourceDefinitionLister interface {
 	// List lists all CustomResourceDefinitions in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1beta1.CustomResourceDefinition, err error)
-	// ListWithContext lists all CustomResourceDefinitions in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.CustomResourceDefinition, err error)
 	// Get retrieves the CustomResourceDefinition from the index for a given name.
 	// Objects returned here must be treated as read-only.
 	Get(name string) (*v1beta1.CustomResourceDefinition, error)
-	// GetWithContext retrieves the CustomResourceDefinition from the index for a given name.
-	// Objects returned here must be treated as read-only.
-	GetWithContext(ctx context.Context, name string) (*v1beta1.CustomResourceDefinition, error)
 	CustomResourceDefinitionListerExpansion
 }
 
@@ -57,11 +49,6 @@ func NewCustomResourceDefinitionLister(indexer cache.Indexer) CustomResourceDefi
 
 // List lists all CustomResourceDefinitions in the indexer.
 func (s *customResourceDefinitionLister) List(selector labels.Selector) (ret []*v1beta1.CustomResourceDefinition, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all CustomResourceDefinitions in the indexer.
-func (s *customResourceDefinitionLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.CustomResourceDefinition, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1beta1.CustomResourceDefinition))
 	})
@@ -70,11 +57,6 @@ func (s *customResourceDefinitionLister) ListWithContext(ctx context.Context, se
 
 // Get retrieves the CustomResourceDefinition from the index for a given name.
 func (s *customResourceDefinitionLister) Get(name string) (*v1beta1.CustomResourceDefinition, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the CustomResourceDefinition from the index for a given name.
-func (s *customResourceDefinitionLister) GetWithContext(ctx context.Context, name string) (*v1beta1.CustomResourceDefinition, error) {
 	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/kcp/cluster_aware_crd_lister.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/kcp/cluster_aware_crd_lister.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kcp
+
+import (
+	"context"
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+// ClusterAwareCRDLister is a CRD lister that is kcp-specific.
+type ClusterAwareCRDLister interface {
+	// List lists all CRDs matching selector.
+	List(ctx context.Context, selector labels.Selector) ([]*v1.CustomResourceDefinition, error)
+	// Get gets a CRD by name.
+	Get(ctx context.Context, name string) (*v1.CustomResourceDefinition, error)
+	// Refresh gets the current/latest copy of the CRD from the cache. This is necessary to ensure the identity
+	// annotation is present when called by crdHandler.getOrCreateServingInfoFor
+	Refresh(crd *v1.CustomResourceDefinition) (*v1.CustomResourceDefinition, error)
+}

--- a/staging/src/k8s.io/client-go/applyconfigurations/internal/internal.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/internal/internal.go
@@ -907,12 +907,24 @@ var schemaYAML = typed.YAMLObject(`types:
       type:
         scalar: string
       default: ""
+- name: io.k8s.api.apps.v1.StatefulSetPersistentVolumeClaimRetentionPolicy
+  map:
+    fields:
+    - name: whenDeleted
+      type:
+        scalar: string
+    - name: whenScaled
+      type:
+        scalar: string
 - name: io.k8s.api.apps.v1.StatefulSetSpec
   map:
     fields:
     - name: minReadySeconds
       type:
         scalar: numeric
+    - name: persistentVolumeClaimRetentionPolicy
+      type:
+        namedType: io.k8s.api.apps.v1.StatefulSetPersistentVolumeClaimRetentionPolicy
     - name: podManagementPolicy
       type:
         scalar: string
@@ -949,6 +961,7 @@ var schemaYAML = typed.YAMLObject(`types:
     - name: availableReplicas
       type:
         scalar: numeric
+      default: 0
     - name: collisionCount
       type:
         scalar: numeric
@@ -1194,12 +1207,24 @@ var schemaYAML = typed.YAMLObject(`types:
       type:
         scalar: string
       default: ""
+- name: io.k8s.api.apps.v1beta1.StatefulSetPersistentVolumeClaimRetentionPolicy
+  map:
+    fields:
+    - name: whenDeleted
+      type:
+        scalar: string
+    - name: whenScaled
+      type:
+        scalar: string
 - name: io.k8s.api.apps.v1beta1.StatefulSetSpec
   map:
     fields:
     - name: minReadySeconds
       type:
         scalar: numeric
+    - name: persistentVolumeClaimRetentionPolicy
+      type:
+        namedType: io.k8s.api.apps.v1beta1.StatefulSetPersistentVolumeClaimRetentionPolicy
     - name: podManagementPolicy
       type:
         scalar: string
@@ -1236,6 +1261,7 @@ var schemaYAML = typed.YAMLObject(`types:
     - name: availableReplicas
       type:
         scalar: numeric
+      default: 0
     - name: collisionCount
       type:
         scalar: numeric
@@ -1679,12 +1705,24 @@ var schemaYAML = typed.YAMLObject(`types:
       type:
         scalar: string
       default: ""
+- name: io.k8s.api.apps.v1beta2.StatefulSetPersistentVolumeClaimRetentionPolicy
+  map:
+    fields:
+    - name: whenDeleted
+      type:
+        scalar: string
+    - name: whenScaled
+      type:
+        scalar: string
 - name: io.k8s.api.apps.v1beta2.StatefulSetSpec
   map:
     fields:
     - name: minReadySeconds
       type:
         scalar: numeric
+    - name: persistentVolumeClaimRetentionPolicy
+      type:
+        namedType: io.k8s.api.apps.v1beta2.StatefulSetPersistentVolumeClaimRetentionPolicy
     - name: podManagementPolicy
       type:
         scalar: string
@@ -1721,6 +1759,7 @@ var schemaYAML = typed.YAMLObject(`types:
     - name: availableReplicas
       type:
         scalar: numeric
+      default: 0
     - name: collisionCount
       type:
         scalar: numeric
@@ -1836,16 +1875,362 @@ var schemaYAML = typed.YAMLObject(`types:
     - name: observedGeneration
       type:
         scalar: numeric
-- name: io.k8s.api.autoscaling.v2.HorizontalPodAutoscaler
-  scalar: untyped
-  list:
-    elementType:
-      namedType: __untyped_atomic_
-    elementRelationship: atomic
+- name: io.k8s.api.autoscaling.v2.ContainerResourceMetricSource
   map:
-    elementType:
-      namedType: __untyped_deduced_
-    elementRelationship: separable
+    fields:
+    - name: container
+      type:
+        scalar: string
+      default: ""
+    - name: name
+      type:
+        scalar: string
+      default: ""
+    - name: target
+      type:
+        namedType: io.k8s.api.autoscaling.v2.MetricTarget
+      default: {}
+- name: io.k8s.api.autoscaling.v2.ContainerResourceMetricStatus
+  map:
+    fields:
+    - name: container
+      type:
+        scalar: string
+      default: ""
+    - name: current
+      type:
+        namedType: io.k8s.api.autoscaling.v2.MetricValueStatus
+      default: {}
+    - name: name
+      type:
+        scalar: string
+      default: ""
+- name: io.k8s.api.autoscaling.v2.CrossVersionObjectReference
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+      default: ""
+    - name: name
+      type:
+        scalar: string
+      default: ""
+- name: io.k8s.api.autoscaling.v2.ExternalMetricSource
+  map:
+    fields:
+    - name: metric
+      type:
+        namedType: io.k8s.api.autoscaling.v2.MetricIdentifier
+      default: {}
+    - name: target
+      type:
+        namedType: io.k8s.api.autoscaling.v2.MetricTarget
+      default: {}
+- name: io.k8s.api.autoscaling.v2.ExternalMetricStatus
+  map:
+    fields:
+    - name: current
+      type:
+        namedType: io.k8s.api.autoscaling.v2.MetricValueStatus
+      default: {}
+    - name: metric
+      type:
+        namedType: io.k8s.api.autoscaling.v2.MetricIdentifier
+      default: {}
+- name: io.k8s.api.autoscaling.v2.HPAScalingPolicy
+  map:
+    fields:
+    - name: periodSeconds
+      type:
+        scalar: numeric
+      default: 0
+    - name: type
+      type:
+        scalar: string
+      default: ""
+    - name: value
+      type:
+        scalar: numeric
+      default: 0
+- name: io.k8s.api.autoscaling.v2.HPAScalingRules
+  map:
+    fields:
+    - name: policies
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.autoscaling.v2.HPAScalingPolicy
+          elementRelationship: atomic
+    - name: selectPolicy
+      type:
+        scalar: string
+    - name: stabilizationWindowSeconds
+      type:
+        scalar: numeric
+- name: io.k8s.api.autoscaling.v2.HorizontalPodAutoscaler
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+      default: {}
+    - name: spec
+      type:
+        namedType: io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerSpec
+      default: {}
+    - name: status
+      type:
+        namedType: io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerStatus
+      default: {}
+- name: io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerBehavior
+  map:
+    fields:
+    - name: scaleDown
+      type:
+        namedType: io.k8s.api.autoscaling.v2.HPAScalingRules
+    - name: scaleUp
+      type:
+        namedType: io.k8s.api.autoscaling.v2.HPAScalingRules
+- name: io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerCondition
+  map:
+    fields:
+    - name: lastTransitionTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+      default: {}
+    - name: message
+      type:
+        scalar: string
+    - name: reason
+      type:
+        scalar: string
+    - name: status
+      type:
+        scalar: string
+      default: ""
+    - name: type
+      type:
+        scalar: string
+      default: ""
+- name: io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerSpec
+  map:
+    fields:
+    - name: behavior
+      type:
+        namedType: io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerBehavior
+    - name: maxReplicas
+      type:
+        scalar: numeric
+      default: 0
+    - name: metrics
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.autoscaling.v2.MetricSpec
+          elementRelationship: atomic
+    - name: minReplicas
+      type:
+        scalar: numeric
+    - name: scaleTargetRef
+      type:
+        namedType: io.k8s.api.autoscaling.v2.CrossVersionObjectReference
+      default: {}
+- name: io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerStatus
+  map:
+    fields:
+    - name: conditions
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerCondition
+          elementRelationship: associative
+          keys:
+          - type
+    - name: currentMetrics
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.autoscaling.v2.MetricStatus
+          elementRelationship: atomic
+    - name: currentReplicas
+      type:
+        scalar: numeric
+    - name: desiredReplicas
+      type:
+        scalar: numeric
+      default: 0
+    - name: lastScaleTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: observedGeneration
+      type:
+        scalar: numeric
+- name: io.k8s.api.autoscaling.v2.MetricIdentifier
+  map:
+    fields:
+    - name: name
+      type:
+        scalar: string
+      default: ""
+    - name: selector
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector
+- name: io.k8s.api.autoscaling.v2.MetricSpec
+  map:
+    fields:
+    - name: containerResource
+      type:
+        namedType: io.k8s.api.autoscaling.v2.ContainerResourceMetricSource
+    - name: external
+      type:
+        namedType: io.k8s.api.autoscaling.v2.ExternalMetricSource
+    - name: object
+      type:
+        namedType: io.k8s.api.autoscaling.v2.ObjectMetricSource
+    - name: pods
+      type:
+        namedType: io.k8s.api.autoscaling.v2.PodsMetricSource
+    - name: resource
+      type:
+        namedType: io.k8s.api.autoscaling.v2.ResourceMetricSource
+    - name: type
+      type:
+        scalar: string
+      default: ""
+- name: io.k8s.api.autoscaling.v2.MetricStatus
+  map:
+    fields:
+    - name: containerResource
+      type:
+        namedType: io.k8s.api.autoscaling.v2.ContainerResourceMetricStatus
+    - name: external
+      type:
+        namedType: io.k8s.api.autoscaling.v2.ExternalMetricStatus
+    - name: object
+      type:
+        namedType: io.k8s.api.autoscaling.v2.ObjectMetricStatus
+    - name: pods
+      type:
+        namedType: io.k8s.api.autoscaling.v2.PodsMetricStatus
+    - name: resource
+      type:
+        namedType: io.k8s.api.autoscaling.v2.ResourceMetricStatus
+    - name: type
+      type:
+        scalar: string
+      default: ""
+- name: io.k8s.api.autoscaling.v2.MetricTarget
+  map:
+    fields:
+    - name: averageUtilization
+      type:
+        scalar: numeric
+    - name: averageValue
+      type:
+        namedType: io.k8s.apimachinery.pkg.api.resource.Quantity
+    - name: type
+      type:
+        scalar: string
+      default: ""
+    - name: value
+      type:
+        namedType: io.k8s.apimachinery.pkg.api.resource.Quantity
+- name: io.k8s.api.autoscaling.v2.MetricValueStatus
+  map:
+    fields:
+    - name: averageUtilization
+      type:
+        scalar: numeric
+    - name: averageValue
+      type:
+        namedType: io.k8s.apimachinery.pkg.api.resource.Quantity
+    - name: value
+      type:
+        namedType: io.k8s.apimachinery.pkg.api.resource.Quantity
+- name: io.k8s.api.autoscaling.v2.ObjectMetricSource
+  map:
+    fields:
+    - name: describedObject
+      type:
+        namedType: io.k8s.api.autoscaling.v2.CrossVersionObjectReference
+      default: {}
+    - name: metric
+      type:
+        namedType: io.k8s.api.autoscaling.v2.MetricIdentifier
+      default: {}
+    - name: target
+      type:
+        namedType: io.k8s.api.autoscaling.v2.MetricTarget
+      default: {}
+- name: io.k8s.api.autoscaling.v2.ObjectMetricStatus
+  map:
+    fields:
+    - name: current
+      type:
+        namedType: io.k8s.api.autoscaling.v2.MetricValueStatus
+      default: {}
+    - name: describedObject
+      type:
+        namedType: io.k8s.api.autoscaling.v2.CrossVersionObjectReference
+      default: {}
+    - name: metric
+      type:
+        namedType: io.k8s.api.autoscaling.v2.MetricIdentifier
+      default: {}
+- name: io.k8s.api.autoscaling.v2.PodsMetricSource
+  map:
+    fields:
+    - name: metric
+      type:
+        namedType: io.k8s.api.autoscaling.v2.MetricIdentifier
+      default: {}
+    - name: target
+      type:
+        namedType: io.k8s.api.autoscaling.v2.MetricTarget
+      default: {}
+- name: io.k8s.api.autoscaling.v2.PodsMetricStatus
+  map:
+    fields:
+    - name: current
+      type:
+        namedType: io.k8s.api.autoscaling.v2.MetricValueStatus
+      default: {}
+    - name: metric
+      type:
+        namedType: io.k8s.api.autoscaling.v2.MetricIdentifier
+      default: {}
+- name: io.k8s.api.autoscaling.v2.ResourceMetricSource
+  map:
+    fields:
+    - name: name
+      type:
+        scalar: string
+      default: ""
+    - name: target
+      type:
+        namedType: io.k8s.api.autoscaling.v2.MetricTarget
+      default: {}
+- name: io.k8s.api.autoscaling.v2.ResourceMetricStatus
+  map:
+    fields:
+    - name: current
+      type:
+        namedType: io.k8s.api.autoscaling.v2.MetricValueStatus
+      default: {}
+    - name: name
+      type:
+        scalar: string
+      default: ""
 - name: io.k8s.api.autoscaling.v2beta1.ContainerResourceMetricSource
   map:
     fields:
@@ -2676,6 +3061,9 @@ var schemaYAML = typed.YAMLObject(`types:
             namedType: io.k8s.api.batch.v1.JobCondition
           elementRelationship: atomic
     - name: failed
+      type:
+        scalar: numeric
+    - name: ready
       type:
         scalar: numeric
     - name: startTime
@@ -3885,7 +4273,10 @@ var schemaYAML = typed.YAMLObject(`types:
         list:
           elementType:
             namedType: io.k8s.api.core.v1.ContainerPort
-          elementRelationship: atomic
+          elementRelationship: associative
+          keys:
+          - containerPort
+          - protocol
     - name: readinessProbe
       type:
         namedType: io.k8s.api.core.v1.Probe
@@ -4123,6 +4514,17 @@ var schemaYAML = typed.YAMLObject(`types:
     - name: readOnly
       type:
         scalar: boolean
+- name: io.k8s.api.core.v1.GRPCAction
+  map:
+    fields:
+    - name: port
+      type:
+        scalar: numeric
+      default: 0
+    - name: service
+      type:
+        scalar: string
+      default: ""
 - name: io.k8s.api.core.v1.GitRepoVolumeSource
   map:
     fields:
@@ -4200,18 +4602,6 @@ var schemaYAML = typed.YAMLObject(`types:
       type:
         scalar: string
       default: ""
-- name: io.k8s.api.core.v1.Handler
-  map:
-    fields:
-    - name: exec
-      type:
-        namedType: io.k8s.api.core.v1.ExecAction
-    - name: httpGet
-      type:
-        namedType: io.k8s.api.core.v1.HTTPGetAction
-    - name: tcpSocket
-      type:
-        namedType: io.k8s.api.core.v1.TCPSocketAction
 - name: io.k8s.api.core.v1.HostAlias
   map:
     fields:
@@ -4337,10 +4727,22 @@ var schemaYAML = typed.YAMLObject(`types:
     fields:
     - name: postStart
       type:
-        namedType: io.k8s.api.core.v1.Handler
+        namedType: io.k8s.api.core.v1.LifecycleHandler
     - name: preStop
       type:
-        namedType: io.k8s.api.core.v1.Handler
+        namedType: io.k8s.api.core.v1.LifecycleHandler
+- name: io.k8s.api.core.v1.LifecycleHandler
+  map:
+    fields:
+    - name: exec
+      type:
+        namedType: io.k8s.api.core.v1.ExecAction
+    - name: httpGet
+      type:
+        namedType: io.k8s.api.core.v1.HTTPGetAction
+    - name: tcpSocket
+      type:
+        namedType: io.k8s.api.core.v1.TCPSocketAction
 - name: io.k8s.api.core.v1.LimitRange
   map:
     fields:
@@ -4936,6 +5338,11 @@ var schemaYAML = typed.YAMLObject(`types:
           elementType:
             scalar: string
           elementRelationship: atomic
+    - name: allocatedResources
+      type:
+        map:
+          elementType:
+            namedType: io.k8s.apimachinery.pkg.api.resource.Quantity
     - name: capacity
       type:
         map:
@@ -4950,6 +5357,9 @@ var schemaYAML = typed.YAMLObject(`types:
           keys:
           - type
     - name: phase
+      type:
+        scalar: string
+    - name: resizeStatus
       type:
         scalar: string
 - name: io.k8s.api.core.v1.PersistentVolumeClaimTemplate
@@ -5227,6 +5637,13 @@ var schemaYAML = typed.YAMLObject(`types:
     - name: ip
       type:
         scalar: string
+- name: io.k8s.api.core.v1.PodOS
+  map:
+    fields:
+    - name: name
+      type:
+        scalar: string
+      default: ""
 - name: io.k8s.api.core.v1.PodReadinessGate
   map:
     fields:
@@ -5355,6 +5772,9 @@ var schemaYAML = typed.YAMLObject(`types:
           elementType:
             scalar: string
           elementRelationship: atomic
+    - name: os
+      type:
+        namedType: io.k8s.api.core.v1.PodOS
     - name: overhead
       type:
         map:
@@ -5564,6 +5984,9 @@ var schemaYAML = typed.YAMLObject(`types:
     - name: failureThreshold
       type:
         scalar: numeric
+    - name: grpc
+      type:
+        namedType: io.k8s.api.core.v1.GRPCAction
     - name: httpGet
       type:
         namedType: io.k8s.api.core.v1.HTTPGetAction
@@ -8405,26 +8828,314 @@ var schemaYAML = typed.YAMLObject(`types:
       type:
         scalar: string
       default: ""
+- name: io.k8s.api.flowcontrol.v1beta2.FlowDistinguisherMethod
+  map:
+    fields:
+    - name: type
+      type:
+        scalar: string
+      default: ""
 - name: io.k8s.api.flowcontrol.v1beta2.FlowSchema
-  scalar: untyped
-  list:
-    elementType:
-      namedType: __untyped_atomic_
-    elementRelationship: atomic
   map:
-    elementType:
-      namedType: __untyped_deduced_
-    elementRelationship: separable
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+      default: {}
+    - name: spec
+      type:
+        namedType: io.k8s.api.flowcontrol.v1beta2.FlowSchemaSpec
+      default: {}
+    - name: status
+      type:
+        namedType: io.k8s.api.flowcontrol.v1beta2.FlowSchemaStatus
+      default: {}
+- name: io.k8s.api.flowcontrol.v1beta2.FlowSchemaCondition
+  map:
+    fields:
+    - name: lastTransitionTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+      default: {}
+    - name: message
+      type:
+        scalar: string
+    - name: reason
+      type:
+        scalar: string
+    - name: status
+      type:
+        scalar: string
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.api.flowcontrol.v1beta2.FlowSchemaSpec
+  map:
+    fields:
+    - name: distinguisherMethod
+      type:
+        namedType: io.k8s.api.flowcontrol.v1beta2.FlowDistinguisherMethod
+    - name: matchingPrecedence
+      type:
+        scalar: numeric
+      default: 0
+    - name: priorityLevelConfiguration
+      type:
+        namedType: io.k8s.api.flowcontrol.v1beta2.PriorityLevelConfigurationReference
+      default: {}
+    - name: rules
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.flowcontrol.v1beta2.PolicyRulesWithSubjects
+          elementRelationship: atomic
+- name: io.k8s.api.flowcontrol.v1beta2.FlowSchemaStatus
+  map:
+    fields:
+    - name: conditions
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.flowcontrol.v1beta2.FlowSchemaCondition
+          elementRelationship: associative
+          keys:
+          - type
+- name: io.k8s.api.flowcontrol.v1beta2.GroupSubject
+  map:
+    fields:
+    - name: name
+      type:
+        scalar: string
+      default: ""
+- name: io.k8s.api.flowcontrol.v1beta2.LimitResponse
+  map:
+    fields:
+    - name: queuing
+      type:
+        namedType: io.k8s.api.flowcontrol.v1beta2.QueuingConfiguration
+    - name: type
+      type:
+        scalar: string
+      default: ""
+    unions:
+    - discriminator: type
+      fields:
+      - fieldName: queuing
+        discriminatorValue: Queuing
+- name: io.k8s.api.flowcontrol.v1beta2.LimitedPriorityLevelConfiguration
+  map:
+    fields:
+    - name: assuredConcurrencyShares
+      type:
+        scalar: numeric
+      default: 0
+    - name: limitResponse
+      type:
+        namedType: io.k8s.api.flowcontrol.v1beta2.LimitResponse
+      default: {}
+- name: io.k8s.api.flowcontrol.v1beta2.NonResourcePolicyRule
+  map:
+    fields:
+    - name: nonResourceURLs
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: associative
+    - name: verbs
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: associative
+- name: io.k8s.api.flowcontrol.v1beta2.PolicyRulesWithSubjects
+  map:
+    fields:
+    - name: nonResourceRules
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.flowcontrol.v1beta2.NonResourcePolicyRule
+          elementRelationship: atomic
+    - name: resourceRules
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.flowcontrol.v1beta2.ResourcePolicyRule
+          elementRelationship: atomic
+    - name: subjects
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.flowcontrol.v1beta2.Subject
+          elementRelationship: atomic
 - name: io.k8s.api.flowcontrol.v1beta2.PriorityLevelConfiguration
-  scalar: untyped
-  list:
-    elementType:
-      namedType: __untyped_atomic_
-    elementRelationship: atomic
   map:
-    elementType:
-      namedType: __untyped_deduced_
-    elementRelationship: separable
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+      default: {}
+    - name: spec
+      type:
+        namedType: io.k8s.api.flowcontrol.v1beta2.PriorityLevelConfigurationSpec
+      default: {}
+    - name: status
+      type:
+        namedType: io.k8s.api.flowcontrol.v1beta2.PriorityLevelConfigurationStatus
+      default: {}
+- name: io.k8s.api.flowcontrol.v1beta2.PriorityLevelConfigurationCondition
+  map:
+    fields:
+    - name: lastTransitionTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+      default: {}
+    - name: message
+      type:
+        scalar: string
+    - name: reason
+      type:
+        scalar: string
+    - name: status
+      type:
+        scalar: string
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.api.flowcontrol.v1beta2.PriorityLevelConfigurationReference
+  map:
+    fields:
+    - name: name
+      type:
+        scalar: string
+      default: ""
+- name: io.k8s.api.flowcontrol.v1beta2.PriorityLevelConfigurationSpec
+  map:
+    fields:
+    - name: limited
+      type:
+        namedType: io.k8s.api.flowcontrol.v1beta2.LimitedPriorityLevelConfiguration
+    - name: type
+      type:
+        scalar: string
+      default: ""
+    unions:
+    - discriminator: type
+      fields:
+      - fieldName: limited
+        discriminatorValue: Limited
+- name: io.k8s.api.flowcontrol.v1beta2.PriorityLevelConfigurationStatus
+  map:
+    fields:
+    - name: conditions
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.flowcontrol.v1beta2.PriorityLevelConfigurationCondition
+          elementRelationship: associative
+          keys:
+          - type
+- name: io.k8s.api.flowcontrol.v1beta2.QueuingConfiguration
+  map:
+    fields:
+    - name: handSize
+      type:
+        scalar: numeric
+      default: 0
+    - name: queueLengthLimit
+      type:
+        scalar: numeric
+      default: 0
+    - name: queues
+      type:
+        scalar: numeric
+      default: 0
+- name: io.k8s.api.flowcontrol.v1beta2.ResourcePolicyRule
+  map:
+    fields:
+    - name: apiGroups
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: associative
+    - name: clusterScope
+      type:
+        scalar: boolean
+    - name: namespaces
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: associative
+    - name: resources
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: associative
+    - name: verbs
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: associative
+- name: io.k8s.api.flowcontrol.v1beta2.ServiceAccountSubject
+  map:
+    fields:
+    - name: name
+      type:
+        scalar: string
+      default: ""
+    - name: namespace
+      type:
+        scalar: string
+      default: ""
+- name: io.k8s.api.flowcontrol.v1beta2.Subject
+  map:
+    fields:
+    - name: group
+      type:
+        namedType: io.k8s.api.flowcontrol.v1beta2.GroupSubject
+    - name: kind
+      type:
+        scalar: string
+      default: ""
+    - name: serviceAccount
+      type:
+        namedType: io.k8s.api.flowcontrol.v1beta2.ServiceAccountSubject
+    - name: user
+      type:
+        namedType: io.k8s.api.flowcontrol.v1beta2.UserSubject
+    unions:
+    - discriminator: kind
+      fields:
+      - fieldName: group
+        discriminatorValue: Group
+      - fieldName: serviceAccount
+        discriminatorValue: ServiceAccount
+      - fieldName: user
+        discriminatorValue: User
+- name: io.k8s.api.flowcontrol.v1beta2.UserSubject
+  map:
+    fields:
+    - name: name
+      type:
+        scalar: string
+      default: ""
 - name: io.k8s.api.imagepolicy.v1alpha1.ImageReview
   map:
     fields:

--- a/staging/src/k8s.io/client-go/listers/admissionregistration/v1/mutatingwebhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/listers/admissionregistration/v1/mutatingwebhookconfiguration.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1
 
 import (
-	"context"
-
 	v1 "k8s.io/api/admissionregistration/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,15 +31,9 @@ type MutatingWebhookConfigurationLister interface {
 	// List lists all MutatingWebhookConfigurations in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1.MutatingWebhookConfiguration, err error)
-	// ListWithContext lists all MutatingWebhookConfigurations in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.MutatingWebhookConfiguration, err error)
 	// Get retrieves the MutatingWebhookConfiguration from the index for a given name.
 	// Objects returned here must be treated as read-only.
 	Get(name string) (*v1.MutatingWebhookConfiguration, error)
-	// GetWithContext retrieves the MutatingWebhookConfiguration from the index for a given name.
-	// Objects returned here must be treated as read-only.
-	GetWithContext(ctx context.Context, name string) (*v1.MutatingWebhookConfiguration, error)
 	MutatingWebhookConfigurationListerExpansion
 }
 
@@ -57,11 +49,6 @@ func NewMutatingWebhookConfigurationLister(indexer cache.Indexer) MutatingWebhoo
 
 // List lists all MutatingWebhookConfigurations in the indexer.
 func (s *mutatingWebhookConfigurationLister) List(selector labels.Selector) (ret []*v1.MutatingWebhookConfiguration, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all MutatingWebhookConfigurations in the indexer.
-func (s *mutatingWebhookConfigurationLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.MutatingWebhookConfiguration, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.MutatingWebhookConfiguration))
 	})
@@ -70,11 +57,6 @@ func (s *mutatingWebhookConfigurationLister) ListWithContext(ctx context.Context
 
 // Get retrieves the MutatingWebhookConfiguration from the index for a given name.
 func (s *mutatingWebhookConfigurationLister) Get(name string) (*v1.MutatingWebhookConfiguration, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the MutatingWebhookConfiguration from the index for a given name.
-func (s *mutatingWebhookConfigurationLister) GetWithContext(ctx context.Context, name string) (*v1.MutatingWebhookConfiguration, error) {
 	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/admissionregistration/v1/validatingwebhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/listers/admissionregistration/v1/validatingwebhookconfiguration.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1
 
 import (
-	"context"
-
 	v1 "k8s.io/api/admissionregistration/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,15 +31,9 @@ type ValidatingWebhookConfigurationLister interface {
 	// List lists all ValidatingWebhookConfigurations in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1.ValidatingWebhookConfiguration, err error)
-	// ListWithContext lists all ValidatingWebhookConfigurations in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.ValidatingWebhookConfiguration, err error)
 	// Get retrieves the ValidatingWebhookConfiguration from the index for a given name.
 	// Objects returned here must be treated as read-only.
 	Get(name string) (*v1.ValidatingWebhookConfiguration, error)
-	// GetWithContext retrieves the ValidatingWebhookConfiguration from the index for a given name.
-	// Objects returned here must be treated as read-only.
-	GetWithContext(ctx context.Context, name string) (*v1.ValidatingWebhookConfiguration, error)
 	ValidatingWebhookConfigurationListerExpansion
 }
 
@@ -57,11 +49,6 @@ func NewValidatingWebhookConfigurationLister(indexer cache.Indexer) ValidatingWe
 
 // List lists all ValidatingWebhookConfigurations in the indexer.
 func (s *validatingWebhookConfigurationLister) List(selector labels.Selector) (ret []*v1.ValidatingWebhookConfiguration, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all ValidatingWebhookConfigurations in the indexer.
-func (s *validatingWebhookConfigurationLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.ValidatingWebhookConfiguration, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.ValidatingWebhookConfiguration))
 	})
@@ -70,11 +57,6 @@ func (s *validatingWebhookConfigurationLister) ListWithContext(ctx context.Conte
 
 // Get retrieves the ValidatingWebhookConfiguration from the index for a given name.
 func (s *validatingWebhookConfigurationLister) Get(name string) (*v1.ValidatingWebhookConfiguration, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the ValidatingWebhookConfiguration from the index for a given name.
-func (s *validatingWebhookConfigurationLister) GetWithContext(ctx context.Context, name string) (*v1.ValidatingWebhookConfiguration, error) {
 	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/admissionregistration/v1beta1/mutatingwebhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/listers/admissionregistration/v1beta1/mutatingwebhookconfiguration.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1beta1
 
 import (
-	"context"
-
 	v1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,15 +31,9 @@ type MutatingWebhookConfigurationLister interface {
 	// List lists all MutatingWebhookConfigurations in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1beta1.MutatingWebhookConfiguration, err error)
-	// ListWithContext lists all MutatingWebhookConfigurations in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.MutatingWebhookConfiguration, err error)
 	// Get retrieves the MutatingWebhookConfiguration from the index for a given name.
 	// Objects returned here must be treated as read-only.
 	Get(name string) (*v1beta1.MutatingWebhookConfiguration, error)
-	// GetWithContext retrieves the MutatingWebhookConfiguration from the index for a given name.
-	// Objects returned here must be treated as read-only.
-	GetWithContext(ctx context.Context, name string) (*v1beta1.MutatingWebhookConfiguration, error)
 	MutatingWebhookConfigurationListerExpansion
 }
 
@@ -57,11 +49,6 @@ func NewMutatingWebhookConfigurationLister(indexer cache.Indexer) MutatingWebhoo
 
 // List lists all MutatingWebhookConfigurations in the indexer.
 func (s *mutatingWebhookConfigurationLister) List(selector labels.Selector) (ret []*v1beta1.MutatingWebhookConfiguration, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all MutatingWebhookConfigurations in the indexer.
-func (s *mutatingWebhookConfigurationLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.MutatingWebhookConfiguration, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1beta1.MutatingWebhookConfiguration))
 	})
@@ -70,11 +57,6 @@ func (s *mutatingWebhookConfigurationLister) ListWithContext(ctx context.Context
 
 // Get retrieves the MutatingWebhookConfiguration from the index for a given name.
 func (s *mutatingWebhookConfigurationLister) Get(name string) (*v1beta1.MutatingWebhookConfiguration, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the MutatingWebhookConfiguration from the index for a given name.
-func (s *mutatingWebhookConfigurationLister) GetWithContext(ctx context.Context, name string) (*v1beta1.MutatingWebhookConfiguration, error) {
 	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/admissionregistration/v1beta1/validatingwebhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/listers/admissionregistration/v1beta1/validatingwebhookconfiguration.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1beta1
 
 import (
-	"context"
-
 	v1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,15 +31,9 @@ type ValidatingWebhookConfigurationLister interface {
 	// List lists all ValidatingWebhookConfigurations in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1beta1.ValidatingWebhookConfiguration, err error)
-	// ListWithContext lists all ValidatingWebhookConfigurations in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.ValidatingWebhookConfiguration, err error)
 	// Get retrieves the ValidatingWebhookConfiguration from the index for a given name.
 	// Objects returned here must be treated as read-only.
 	Get(name string) (*v1beta1.ValidatingWebhookConfiguration, error)
-	// GetWithContext retrieves the ValidatingWebhookConfiguration from the index for a given name.
-	// Objects returned here must be treated as read-only.
-	GetWithContext(ctx context.Context, name string) (*v1beta1.ValidatingWebhookConfiguration, error)
 	ValidatingWebhookConfigurationListerExpansion
 }
 
@@ -57,11 +49,6 @@ func NewValidatingWebhookConfigurationLister(indexer cache.Indexer) ValidatingWe
 
 // List lists all ValidatingWebhookConfigurations in the indexer.
 func (s *validatingWebhookConfigurationLister) List(selector labels.Selector) (ret []*v1beta1.ValidatingWebhookConfiguration, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all ValidatingWebhookConfigurations in the indexer.
-func (s *validatingWebhookConfigurationLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.ValidatingWebhookConfiguration, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1beta1.ValidatingWebhookConfiguration))
 	})
@@ -70,11 +57,6 @@ func (s *validatingWebhookConfigurationLister) ListWithContext(ctx context.Conte
 
 // Get retrieves the ValidatingWebhookConfiguration from the index for a given name.
 func (s *validatingWebhookConfigurationLister) Get(name string) (*v1beta1.ValidatingWebhookConfiguration, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the ValidatingWebhookConfiguration from the index for a given name.
-func (s *validatingWebhookConfigurationLister) GetWithContext(ctx context.Context, name string) (*v1beta1.ValidatingWebhookConfiguration, error) {
 	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/apiserverinternal/v1alpha1/storageversion.go
+++ b/staging/src/k8s.io/client-go/listers/apiserverinternal/v1alpha1/storageversion.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"context"
-
 	v1alpha1 "k8s.io/api/apiserverinternal/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,15 +31,9 @@ type StorageVersionLister interface {
 	// List lists all StorageVersions in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1alpha1.StorageVersion, err error)
-	// ListWithContext lists all StorageVersions in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1alpha1.StorageVersion, err error)
 	// Get retrieves the StorageVersion from the index for a given name.
 	// Objects returned here must be treated as read-only.
 	Get(name string) (*v1alpha1.StorageVersion, error)
-	// GetWithContext retrieves the StorageVersion from the index for a given name.
-	// Objects returned here must be treated as read-only.
-	GetWithContext(ctx context.Context, name string) (*v1alpha1.StorageVersion, error)
 	StorageVersionListerExpansion
 }
 
@@ -57,11 +49,6 @@ func NewStorageVersionLister(indexer cache.Indexer) StorageVersionLister {
 
 // List lists all StorageVersions in the indexer.
 func (s *storageVersionLister) List(selector labels.Selector) (ret []*v1alpha1.StorageVersion, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all StorageVersions in the indexer.
-func (s *storageVersionLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1alpha1.StorageVersion, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1alpha1.StorageVersion))
 	})
@@ -70,11 +57,6 @@ func (s *storageVersionLister) ListWithContext(ctx context.Context, selector lab
 
 // Get retrieves the StorageVersion from the index for a given name.
 func (s *storageVersionLister) Get(name string) (*v1alpha1.StorageVersion, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the StorageVersion from the index for a given name.
-func (s *storageVersionLister) GetWithContext(ctx context.Context, name string) (*v1alpha1.StorageVersion, error) {
 	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/apps/v1/controllerrevision.go
+++ b/staging/src/k8s.io/client-go/listers/apps/v1/controllerrevision.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1
 
 import (
-	"context"
-
 	v1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,9 +31,6 @@ type ControllerRevisionLister interface {
 	// List lists all ControllerRevisions in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1.ControllerRevision, err error)
-	// ListWithContext lists all ControllerRevisions in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.ControllerRevision, err error)
 	// ControllerRevisions returns an object that can list and get ControllerRevisions.
 	ControllerRevisions(namespace string) ControllerRevisionNamespaceLister
 	ControllerRevisionListerExpansion
@@ -53,11 +48,6 @@ func NewControllerRevisionLister(indexer cache.Indexer) ControllerRevisionLister
 
 // List lists all ControllerRevisions in the indexer.
 func (s *controllerRevisionLister) List(selector labels.Selector) (ret []*v1.ControllerRevision, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all ControllerRevisions in the indexer.
-func (s *controllerRevisionLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.ControllerRevision, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.ControllerRevision))
 	})
@@ -90,11 +80,6 @@ type controllerRevisionNamespaceLister struct {
 
 // List lists all ControllerRevisions in the indexer for a given namespace.
 func (s controllerRevisionNamespaceLister) List(selector labels.Selector) (ret []*v1.ControllerRevision, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all ControllerRevisions in the indexer for a given namespace.
-func (s controllerRevisionNamespaceLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.ControllerRevision, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.ControllerRevision))
 	})
@@ -103,11 +88,6 @@ func (s controllerRevisionNamespaceLister) ListWithContext(ctx context.Context, 
 
 // Get retrieves the ControllerRevision from the indexer for a given namespace and name.
 func (s controllerRevisionNamespaceLister) Get(name string) (*v1.ControllerRevision, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the ControllerRevision from the indexer for a given namespace and name.
-func (s controllerRevisionNamespaceLister) GetWithContext(ctx context.Context, name string) (*v1.ControllerRevision, error) {
 	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/apps/v1/daemonset.go
+++ b/staging/src/k8s.io/client-go/listers/apps/v1/daemonset.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1
 
 import (
-	"context"
-
 	v1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,9 +31,6 @@ type DaemonSetLister interface {
 	// List lists all DaemonSets in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1.DaemonSet, err error)
-	// ListWithContext lists all DaemonSets in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.DaemonSet, err error)
 	// DaemonSets returns an object that can list and get DaemonSets.
 	DaemonSets(namespace string) DaemonSetNamespaceLister
 	DaemonSetListerExpansion
@@ -53,11 +48,6 @@ func NewDaemonSetLister(indexer cache.Indexer) DaemonSetLister {
 
 // List lists all DaemonSets in the indexer.
 func (s *daemonSetLister) List(selector labels.Selector) (ret []*v1.DaemonSet, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all DaemonSets in the indexer.
-func (s *daemonSetLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.DaemonSet, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.DaemonSet))
 	})
@@ -90,11 +80,6 @@ type daemonSetNamespaceLister struct {
 
 // List lists all DaemonSets in the indexer for a given namespace.
 func (s daemonSetNamespaceLister) List(selector labels.Selector) (ret []*v1.DaemonSet, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all DaemonSets in the indexer for a given namespace.
-func (s daemonSetNamespaceLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.DaemonSet, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.DaemonSet))
 	})
@@ -103,11 +88,6 @@ func (s daemonSetNamespaceLister) ListWithContext(ctx context.Context, selector 
 
 // Get retrieves the DaemonSet from the indexer for a given namespace and name.
 func (s daemonSetNamespaceLister) Get(name string) (*v1.DaemonSet, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the DaemonSet from the indexer for a given namespace and name.
-func (s daemonSetNamespaceLister) GetWithContext(ctx context.Context, name string) (*v1.DaemonSet, error) {
 	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/apps/v1/deployment.go
+++ b/staging/src/k8s.io/client-go/listers/apps/v1/deployment.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1
 
 import (
-	"context"
-
 	v1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,9 +31,6 @@ type DeploymentLister interface {
 	// List lists all Deployments in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1.Deployment, err error)
-	// ListWithContext lists all Deployments in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.Deployment, err error)
 	// Deployments returns an object that can list and get Deployments.
 	Deployments(namespace string) DeploymentNamespaceLister
 	DeploymentListerExpansion
@@ -53,11 +48,6 @@ func NewDeploymentLister(indexer cache.Indexer) DeploymentLister {
 
 // List lists all Deployments in the indexer.
 func (s *deploymentLister) List(selector labels.Selector) (ret []*v1.Deployment, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all Deployments in the indexer.
-func (s *deploymentLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.Deployment, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.Deployment))
 	})
@@ -90,11 +80,6 @@ type deploymentNamespaceLister struct {
 
 // List lists all Deployments in the indexer for a given namespace.
 func (s deploymentNamespaceLister) List(selector labels.Selector) (ret []*v1.Deployment, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all Deployments in the indexer for a given namespace.
-func (s deploymentNamespaceLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.Deployment, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.Deployment))
 	})
@@ -103,11 +88,6 @@ func (s deploymentNamespaceLister) ListWithContext(ctx context.Context, selector
 
 // Get retrieves the Deployment from the indexer for a given namespace and name.
 func (s deploymentNamespaceLister) Get(name string) (*v1.Deployment, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the Deployment from the indexer for a given namespace and name.
-func (s deploymentNamespaceLister) GetWithContext(ctx context.Context, name string) (*v1.Deployment, error) {
 	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/apps/v1/replicaset.go
+++ b/staging/src/k8s.io/client-go/listers/apps/v1/replicaset.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1
 
 import (
-	"context"
-
 	v1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,9 +31,6 @@ type ReplicaSetLister interface {
 	// List lists all ReplicaSets in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1.ReplicaSet, err error)
-	// ListWithContext lists all ReplicaSets in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.ReplicaSet, err error)
 	// ReplicaSets returns an object that can list and get ReplicaSets.
 	ReplicaSets(namespace string) ReplicaSetNamespaceLister
 	ReplicaSetListerExpansion
@@ -53,11 +48,6 @@ func NewReplicaSetLister(indexer cache.Indexer) ReplicaSetLister {
 
 // List lists all ReplicaSets in the indexer.
 func (s *replicaSetLister) List(selector labels.Selector) (ret []*v1.ReplicaSet, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all ReplicaSets in the indexer.
-func (s *replicaSetLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.ReplicaSet, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.ReplicaSet))
 	})
@@ -90,11 +80,6 @@ type replicaSetNamespaceLister struct {
 
 // List lists all ReplicaSets in the indexer for a given namespace.
 func (s replicaSetNamespaceLister) List(selector labels.Selector) (ret []*v1.ReplicaSet, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all ReplicaSets in the indexer for a given namespace.
-func (s replicaSetNamespaceLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.ReplicaSet, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.ReplicaSet))
 	})
@@ -103,11 +88,6 @@ func (s replicaSetNamespaceLister) ListWithContext(ctx context.Context, selector
 
 // Get retrieves the ReplicaSet from the indexer for a given namespace and name.
 func (s replicaSetNamespaceLister) Get(name string) (*v1.ReplicaSet, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the ReplicaSet from the indexer for a given namespace and name.
-func (s replicaSetNamespaceLister) GetWithContext(ctx context.Context, name string) (*v1.ReplicaSet, error) {
 	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/apps/v1/statefulset.go
+++ b/staging/src/k8s.io/client-go/listers/apps/v1/statefulset.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1
 
 import (
-	"context"
-
 	v1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,9 +31,6 @@ type StatefulSetLister interface {
 	// List lists all StatefulSets in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1.StatefulSet, err error)
-	// ListWithContext lists all StatefulSets in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.StatefulSet, err error)
 	// StatefulSets returns an object that can list and get StatefulSets.
 	StatefulSets(namespace string) StatefulSetNamespaceLister
 	StatefulSetListerExpansion
@@ -53,11 +48,6 @@ func NewStatefulSetLister(indexer cache.Indexer) StatefulSetLister {
 
 // List lists all StatefulSets in the indexer.
 func (s *statefulSetLister) List(selector labels.Selector) (ret []*v1.StatefulSet, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all StatefulSets in the indexer.
-func (s *statefulSetLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.StatefulSet, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.StatefulSet))
 	})
@@ -90,11 +80,6 @@ type statefulSetNamespaceLister struct {
 
 // List lists all StatefulSets in the indexer for a given namespace.
 func (s statefulSetNamespaceLister) List(selector labels.Selector) (ret []*v1.StatefulSet, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all StatefulSets in the indexer for a given namespace.
-func (s statefulSetNamespaceLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.StatefulSet, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.StatefulSet))
 	})
@@ -103,11 +88,6 @@ func (s statefulSetNamespaceLister) ListWithContext(ctx context.Context, selecto
 
 // Get retrieves the StatefulSet from the indexer for a given namespace and name.
 func (s statefulSetNamespaceLister) Get(name string) (*v1.StatefulSet, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the StatefulSet from the indexer for a given namespace and name.
-func (s statefulSetNamespaceLister) GetWithContext(ctx context.Context, name string) (*v1.StatefulSet, error) {
 	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/apps/v1beta1/controllerrevision.go
+++ b/staging/src/k8s.io/client-go/listers/apps/v1beta1/controllerrevision.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1beta1
 
 import (
-	"context"
-
 	v1beta1 "k8s.io/api/apps/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,9 +31,6 @@ type ControllerRevisionLister interface {
 	// List lists all ControllerRevisions in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1beta1.ControllerRevision, err error)
-	// ListWithContext lists all ControllerRevisions in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.ControllerRevision, err error)
 	// ControllerRevisions returns an object that can list and get ControllerRevisions.
 	ControllerRevisions(namespace string) ControllerRevisionNamespaceLister
 	ControllerRevisionListerExpansion
@@ -53,11 +48,6 @@ func NewControllerRevisionLister(indexer cache.Indexer) ControllerRevisionLister
 
 // List lists all ControllerRevisions in the indexer.
 func (s *controllerRevisionLister) List(selector labels.Selector) (ret []*v1beta1.ControllerRevision, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all ControllerRevisions in the indexer.
-func (s *controllerRevisionLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.ControllerRevision, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1beta1.ControllerRevision))
 	})
@@ -90,11 +80,6 @@ type controllerRevisionNamespaceLister struct {
 
 // List lists all ControllerRevisions in the indexer for a given namespace.
 func (s controllerRevisionNamespaceLister) List(selector labels.Selector) (ret []*v1beta1.ControllerRevision, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all ControllerRevisions in the indexer for a given namespace.
-func (s controllerRevisionNamespaceLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.ControllerRevision, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1beta1.ControllerRevision))
 	})
@@ -103,11 +88,6 @@ func (s controllerRevisionNamespaceLister) ListWithContext(ctx context.Context, 
 
 // Get retrieves the ControllerRevision from the indexer for a given namespace and name.
 func (s controllerRevisionNamespaceLister) Get(name string) (*v1beta1.ControllerRevision, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the ControllerRevision from the indexer for a given namespace and name.
-func (s controllerRevisionNamespaceLister) GetWithContext(ctx context.Context, name string) (*v1beta1.ControllerRevision, error) {
 	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/apps/v1beta1/deployment.go
+++ b/staging/src/k8s.io/client-go/listers/apps/v1beta1/deployment.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1beta1
 
 import (
-	"context"
-
 	v1beta1 "k8s.io/api/apps/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,9 +31,6 @@ type DeploymentLister interface {
 	// List lists all Deployments in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1beta1.Deployment, err error)
-	// ListWithContext lists all Deployments in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.Deployment, err error)
 	// Deployments returns an object that can list and get Deployments.
 	Deployments(namespace string) DeploymentNamespaceLister
 	DeploymentListerExpansion
@@ -53,11 +48,6 @@ func NewDeploymentLister(indexer cache.Indexer) DeploymentLister {
 
 // List lists all Deployments in the indexer.
 func (s *deploymentLister) List(selector labels.Selector) (ret []*v1beta1.Deployment, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all Deployments in the indexer.
-func (s *deploymentLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.Deployment, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1beta1.Deployment))
 	})
@@ -90,11 +80,6 @@ type deploymentNamespaceLister struct {
 
 // List lists all Deployments in the indexer for a given namespace.
 func (s deploymentNamespaceLister) List(selector labels.Selector) (ret []*v1beta1.Deployment, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all Deployments in the indexer for a given namespace.
-func (s deploymentNamespaceLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.Deployment, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1beta1.Deployment))
 	})
@@ -103,11 +88,6 @@ func (s deploymentNamespaceLister) ListWithContext(ctx context.Context, selector
 
 // Get retrieves the Deployment from the indexer for a given namespace and name.
 func (s deploymentNamespaceLister) Get(name string) (*v1beta1.Deployment, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the Deployment from the indexer for a given namespace and name.
-func (s deploymentNamespaceLister) GetWithContext(ctx context.Context, name string) (*v1beta1.Deployment, error) {
 	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/apps/v1beta1/statefulset.go
+++ b/staging/src/k8s.io/client-go/listers/apps/v1beta1/statefulset.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1beta1
 
 import (
-	"context"
-
 	v1beta1 "k8s.io/api/apps/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,9 +31,6 @@ type StatefulSetLister interface {
 	// List lists all StatefulSets in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1beta1.StatefulSet, err error)
-	// ListWithContext lists all StatefulSets in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.StatefulSet, err error)
 	// StatefulSets returns an object that can list and get StatefulSets.
 	StatefulSets(namespace string) StatefulSetNamespaceLister
 	StatefulSetListerExpansion
@@ -53,11 +48,6 @@ func NewStatefulSetLister(indexer cache.Indexer) StatefulSetLister {
 
 // List lists all StatefulSets in the indexer.
 func (s *statefulSetLister) List(selector labels.Selector) (ret []*v1beta1.StatefulSet, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all StatefulSets in the indexer.
-func (s *statefulSetLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.StatefulSet, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1beta1.StatefulSet))
 	})
@@ -90,11 +80,6 @@ type statefulSetNamespaceLister struct {
 
 // List lists all StatefulSets in the indexer for a given namespace.
 func (s statefulSetNamespaceLister) List(selector labels.Selector) (ret []*v1beta1.StatefulSet, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all StatefulSets in the indexer for a given namespace.
-func (s statefulSetNamespaceLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.StatefulSet, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1beta1.StatefulSet))
 	})
@@ -103,11 +88,6 @@ func (s statefulSetNamespaceLister) ListWithContext(ctx context.Context, selecto
 
 // Get retrieves the StatefulSet from the indexer for a given namespace and name.
 func (s statefulSetNamespaceLister) Get(name string) (*v1beta1.StatefulSet, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the StatefulSet from the indexer for a given namespace and name.
-func (s statefulSetNamespaceLister) GetWithContext(ctx context.Context, name string) (*v1beta1.StatefulSet, error) {
 	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/apps/v1beta2/controllerrevision.go
+++ b/staging/src/k8s.io/client-go/listers/apps/v1beta2/controllerrevision.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1beta2
 
 import (
-	"context"
-
 	v1beta2 "k8s.io/api/apps/v1beta2"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,9 +31,6 @@ type ControllerRevisionLister interface {
 	// List lists all ControllerRevisions in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1beta2.ControllerRevision, err error)
-	// ListWithContext lists all ControllerRevisions in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta2.ControllerRevision, err error)
 	// ControllerRevisions returns an object that can list and get ControllerRevisions.
 	ControllerRevisions(namespace string) ControllerRevisionNamespaceLister
 	ControllerRevisionListerExpansion
@@ -53,11 +48,6 @@ func NewControllerRevisionLister(indexer cache.Indexer) ControllerRevisionLister
 
 // List lists all ControllerRevisions in the indexer.
 func (s *controllerRevisionLister) List(selector labels.Selector) (ret []*v1beta2.ControllerRevision, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all ControllerRevisions in the indexer.
-func (s *controllerRevisionLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta2.ControllerRevision, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1beta2.ControllerRevision))
 	})
@@ -90,11 +80,6 @@ type controllerRevisionNamespaceLister struct {
 
 // List lists all ControllerRevisions in the indexer for a given namespace.
 func (s controllerRevisionNamespaceLister) List(selector labels.Selector) (ret []*v1beta2.ControllerRevision, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all ControllerRevisions in the indexer for a given namespace.
-func (s controllerRevisionNamespaceLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta2.ControllerRevision, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1beta2.ControllerRevision))
 	})
@@ -103,11 +88,6 @@ func (s controllerRevisionNamespaceLister) ListWithContext(ctx context.Context, 
 
 // Get retrieves the ControllerRevision from the indexer for a given namespace and name.
 func (s controllerRevisionNamespaceLister) Get(name string) (*v1beta2.ControllerRevision, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the ControllerRevision from the indexer for a given namespace and name.
-func (s controllerRevisionNamespaceLister) GetWithContext(ctx context.Context, name string) (*v1beta2.ControllerRevision, error) {
 	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/apps/v1beta2/daemonset.go
+++ b/staging/src/k8s.io/client-go/listers/apps/v1beta2/daemonset.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1beta2
 
 import (
-	"context"
-
 	v1beta2 "k8s.io/api/apps/v1beta2"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,9 +31,6 @@ type DaemonSetLister interface {
 	// List lists all DaemonSets in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1beta2.DaemonSet, err error)
-	// ListWithContext lists all DaemonSets in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta2.DaemonSet, err error)
 	// DaemonSets returns an object that can list and get DaemonSets.
 	DaemonSets(namespace string) DaemonSetNamespaceLister
 	DaemonSetListerExpansion
@@ -53,11 +48,6 @@ func NewDaemonSetLister(indexer cache.Indexer) DaemonSetLister {
 
 // List lists all DaemonSets in the indexer.
 func (s *daemonSetLister) List(selector labels.Selector) (ret []*v1beta2.DaemonSet, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all DaemonSets in the indexer.
-func (s *daemonSetLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta2.DaemonSet, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1beta2.DaemonSet))
 	})
@@ -90,11 +80,6 @@ type daemonSetNamespaceLister struct {
 
 // List lists all DaemonSets in the indexer for a given namespace.
 func (s daemonSetNamespaceLister) List(selector labels.Selector) (ret []*v1beta2.DaemonSet, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all DaemonSets in the indexer for a given namespace.
-func (s daemonSetNamespaceLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta2.DaemonSet, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1beta2.DaemonSet))
 	})
@@ -103,11 +88,6 @@ func (s daemonSetNamespaceLister) ListWithContext(ctx context.Context, selector 
 
 // Get retrieves the DaemonSet from the indexer for a given namespace and name.
 func (s daemonSetNamespaceLister) Get(name string) (*v1beta2.DaemonSet, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the DaemonSet from the indexer for a given namespace and name.
-func (s daemonSetNamespaceLister) GetWithContext(ctx context.Context, name string) (*v1beta2.DaemonSet, error) {
 	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/apps/v1beta2/deployment.go
+++ b/staging/src/k8s.io/client-go/listers/apps/v1beta2/deployment.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1beta2
 
 import (
-	"context"
-
 	v1beta2 "k8s.io/api/apps/v1beta2"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,9 +31,6 @@ type DeploymentLister interface {
 	// List lists all Deployments in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1beta2.Deployment, err error)
-	// ListWithContext lists all Deployments in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta2.Deployment, err error)
 	// Deployments returns an object that can list and get Deployments.
 	Deployments(namespace string) DeploymentNamespaceLister
 	DeploymentListerExpansion
@@ -53,11 +48,6 @@ func NewDeploymentLister(indexer cache.Indexer) DeploymentLister {
 
 // List lists all Deployments in the indexer.
 func (s *deploymentLister) List(selector labels.Selector) (ret []*v1beta2.Deployment, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all Deployments in the indexer.
-func (s *deploymentLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta2.Deployment, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1beta2.Deployment))
 	})
@@ -90,11 +80,6 @@ type deploymentNamespaceLister struct {
 
 // List lists all Deployments in the indexer for a given namespace.
 func (s deploymentNamespaceLister) List(selector labels.Selector) (ret []*v1beta2.Deployment, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all Deployments in the indexer for a given namespace.
-func (s deploymentNamespaceLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta2.Deployment, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1beta2.Deployment))
 	})
@@ -103,11 +88,6 @@ func (s deploymentNamespaceLister) ListWithContext(ctx context.Context, selector
 
 // Get retrieves the Deployment from the indexer for a given namespace and name.
 func (s deploymentNamespaceLister) Get(name string) (*v1beta2.Deployment, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the Deployment from the indexer for a given namespace and name.
-func (s deploymentNamespaceLister) GetWithContext(ctx context.Context, name string) (*v1beta2.Deployment, error) {
 	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/apps/v1beta2/replicaset.go
+++ b/staging/src/k8s.io/client-go/listers/apps/v1beta2/replicaset.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1beta2
 
 import (
-	"context"
-
 	v1beta2 "k8s.io/api/apps/v1beta2"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,9 +31,6 @@ type ReplicaSetLister interface {
 	// List lists all ReplicaSets in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1beta2.ReplicaSet, err error)
-	// ListWithContext lists all ReplicaSets in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta2.ReplicaSet, err error)
 	// ReplicaSets returns an object that can list and get ReplicaSets.
 	ReplicaSets(namespace string) ReplicaSetNamespaceLister
 	ReplicaSetListerExpansion
@@ -53,11 +48,6 @@ func NewReplicaSetLister(indexer cache.Indexer) ReplicaSetLister {
 
 // List lists all ReplicaSets in the indexer.
 func (s *replicaSetLister) List(selector labels.Selector) (ret []*v1beta2.ReplicaSet, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all ReplicaSets in the indexer.
-func (s *replicaSetLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta2.ReplicaSet, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1beta2.ReplicaSet))
 	})
@@ -90,11 +80,6 @@ type replicaSetNamespaceLister struct {
 
 // List lists all ReplicaSets in the indexer for a given namespace.
 func (s replicaSetNamespaceLister) List(selector labels.Selector) (ret []*v1beta2.ReplicaSet, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all ReplicaSets in the indexer for a given namespace.
-func (s replicaSetNamespaceLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta2.ReplicaSet, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1beta2.ReplicaSet))
 	})
@@ -103,11 +88,6 @@ func (s replicaSetNamespaceLister) ListWithContext(ctx context.Context, selector
 
 // Get retrieves the ReplicaSet from the indexer for a given namespace and name.
 func (s replicaSetNamespaceLister) Get(name string) (*v1beta2.ReplicaSet, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the ReplicaSet from the indexer for a given namespace and name.
-func (s replicaSetNamespaceLister) GetWithContext(ctx context.Context, name string) (*v1beta2.ReplicaSet, error) {
 	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/apps/v1beta2/statefulset.go
+++ b/staging/src/k8s.io/client-go/listers/apps/v1beta2/statefulset.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1beta2
 
 import (
-	"context"
-
 	v1beta2 "k8s.io/api/apps/v1beta2"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,9 +31,6 @@ type StatefulSetLister interface {
 	// List lists all StatefulSets in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1beta2.StatefulSet, err error)
-	// ListWithContext lists all StatefulSets in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta2.StatefulSet, err error)
 	// StatefulSets returns an object that can list and get StatefulSets.
 	StatefulSets(namespace string) StatefulSetNamespaceLister
 	StatefulSetListerExpansion
@@ -53,11 +48,6 @@ func NewStatefulSetLister(indexer cache.Indexer) StatefulSetLister {
 
 // List lists all StatefulSets in the indexer.
 func (s *statefulSetLister) List(selector labels.Selector) (ret []*v1beta2.StatefulSet, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all StatefulSets in the indexer.
-func (s *statefulSetLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta2.StatefulSet, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1beta2.StatefulSet))
 	})
@@ -90,11 +80,6 @@ type statefulSetNamespaceLister struct {
 
 // List lists all StatefulSets in the indexer for a given namespace.
 func (s statefulSetNamespaceLister) List(selector labels.Selector) (ret []*v1beta2.StatefulSet, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all StatefulSets in the indexer for a given namespace.
-func (s statefulSetNamespaceLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta2.StatefulSet, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1beta2.StatefulSet))
 	})
@@ -103,11 +88,6 @@ func (s statefulSetNamespaceLister) ListWithContext(ctx context.Context, selecto
 
 // Get retrieves the StatefulSet from the indexer for a given namespace and name.
 func (s statefulSetNamespaceLister) Get(name string) (*v1beta2.StatefulSet, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the StatefulSet from the indexer for a given namespace and name.
-func (s statefulSetNamespaceLister) GetWithContext(ctx context.Context, name string) (*v1beta2.StatefulSet, error) {
 	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/autoscaling/v1/horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/listers/autoscaling/v1/horizontalpodautoscaler.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1
 
 import (
-	"context"
-
 	v1 "k8s.io/api/autoscaling/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,9 +31,6 @@ type HorizontalPodAutoscalerLister interface {
 	// List lists all HorizontalPodAutoscalers in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1.HorizontalPodAutoscaler, err error)
-	// ListWithContext lists all HorizontalPodAutoscalers in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.HorizontalPodAutoscaler, err error)
 	// HorizontalPodAutoscalers returns an object that can list and get HorizontalPodAutoscalers.
 	HorizontalPodAutoscalers(namespace string) HorizontalPodAutoscalerNamespaceLister
 	HorizontalPodAutoscalerListerExpansion
@@ -53,11 +48,6 @@ func NewHorizontalPodAutoscalerLister(indexer cache.Indexer) HorizontalPodAutosc
 
 // List lists all HorizontalPodAutoscalers in the indexer.
 func (s *horizontalPodAutoscalerLister) List(selector labels.Selector) (ret []*v1.HorizontalPodAutoscaler, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all HorizontalPodAutoscalers in the indexer.
-func (s *horizontalPodAutoscalerLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.HorizontalPodAutoscaler, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.HorizontalPodAutoscaler))
 	})
@@ -90,11 +80,6 @@ type horizontalPodAutoscalerNamespaceLister struct {
 
 // List lists all HorizontalPodAutoscalers in the indexer for a given namespace.
 func (s horizontalPodAutoscalerNamespaceLister) List(selector labels.Selector) (ret []*v1.HorizontalPodAutoscaler, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all HorizontalPodAutoscalers in the indexer for a given namespace.
-func (s horizontalPodAutoscalerNamespaceLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.HorizontalPodAutoscaler, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.HorizontalPodAutoscaler))
 	})
@@ -103,11 +88,6 @@ func (s horizontalPodAutoscalerNamespaceLister) ListWithContext(ctx context.Cont
 
 // Get retrieves the HorizontalPodAutoscaler from the indexer for a given namespace and name.
 func (s horizontalPodAutoscalerNamespaceLister) Get(name string) (*v1.HorizontalPodAutoscaler, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the HorizontalPodAutoscaler from the indexer for a given namespace and name.
-func (s horizontalPodAutoscalerNamespaceLister) GetWithContext(ctx context.Context, name string) (*v1.HorizontalPodAutoscaler, error) {
 	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/autoscaling/v2/horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/listers/autoscaling/v2/horizontalpodautoscaler.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v2
 
 import (
-	"context"
-
 	v2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,9 +31,6 @@ type HorizontalPodAutoscalerLister interface {
 	// List lists all HorizontalPodAutoscalers in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v2.HorizontalPodAutoscaler, err error)
-	// ListWithContext lists all HorizontalPodAutoscalers in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v2.HorizontalPodAutoscaler, err error)
 	// HorizontalPodAutoscalers returns an object that can list and get HorizontalPodAutoscalers.
 	HorizontalPodAutoscalers(namespace string) HorizontalPodAutoscalerNamespaceLister
 	HorizontalPodAutoscalerListerExpansion
@@ -53,11 +48,6 @@ func NewHorizontalPodAutoscalerLister(indexer cache.Indexer) HorizontalPodAutosc
 
 // List lists all HorizontalPodAutoscalers in the indexer.
 func (s *horizontalPodAutoscalerLister) List(selector labels.Selector) (ret []*v2.HorizontalPodAutoscaler, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all HorizontalPodAutoscalers in the indexer.
-func (s *horizontalPodAutoscalerLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v2.HorizontalPodAutoscaler, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v2.HorizontalPodAutoscaler))
 	})
@@ -90,11 +80,6 @@ type horizontalPodAutoscalerNamespaceLister struct {
 
 // List lists all HorizontalPodAutoscalers in the indexer for a given namespace.
 func (s horizontalPodAutoscalerNamespaceLister) List(selector labels.Selector) (ret []*v2.HorizontalPodAutoscaler, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all HorizontalPodAutoscalers in the indexer for a given namespace.
-func (s horizontalPodAutoscalerNamespaceLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v2.HorizontalPodAutoscaler, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
 		ret = append(ret, m.(*v2.HorizontalPodAutoscaler))
 	})
@@ -103,11 +88,6 @@ func (s horizontalPodAutoscalerNamespaceLister) ListWithContext(ctx context.Cont
 
 // Get retrieves the HorizontalPodAutoscaler from the indexer for a given namespace and name.
 func (s horizontalPodAutoscalerNamespaceLister) Get(name string) (*v2.HorizontalPodAutoscaler, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the HorizontalPodAutoscaler from the indexer for a given namespace and name.
-func (s horizontalPodAutoscalerNamespaceLister) GetWithContext(ctx context.Context, name string) (*v2.HorizontalPodAutoscaler, error) {
 	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/autoscaling/v2beta1/horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/listers/autoscaling/v2beta1/horizontalpodautoscaler.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v2beta1
 
 import (
-	"context"
-
 	v2beta1 "k8s.io/api/autoscaling/v2beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,9 +31,6 @@ type HorizontalPodAutoscalerLister interface {
 	// List lists all HorizontalPodAutoscalers in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v2beta1.HorizontalPodAutoscaler, err error)
-	// ListWithContext lists all HorizontalPodAutoscalers in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v2beta1.HorizontalPodAutoscaler, err error)
 	// HorizontalPodAutoscalers returns an object that can list and get HorizontalPodAutoscalers.
 	HorizontalPodAutoscalers(namespace string) HorizontalPodAutoscalerNamespaceLister
 	HorizontalPodAutoscalerListerExpansion
@@ -53,11 +48,6 @@ func NewHorizontalPodAutoscalerLister(indexer cache.Indexer) HorizontalPodAutosc
 
 // List lists all HorizontalPodAutoscalers in the indexer.
 func (s *horizontalPodAutoscalerLister) List(selector labels.Selector) (ret []*v2beta1.HorizontalPodAutoscaler, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all HorizontalPodAutoscalers in the indexer.
-func (s *horizontalPodAutoscalerLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v2beta1.HorizontalPodAutoscaler, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v2beta1.HorizontalPodAutoscaler))
 	})
@@ -90,11 +80,6 @@ type horizontalPodAutoscalerNamespaceLister struct {
 
 // List lists all HorizontalPodAutoscalers in the indexer for a given namespace.
 func (s horizontalPodAutoscalerNamespaceLister) List(selector labels.Selector) (ret []*v2beta1.HorizontalPodAutoscaler, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all HorizontalPodAutoscalers in the indexer for a given namespace.
-func (s horizontalPodAutoscalerNamespaceLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v2beta1.HorizontalPodAutoscaler, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
 		ret = append(ret, m.(*v2beta1.HorizontalPodAutoscaler))
 	})
@@ -103,11 +88,6 @@ func (s horizontalPodAutoscalerNamespaceLister) ListWithContext(ctx context.Cont
 
 // Get retrieves the HorizontalPodAutoscaler from the indexer for a given namespace and name.
 func (s horizontalPodAutoscalerNamespaceLister) Get(name string) (*v2beta1.HorizontalPodAutoscaler, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the HorizontalPodAutoscaler from the indexer for a given namespace and name.
-func (s horizontalPodAutoscalerNamespaceLister) GetWithContext(ctx context.Context, name string) (*v2beta1.HorizontalPodAutoscaler, error) {
 	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/autoscaling/v2beta2/horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/listers/autoscaling/v2beta2/horizontalpodautoscaler.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v2beta2
 
 import (
-	"context"
-
 	v2beta2 "k8s.io/api/autoscaling/v2beta2"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,9 +31,6 @@ type HorizontalPodAutoscalerLister interface {
 	// List lists all HorizontalPodAutoscalers in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v2beta2.HorizontalPodAutoscaler, err error)
-	// ListWithContext lists all HorizontalPodAutoscalers in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v2beta2.HorizontalPodAutoscaler, err error)
 	// HorizontalPodAutoscalers returns an object that can list and get HorizontalPodAutoscalers.
 	HorizontalPodAutoscalers(namespace string) HorizontalPodAutoscalerNamespaceLister
 	HorizontalPodAutoscalerListerExpansion
@@ -53,11 +48,6 @@ func NewHorizontalPodAutoscalerLister(indexer cache.Indexer) HorizontalPodAutosc
 
 // List lists all HorizontalPodAutoscalers in the indexer.
 func (s *horizontalPodAutoscalerLister) List(selector labels.Selector) (ret []*v2beta2.HorizontalPodAutoscaler, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all HorizontalPodAutoscalers in the indexer.
-func (s *horizontalPodAutoscalerLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v2beta2.HorizontalPodAutoscaler, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v2beta2.HorizontalPodAutoscaler))
 	})
@@ -90,11 +80,6 @@ type horizontalPodAutoscalerNamespaceLister struct {
 
 // List lists all HorizontalPodAutoscalers in the indexer for a given namespace.
 func (s horizontalPodAutoscalerNamespaceLister) List(selector labels.Selector) (ret []*v2beta2.HorizontalPodAutoscaler, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all HorizontalPodAutoscalers in the indexer for a given namespace.
-func (s horizontalPodAutoscalerNamespaceLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v2beta2.HorizontalPodAutoscaler, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
 		ret = append(ret, m.(*v2beta2.HorizontalPodAutoscaler))
 	})
@@ -103,11 +88,6 @@ func (s horizontalPodAutoscalerNamespaceLister) ListWithContext(ctx context.Cont
 
 // Get retrieves the HorizontalPodAutoscaler from the indexer for a given namespace and name.
 func (s horizontalPodAutoscalerNamespaceLister) Get(name string) (*v2beta2.HorizontalPodAutoscaler, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the HorizontalPodAutoscaler from the indexer for a given namespace and name.
-func (s horizontalPodAutoscalerNamespaceLister) GetWithContext(ctx context.Context, name string) (*v2beta2.HorizontalPodAutoscaler, error) {
 	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/batch/v1/cronjob.go
+++ b/staging/src/k8s.io/client-go/listers/batch/v1/cronjob.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1
 
 import (
-	"context"
-
 	v1 "k8s.io/api/batch/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,9 +31,6 @@ type CronJobLister interface {
 	// List lists all CronJobs in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1.CronJob, err error)
-	// ListWithContext lists all CronJobs in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.CronJob, err error)
 	// CronJobs returns an object that can list and get CronJobs.
 	CronJobs(namespace string) CronJobNamespaceLister
 	CronJobListerExpansion
@@ -53,11 +48,6 @@ func NewCronJobLister(indexer cache.Indexer) CronJobLister {
 
 // List lists all CronJobs in the indexer.
 func (s *cronJobLister) List(selector labels.Selector) (ret []*v1.CronJob, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all CronJobs in the indexer.
-func (s *cronJobLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.CronJob, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.CronJob))
 	})
@@ -90,11 +80,6 @@ type cronJobNamespaceLister struct {
 
 // List lists all CronJobs in the indexer for a given namespace.
 func (s cronJobNamespaceLister) List(selector labels.Selector) (ret []*v1.CronJob, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all CronJobs in the indexer for a given namespace.
-func (s cronJobNamespaceLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.CronJob, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.CronJob))
 	})
@@ -103,11 +88,6 @@ func (s cronJobNamespaceLister) ListWithContext(ctx context.Context, selector la
 
 // Get retrieves the CronJob from the indexer for a given namespace and name.
 func (s cronJobNamespaceLister) Get(name string) (*v1.CronJob, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the CronJob from the indexer for a given namespace and name.
-func (s cronJobNamespaceLister) GetWithContext(ctx context.Context, name string) (*v1.CronJob, error) {
 	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/batch/v1/job.go
+++ b/staging/src/k8s.io/client-go/listers/batch/v1/job.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1
 
 import (
-	"context"
-
 	v1 "k8s.io/api/batch/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,9 +31,6 @@ type JobLister interface {
 	// List lists all Jobs in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1.Job, err error)
-	// ListWithContext lists all Jobs in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.Job, err error)
 	// Jobs returns an object that can list and get Jobs.
 	Jobs(namespace string) JobNamespaceLister
 	JobListerExpansion
@@ -53,11 +48,6 @@ func NewJobLister(indexer cache.Indexer) JobLister {
 
 // List lists all Jobs in the indexer.
 func (s *jobLister) List(selector labels.Selector) (ret []*v1.Job, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all Jobs in the indexer.
-func (s *jobLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.Job, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.Job))
 	})
@@ -90,11 +80,6 @@ type jobNamespaceLister struct {
 
 // List lists all Jobs in the indexer for a given namespace.
 func (s jobNamespaceLister) List(selector labels.Selector) (ret []*v1.Job, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all Jobs in the indexer for a given namespace.
-func (s jobNamespaceLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.Job, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.Job))
 	})
@@ -103,11 +88,6 @@ func (s jobNamespaceLister) ListWithContext(ctx context.Context, selector labels
 
 // Get retrieves the Job from the indexer for a given namespace and name.
 func (s jobNamespaceLister) Get(name string) (*v1.Job, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the Job from the indexer for a given namespace and name.
-func (s jobNamespaceLister) GetWithContext(ctx context.Context, name string) (*v1.Job, error) {
 	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/batch/v1beta1/cronjob.go
+++ b/staging/src/k8s.io/client-go/listers/batch/v1beta1/cronjob.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1beta1
 
 import (
-	"context"
-
 	v1beta1 "k8s.io/api/batch/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,9 +31,6 @@ type CronJobLister interface {
 	// List lists all CronJobs in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1beta1.CronJob, err error)
-	// ListWithContext lists all CronJobs in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.CronJob, err error)
 	// CronJobs returns an object that can list and get CronJobs.
 	CronJobs(namespace string) CronJobNamespaceLister
 	CronJobListerExpansion
@@ -53,11 +48,6 @@ func NewCronJobLister(indexer cache.Indexer) CronJobLister {
 
 // List lists all CronJobs in the indexer.
 func (s *cronJobLister) List(selector labels.Selector) (ret []*v1beta1.CronJob, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all CronJobs in the indexer.
-func (s *cronJobLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.CronJob, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1beta1.CronJob))
 	})
@@ -90,11 +80,6 @@ type cronJobNamespaceLister struct {
 
 // List lists all CronJobs in the indexer for a given namespace.
 func (s cronJobNamespaceLister) List(selector labels.Selector) (ret []*v1beta1.CronJob, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all CronJobs in the indexer for a given namespace.
-func (s cronJobNamespaceLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.CronJob, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1beta1.CronJob))
 	})
@@ -103,11 +88,6 @@ func (s cronJobNamespaceLister) ListWithContext(ctx context.Context, selector la
 
 // Get retrieves the CronJob from the indexer for a given namespace and name.
 func (s cronJobNamespaceLister) Get(name string) (*v1beta1.CronJob, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the CronJob from the indexer for a given namespace and name.
-func (s cronJobNamespaceLister) GetWithContext(ctx context.Context, name string) (*v1beta1.CronJob, error) {
 	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/certificates/v1/certificatesigningrequest.go
+++ b/staging/src/k8s.io/client-go/listers/certificates/v1/certificatesigningrequest.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1
 
 import (
-	"context"
-
 	v1 "k8s.io/api/certificates/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,15 +31,9 @@ type CertificateSigningRequestLister interface {
 	// List lists all CertificateSigningRequests in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1.CertificateSigningRequest, err error)
-	// ListWithContext lists all CertificateSigningRequests in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.CertificateSigningRequest, err error)
 	// Get retrieves the CertificateSigningRequest from the index for a given name.
 	// Objects returned here must be treated as read-only.
 	Get(name string) (*v1.CertificateSigningRequest, error)
-	// GetWithContext retrieves the CertificateSigningRequest from the index for a given name.
-	// Objects returned here must be treated as read-only.
-	GetWithContext(ctx context.Context, name string) (*v1.CertificateSigningRequest, error)
 	CertificateSigningRequestListerExpansion
 }
 
@@ -57,11 +49,6 @@ func NewCertificateSigningRequestLister(indexer cache.Indexer) CertificateSignin
 
 // List lists all CertificateSigningRequests in the indexer.
 func (s *certificateSigningRequestLister) List(selector labels.Selector) (ret []*v1.CertificateSigningRequest, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all CertificateSigningRequests in the indexer.
-func (s *certificateSigningRequestLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.CertificateSigningRequest, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.CertificateSigningRequest))
 	})
@@ -70,11 +57,6 @@ func (s *certificateSigningRequestLister) ListWithContext(ctx context.Context, s
 
 // Get retrieves the CertificateSigningRequest from the index for a given name.
 func (s *certificateSigningRequestLister) Get(name string) (*v1.CertificateSigningRequest, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the CertificateSigningRequest from the index for a given name.
-func (s *certificateSigningRequestLister) GetWithContext(ctx context.Context, name string) (*v1.CertificateSigningRequest, error) {
 	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/certificates/v1beta1/certificatesigningrequest.go
+++ b/staging/src/k8s.io/client-go/listers/certificates/v1beta1/certificatesigningrequest.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1beta1
 
 import (
-	"context"
-
 	v1beta1 "k8s.io/api/certificates/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,15 +31,9 @@ type CertificateSigningRequestLister interface {
 	// List lists all CertificateSigningRequests in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1beta1.CertificateSigningRequest, err error)
-	// ListWithContext lists all CertificateSigningRequests in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.CertificateSigningRequest, err error)
 	// Get retrieves the CertificateSigningRequest from the index for a given name.
 	// Objects returned here must be treated as read-only.
 	Get(name string) (*v1beta1.CertificateSigningRequest, error)
-	// GetWithContext retrieves the CertificateSigningRequest from the index for a given name.
-	// Objects returned here must be treated as read-only.
-	GetWithContext(ctx context.Context, name string) (*v1beta1.CertificateSigningRequest, error)
 	CertificateSigningRequestListerExpansion
 }
 
@@ -57,11 +49,6 @@ func NewCertificateSigningRequestLister(indexer cache.Indexer) CertificateSignin
 
 // List lists all CertificateSigningRequests in the indexer.
 func (s *certificateSigningRequestLister) List(selector labels.Selector) (ret []*v1beta1.CertificateSigningRequest, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all CertificateSigningRequests in the indexer.
-func (s *certificateSigningRequestLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.CertificateSigningRequest, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1beta1.CertificateSigningRequest))
 	})
@@ -70,11 +57,6 @@ func (s *certificateSigningRequestLister) ListWithContext(ctx context.Context, s
 
 // Get retrieves the CertificateSigningRequest from the index for a given name.
 func (s *certificateSigningRequestLister) Get(name string) (*v1beta1.CertificateSigningRequest, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the CertificateSigningRequest from the index for a given name.
-func (s *certificateSigningRequestLister) GetWithContext(ctx context.Context, name string) (*v1beta1.CertificateSigningRequest, error) {
 	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/coordination/v1/lease.go
+++ b/staging/src/k8s.io/client-go/listers/coordination/v1/lease.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1
 
 import (
-	"context"
-
 	v1 "k8s.io/api/coordination/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,9 +31,6 @@ type LeaseLister interface {
 	// List lists all Leases in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1.Lease, err error)
-	// ListWithContext lists all Leases in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.Lease, err error)
 	// Leases returns an object that can list and get Leases.
 	Leases(namespace string) LeaseNamespaceLister
 	LeaseListerExpansion
@@ -53,11 +48,6 @@ func NewLeaseLister(indexer cache.Indexer) LeaseLister {
 
 // List lists all Leases in the indexer.
 func (s *leaseLister) List(selector labels.Selector) (ret []*v1.Lease, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all Leases in the indexer.
-func (s *leaseLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.Lease, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.Lease))
 	})
@@ -90,11 +80,6 @@ type leaseNamespaceLister struct {
 
 // List lists all Leases in the indexer for a given namespace.
 func (s leaseNamespaceLister) List(selector labels.Selector) (ret []*v1.Lease, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all Leases in the indexer for a given namespace.
-func (s leaseNamespaceLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.Lease, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.Lease))
 	})
@@ -103,11 +88,6 @@ func (s leaseNamespaceLister) ListWithContext(ctx context.Context, selector labe
 
 // Get retrieves the Lease from the indexer for a given namespace and name.
 func (s leaseNamespaceLister) Get(name string) (*v1.Lease, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the Lease from the indexer for a given namespace and name.
-func (s leaseNamespaceLister) GetWithContext(ctx context.Context, name string) (*v1.Lease, error) {
 	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/coordination/v1beta1/lease.go
+++ b/staging/src/k8s.io/client-go/listers/coordination/v1beta1/lease.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1beta1
 
 import (
-	"context"
-
 	v1beta1 "k8s.io/api/coordination/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,9 +31,6 @@ type LeaseLister interface {
 	// List lists all Leases in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1beta1.Lease, err error)
-	// ListWithContext lists all Leases in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.Lease, err error)
 	// Leases returns an object that can list and get Leases.
 	Leases(namespace string) LeaseNamespaceLister
 	LeaseListerExpansion
@@ -53,11 +48,6 @@ func NewLeaseLister(indexer cache.Indexer) LeaseLister {
 
 // List lists all Leases in the indexer.
 func (s *leaseLister) List(selector labels.Selector) (ret []*v1beta1.Lease, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all Leases in the indexer.
-func (s *leaseLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.Lease, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1beta1.Lease))
 	})
@@ -90,11 +80,6 @@ type leaseNamespaceLister struct {
 
 // List lists all Leases in the indexer for a given namespace.
 func (s leaseNamespaceLister) List(selector labels.Selector) (ret []*v1beta1.Lease, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all Leases in the indexer for a given namespace.
-func (s leaseNamespaceLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.Lease, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1beta1.Lease))
 	})
@@ -103,11 +88,6 @@ func (s leaseNamespaceLister) ListWithContext(ctx context.Context, selector labe
 
 // Get retrieves the Lease from the indexer for a given namespace and name.
 func (s leaseNamespaceLister) Get(name string) (*v1beta1.Lease, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the Lease from the indexer for a given namespace and name.
-func (s leaseNamespaceLister) GetWithContext(ctx context.Context, name string) (*v1beta1.Lease, error) {
 	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/core/v1/componentstatus.go
+++ b/staging/src/k8s.io/client-go/listers/core/v1/componentstatus.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1
 
 import (
-	"context"
-
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,15 +31,9 @@ type ComponentStatusLister interface {
 	// List lists all ComponentStatuses in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1.ComponentStatus, err error)
-	// ListWithContext lists all ComponentStatuses in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.ComponentStatus, err error)
 	// Get retrieves the ComponentStatus from the index for a given name.
 	// Objects returned here must be treated as read-only.
 	Get(name string) (*v1.ComponentStatus, error)
-	// GetWithContext retrieves the ComponentStatus from the index for a given name.
-	// Objects returned here must be treated as read-only.
-	GetWithContext(ctx context.Context, name string) (*v1.ComponentStatus, error)
 	ComponentStatusListerExpansion
 }
 
@@ -57,11 +49,6 @@ func NewComponentStatusLister(indexer cache.Indexer) ComponentStatusLister {
 
 // List lists all ComponentStatuses in the indexer.
 func (s *componentStatusLister) List(selector labels.Selector) (ret []*v1.ComponentStatus, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all ComponentStatuses in the indexer.
-func (s *componentStatusLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.ComponentStatus, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.ComponentStatus))
 	})
@@ -70,11 +57,6 @@ func (s *componentStatusLister) ListWithContext(ctx context.Context, selector la
 
 // Get retrieves the ComponentStatus from the index for a given name.
 func (s *componentStatusLister) Get(name string) (*v1.ComponentStatus, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the ComponentStatus from the index for a given name.
-func (s *componentStatusLister) GetWithContext(ctx context.Context, name string) (*v1.ComponentStatus, error) {
 	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/core/v1/configmap.go
+++ b/staging/src/k8s.io/client-go/listers/core/v1/configmap.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1
 
 import (
-	"context"
-
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,9 +31,6 @@ type ConfigMapLister interface {
 	// List lists all ConfigMaps in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1.ConfigMap, err error)
-	// ListWithContext lists all ConfigMaps in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.ConfigMap, err error)
 	// ConfigMaps returns an object that can list and get ConfigMaps.
 	ConfigMaps(namespace string) ConfigMapNamespaceLister
 	ConfigMapListerExpansion
@@ -53,11 +48,6 @@ func NewConfigMapLister(indexer cache.Indexer) ConfigMapLister {
 
 // List lists all ConfigMaps in the indexer.
 func (s *configMapLister) List(selector labels.Selector) (ret []*v1.ConfigMap, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all ConfigMaps in the indexer.
-func (s *configMapLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.ConfigMap, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.ConfigMap))
 	})
@@ -90,11 +80,6 @@ type configMapNamespaceLister struct {
 
 // List lists all ConfigMaps in the indexer for a given namespace.
 func (s configMapNamespaceLister) List(selector labels.Selector) (ret []*v1.ConfigMap, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all ConfigMaps in the indexer for a given namespace.
-func (s configMapNamespaceLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.ConfigMap, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.ConfigMap))
 	})
@@ -103,11 +88,6 @@ func (s configMapNamespaceLister) ListWithContext(ctx context.Context, selector 
 
 // Get retrieves the ConfigMap from the indexer for a given namespace and name.
 func (s configMapNamespaceLister) Get(name string) (*v1.ConfigMap, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the ConfigMap from the indexer for a given namespace and name.
-func (s configMapNamespaceLister) GetWithContext(ctx context.Context, name string) (*v1.ConfigMap, error) {
 	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/core/v1/endpoints.go
+++ b/staging/src/k8s.io/client-go/listers/core/v1/endpoints.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1
 
 import (
-	"context"
-
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,9 +31,6 @@ type EndpointsLister interface {
 	// List lists all Endpoints in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1.Endpoints, err error)
-	// ListWithContext lists all Endpoints in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.Endpoints, err error)
 	// Endpoints returns an object that can list and get Endpoints.
 	Endpoints(namespace string) EndpointsNamespaceLister
 	EndpointsListerExpansion
@@ -53,11 +48,6 @@ func NewEndpointsLister(indexer cache.Indexer) EndpointsLister {
 
 // List lists all Endpoints in the indexer.
 func (s *endpointsLister) List(selector labels.Selector) (ret []*v1.Endpoints, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all Endpoints in the indexer.
-func (s *endpointsLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.Endpoints, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.Endpoints))
 	})
@@ -90,11 +80,6 @@ type endpointsNamespaceLister struct {
 
 // List lists all Endpoints in the indexer for a given namespace.
 func (s endpointsNamespaceLister) List(selector labels.Selector) (ret []*v1.Endpoints, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all Endpoints in the indexer for a given namespace.
-func (s endpointsNamespaceLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.Endpoints, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.Endpoints))
 	})
@@ -103,11 +88,6 @@ func (s endpointsNamespaceLister) ListWithContext(ctx context.Context, selector 
 
 // Get retrieves the Endpoints from the indexer for a given namespace and name.
 func (s endpointsNamespaceLister) Get(name string) (*v1.Endpoints, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the Endpoints from the indexer for a given namespace and name.
-func (s endpointsNamespaceLister) GetWithContext(ctx context.Context, name string) (*v1.Endpoints, error) {
 	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/core/v1/event.go
+++ b/staging/src/k8s.io/client-go/listers/core/v1/event.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1
 
 import (
-	"context"
-
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,9 +31,6 @@ type EventLister interface {
 	// List lists all Events in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1.Event, err error)
-	// ListWithContext lists all Events in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.Event, err error)
 	// Events returns an object that can list and get Events.
 	Events(namespace string) EventNamespaceLister
 	EventListerExpansion
@@ -53,11 +48,6 @@ func NewEventLister(indexer cache.Indexer) EventLister {
 
 // List lists all Events in the indexer.
 func (s *eventLister) List(selector labels.Selector) (ret []*v1.Event, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all Events in the indexer.
-func (s *eventLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.Event, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.Event))
 	})
@@ -90,11 +80,6 @@ type eventNamespaceLister struct {
 
 // List lists all Events in the indexer for a given namespace.
 func (s eventNamespaceLister) List(selector labels.Selector) (ret []*v1.Event, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all Events in the indexer for a given namespace.
-func (s eventNamespaceLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.Event, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.Event))
 	})
@@ -103,11 +88,6 @@ func (s eventNamespaceLister) ListWithContext(ctx context.Context, selector labe
 
 // Get retrieves the Event from the indexer for a given namespace and name.
 func (s eventNamespaceLister) Get(name string) (*v1.Event, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the Event from the indexer for a given namespace and name.
-func (s eventNamespaceLister) GetWithContext(ctx context.Context, name string) (*v1.Event, error) {
 	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/core/v1/limitrange.go
+++ b/staging/src/k8s.io/client-go/listers/core/v1/limitrange.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1
 
 import (
-	"context"
-
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,9 +31,6 @@ type LimitRangeLister interface {
 	// List lists all LimitRanges in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1.LimitRange, err error)
-	// ListWithContext lists all LimitRanges in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.LimitRange, err error)
 	// LimitRanges returns an object that can list and get LimitRanges.
 	LimitRanges(namespace string) LimitRangeNamespaceLister
 	LimitRangeListerExpansion
@@ -53,11 +48,6 @@ func NewLimitRangeLister(indexer cache.Indexer) LimitRangeLister {
 
 // List lists all LimitRanges in the indexer.
 func (s *limitRangeLister) List(selector labels.Selector) (ret []*v1.LimitRange, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all LimitRanges in the indexer.
-func (s *limitRangeLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.LimitRange, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.LimitRange))
 	})
@@ -90,11 +80,6 @@ type limitRangeNamespaceLister struct {
 
 // List lists all LimitRanges in the indexer for a given namespace.
 func (s limitRangeNamespaceLister) List(selector labels.Selector) (ret []*v1.LimitRange, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all LimitRanges in the indexer for a given namespace.
-func (s limitRangeNamespaceLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.LimitRange, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.LimitRange))
 	})
@@ -103,11 +88,6 @@ func (s limitRangeNamespaceLister) ListWithContext(ctx context.Context, selector
 
 // Get retrieves the LimitRange from the indexer for a given namespace and name.
 func (s limitRangeNamespaceLister) Get(name string) (*v1.LimitRange, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the LimitRange from the indexer for a given namespace and name.
-func (s limitRangeNamespaceLister) GetWithContext(ctx context.Context, name string) (*v1.LimitRange, error) {
 	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/core/v1/namespace.go
+++ b/staging/src/k8s.io/client-go/listers/core/v1/namespace.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1
 
 import (
-	"context"
-
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,15 +31,9 @@ type NamespaceLister interface {
 	// List lists all Namespaces in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1.Namespace, err error)
-	// ListWithContext lists all Namespaces in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.Namespace, err error)
 	// Get retrieves the Namespace from the index for a given name.
 	// Objects returned here must be treated as read-only.
 	Get(name string) (*v1.Namespace, error)
-	// GetWithContext retrieves the Namespace from the index for a given name.
-	// Objects returned here must be treated as read-only.
-	GetWithContext(ctx context.Context, name string) (*v1.Namespace, error)
 	NamespaceListerExpansion
 }
 
@@ -57,11 +49,6 @@ func NewNamespaceLister(indexer cache.Indexer) NamespaceLister {
 
 // List lists all Namespaces in the indexer.
 func (s *namespaceLister) List(selector labels.Selector) (ret []*v1.Namespace, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all Namespaces in the indexer.
-func (s *namespaceLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.Namespace, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.Namespace))
 	})
@@ -70,11 +57,6 @@ func (s *namespaceLister) ListWithContext(ctx context.Context, selector labels.S
 
 // Get retrieves the Namespace from the index for a given name.
 func (s *namespaceLister) Get(name string) (*v1.Namespace, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the Namespace from the index for a given name.
-func (s *namespaceLister) GetWithContext(ctx context.Context, name string) (*v1.Namespace, error) {
 	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/core/v1/node.go
+++ b/staging/src/k8s.io/client-go/listers/core/v1/node.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1
 
 import (
-	"context"
-
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,15 +31,9 @@ type NodeLister interface {
 	// List lists all Nodes in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1.Node, err error)
-	// ListWithContext lists all Nodes in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.Node, err error)
 	// Get retrieves the Node from the index for a given name.
 	// Objects returned here must be treated as read-only.
 	Get(name string) (*v1.Node, error)
-	// GetWithContext retrieves the Node from the index for a given name.
-	// Objects returned here must be treated as read-only.
-	GetWithContext(ctx context.Context, name string) (*v1.Node, error)
 	NodeListerExpansion
 }
 
@@ -57,11 +49,6 @@ func NewNodeLister(indexer cache.Indexer) NodeLister {
 
 // List lists all Nodes in the indexer.
 func (s *nodeLister) List(selector labels.Selector) (ret []*v1.Node, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all Nodes in the indexer.
-func (s *nodeLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.Node, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.Node))
 	})
@@ -70,11 +57,6 @@ func (s *nodeLister) ListWithContext(ctx context.Context, selector labels.Select
 
 // Get retrieves the Node from the index for a given name.
 func (s *nodeLister) Get(name string) (*v1.Node, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the Node from the index for a given name.
-func (s *nodeLister) GetWithContext(ctx context.Context, name string) (*v1.Node, error) {
 	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/core/v1/persistentvolume.go
+++ b/staging/src/k8s.io/client-go/listers/core/v1/persistentvolume.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1
 
 import (
-	"context"
-
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,15 +31,9 @@ type PersistentVolumeLister interface {
 	// List lists all PersistentVolumes in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1.PersistentVolume, err error)
-	// ListWithContext lists all PersistentVolumes in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.PersistentVolume, err error)
 	// Get retrieves the PersistentVolume from the index for a given name.
 	// Objects returned here must be treated as read-only.
 	Get(name string) (*v1.PersistentVolume, error)
-	// GetWithContext retrieves the PersistentVolume from the index for a given name.
-	// Objects returned here must be treated as read-only.
-	GetWithContext(ctx context.Context, name string) (*v1.PersistentVolume, error)
 	PersistentVolumeListerExpansion
 }
 
@@ -57,11 +49,6 @@ func NewPersistentVolumeLister(indexer cache.Indexer) PersistentVolumeLister {
 
 // List lists all PersistentVolumes in the indexer.
 func (s *persistentVolumeLister) List(selector labels.Selector) (ret []*v1.PersistentVolume, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all PersistentVolumes in the indexer.
-func (s *persistentVolumeLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.PersistentVolume, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.PersistentVolume))
 	})
@@ -70,11 +57,6 @@ func (s *persistentVolumeLister) ListWithContext(ctx context.Context, selector l
 
 // Get retrieves the PersistentVolume from the index for a given name.
 func (s *persistentVolumeLister) Get(name string) (*v1.PersistentVolume, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the PersistentVolume from the index for a given name.
-func (s *persistentVolumeLister) GetWithContext(ctx context.Context, name string) (*v1.PersistentVolume, error) {
 	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/core/v1/persistentvolumeclaim.go
+++ b/staging/src/k8s.io/client-go/listers/core/v1/persistentvolumeclaim.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1
 
 import (
-	"context"
-
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,9 +31,6 @@ type PersistentVolumeClaimLister interface {
 	// List lists all PersistentVolumeClaims in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1.PersistentVolumeClaim, err error)
-	// ListWithContext lists all PersistentVolumeClaims in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.PersistentVolumeClaim, err error)
 	// PersistentVolumeClaims returns an object that can list and get PersistentVolumeClaims.
 	PersistentVolumeClaims(namespace string) PersistentVolumeClaimNamespaceLister
 	PersistentVolumeClaimListerExpansion
@@ -53,11 +48,6 @@ func NewPersistentVolumeClaimLister(indexer cache.Indexer) PersistentVolumeClaim
 
 // List lists all PersistentVolumeClaims in the indexer.
 func (s *persistentVolumeClaimLister) List(selector labels.Selector) (ret []*v1.PersistentVolumeClaim, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all PersistentVolumeClaims in the indexer.
-func (s *persistentVolumeClaimLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.PersistentVolumeClaim, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.PersistentVolumeClaim))
 	})
@@ -90,11 +80,6 @@ type persistentVolumeClaimNamespaceLister struct {
 
 // List lists all PersistentVolumeClaims in the indexer for a given namespace.
 func (s persistentVolumeClaimNamespaceLister) List(selector labels.Selector) (ret []*v1.PersistentVolumeClaim, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all PersistentVolumeClaims in the indexer for a given namespace.
-func (s persistentVolumeClaimNamespaceLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.PersistentVolumeClaim, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.PersistentVolumeClaim))
 	})
@@ -103,11 +88,6 @@ func (s persistentVolumeClaimNamespaceLister) ListWithContext(ctx context.Contex
 
 // Get retrieves the PersistentVolumeClaim from the indexer for a given namespace and name.
 func (s persistentVolumeClaimNamespaceLister) Get(name string) (*v1.PersistentVolumeClaim, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the PersistentVolumeClaim from the indexer for a given namespace and name.
-func (s persistentVolumeClaimNamespaceLister) GetWithContext(ctx context.Context, name string) (*v1.PersistentVolumeClaim, error) {
 	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/core/v1/pod.go
+++ b/staging/src/k8s.io/client-go/listers/core/v1/pod.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1
 
 import (
-	"context"
-
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,9 +31,6 @@ type PodLister interface {
 	// List lists all Pods in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1.Pod, err error)
-	// ListWithContext lists all Pods in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.Pod, err error)
 	// Pods returns an object that can list and get Pods.
 	Pods(namespace string) PodNamespaceLister
 	PodListerExpansion
@@ -53,11 +48,6 @@ func NewPodLister(indexer cache.Indexer) PodLister {
 
 // List lists all Pods in the indexer.
 func (s *podLister) List(selector labels.Selector) (ret []*v1.Pod, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all Pods in the indexer.
-func (s *podLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.Pod, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.Pod))
 	})
@@ -90,11 +80,6 @@ type podNamespaceLister struct {
 
 // List lists all Pods in the indexer for a given namespace.
 func (s podNamespaceLister) List(selector labels.Selector) (ret []*v1.Pod, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all Pods in the indexer for a given namespace.
-func (s podNamespaceLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.Pod, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.Pod))
 	})
@@ -103,11 +88,6 @@ func (s podNamespaceLister) ListWithContext(ctx context.Context, selector labels
 
 // Get retrieves the Pod from the indexer for a given namespace and name.
 func (s podNamespaceLister) Get(name string) (*v1.Pod, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the Pod from the indexer for a given namespace and name.
-func (s podNamespaceLister) GetWithContext(ctx context.Context, name string) (*v1.Pod, error) {
 	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/core/v1/podtemplate.go
+++ b/staging/src/k8s.io/client-go/listers/core/v1/podtemplate.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1
 
 import (
-	"context"
-
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,9 +31,6 @@ type PodTemplateLister interface {
 	// List lists all PodTemplates in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1.PodTemplate, err error)
-	// ListWithContext lists all PodTemplates in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.PodTemplate, err error)
 	// PodTemplates returns an object that can list and get PodTemplates.
 	PodTemplates(namespace string) PodTemplateNamespaceLister
 	PodTemplateListerExpansion
@@ -53,11 +48,6 @@ func NewPodTemplateLister(indexer cache.Indexer) PodTemplateLister {
 
 // List lists all PodTemplates in the indexer.
 func (s *podTemplateLister) List(selector labels.Selector) (ret []*v1.PodTemplate, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all PodTemplates in the indexer.
-func (s *podTemplateLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.PodTemplate, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.PodTemplate))
 	})
@@ -90,11 +80,6 @@ type podTemplateNamespaceLister struct {
 
 // List lists all PodTemplates in the indexer for a given namespace.
 func (s podTemplateNamespaceLister) List(selector labels.Selector) (ret []*v1.PodTemplate, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all PodTemplates in the indexer for a given namespace.
-func (s podTemplateNamespaceLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.PodTemplate, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.PodTemplate))
 	})
@@ -103,11 +88,6 @@ func (s podTemplateNamespaceLister) ListWithContext(ctx context.Context, selecto
 
 // Get retrieves the PodTemplate from the indexer for a given namespace and name.
 func (s podTemplateNamespaceLister) Get(name string) (*v1.PodTemplate, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the PodTemplate from the indexer for a given namespace and name.
-func (s podTemplateNamespaceLister) GetWithContext(ctx context.Context, name string) (*v1.PodTemplate, error) {
 	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/core/v1/replicationcontroller.go
+++ b/staging/src/k8s.io/client-go/listers/core/v1/replicationcontroller.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1
 
 import (
-	"context"
-
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,9 +31,6 @@ type ReplicationControllerLister interface {
 	// List lists all ReplicationControllers in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1.ReplicationController, err error)
-	// ListWithContext lists all ReplicationControllers in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.ReplicationController, err error)
 	// ReplicationControllers returns an object that can list and get ReplicationControllers.
 	ReplicationControllers(namespace string) ReplicationControllerNamespaceLister
 	ReplicationControllerListerExpansion
@@ -53,11 +48,6 @@ func NewReplicationControllerLister(indexer cache.Indexer) ReplicationController
 
 // List lists all ReplicationControllers in the indexer.
 func (s *replicationControllerLister) List(selector labels.Selector) (ret []*v1.ReplicationController, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all ReplicationControllers in the indexer.
-func (s *replicationControllerLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.ReplicationController, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.ReplicationController))
 	})
@@ -90,11 +80,6 @@ type replicationControllerNamespaceLister struct {
 
 // List lists all ReplicationControllers in the indexer for a given namespace.
 func (s replicationControllerNamespaceLister) List(selector labels.Selector) (ret []*v1.ReplicationController, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all ReplicationControllers in the indexer for a given namespace.
-func (s replicationControllerNamespaceLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.ReplicationController, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.ReplicationController))
 	})
@@ -103,11 +88,6 @@ func (s replicationControllerNamespaceLister) ListWithContext(ctx context.Contex
 
 // Get retrieves the ReplicationController from the indexer for a given namespace and name.
 func (s replicationControllerNamespaceLister) Get(name string) (*v1.ReplicationController, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the ReplicationController from the indexer for a given namespace and name.
-func (s replicationControllerNamespaceLister) GetWithContext(ctx context.Context, name string) (*v1.ReplicationController, error) {
 	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/core/v1/resourcequota.go
+++ b/staging/src/k8s.io/client-go/listers/core/v1/resourcequota.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1
 
 import (
-	"context"
-
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,9 +31,6 @@ type ResourceQuotaLister interface {
 	// List lists all ResourceQuotas in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1.ResourceQuota, err error)
-	// ListWithContext lists all ResourceQuotas in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.ResourceQuota, err error)
 	// ResourceQuotas returns an object that can list and get ResourceQuotas.
 	ResourceQuotas(namespace string) ResourceQuotaNamespaceLister
 	ResourceQuotaListerExpansion
@@ -53,11 +48,6 @@ func NewResourceQuotaLister(indexer cache.Indexer) ResourceQuotaLister {
 
 // List lists all ResourceQuotas in the indexer.
 func (s *resourceQuotaLister) List(selector labels.Selector) (ret []*v1.ResourceQuota, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all ResourceQuotas in the indexer.
-func (s *resourceQuotaLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.ResourceQuota, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.ResourceQuota))
 	})
@@ -90,11 +80,6 @@ type resourceQuotaNamespaceLister struct {
 
 // List lists all ResourceQuotas in the indexer for a given namespace.
 func (s resourceQuotaNamespaceLister) List(selector labels.Selector) (ret []*v1.ResourceQuota, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all ResourceQuotas in the indexer for a given namespace.
-func (s resourceQuotaNamespaceLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.ResourceQuota, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.ResourceQuota))
 	})
@@ -103,11 +88,6 @@ func (s resourceQuotaNamespaceLister) ListWithContext(ctx context.Context, selec
 
 // Get retrieves the ResourceQuota from the indexer for a given namespace and name.
 func (s resourceQuotaNamespaceLister) Get(name string) (*v1.ResourceQuota, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the ResourceQuota from the indexer for a given namespace and name.
-func (s resourceQuotaNamespaceLister) GetWithContext(ctx context.Context, name string) (*v1.ResourceQuota, error) {
 	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/core/v1/secret.go
+++ b/staging/src/k8s.io/client-go/listers/core/v1/secret.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1
 
 import (
-	"context"
-
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,9 +31,6 @@ type SecretLister interface {
 	// List lists all Secrets in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1.Secret, err error)
-	// ListWithContext lists all Secrets in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.Secret, err error)
 	// Secrets returns an object that can list and get Secrets.
 	Secrets(namespace string) SecretNamespaceLister
 	SecretListerExpansion
@@ -53,11 +48,6 @@ func NewSecretLister(indexer cache.Indexer) SecretLister {
 
 // List lists all Secrets in the indexer.
 func (s *secretLister) List(selector labels.Selector) (ret []*v1.Secret, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all Secrets in the indexer.
-func (s *secretLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.Secret, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.Secret))
 	})
@@ -90,11 +80,6 @@ type secretNamespaceLister struct {
 
 // List lists all Secrets in the indexer for a given namespace.
 func (s secretNamespaceLister) List(selector labels.Selector) (ret []*v1.Secret, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all Secrets in the indexer for a given namespace.
-func (s secretNamespaceLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.Secret, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.Secret))
 	})
@@ -103,11 +88,6 @@ func (s secretNamespaceLister) ListWithContext(ctx context.Context, selector lab
 
 // Get retrieves the Secret from the indexer for a given namespace and name.
 func (s secretNamespaceLister) Get(name string) (*v1.Secret, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the Secret from the indexer for a given namespace and name.
-func (s secretNamespaceLister) GetWithContext(ctx context.Context, name string) (*v1.Secret, error) {
 	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/core/v1/service.go
+++ b/staging/src/k8s.io/client-go/listers/core/v1/service.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1
 
 import (
-	"context"
-
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,9 +31,6 @@ type ServiceLister interface {
 	// List lists all Services in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1.Service, err error)
-	// ListWithContext lists all Services in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.Service, err error)
 	// Services returns an object that can list and get Services.
 	Services(namespace string) ServiceNamespaceLister
 	ServiceListerExpansion
@@ -53,11 +48,6 @@ func NewServiceLister(indexer cache.Indexer) ServiceLister {
 
 // List lists all Services in the indexer.
 func (s *serviceLister) List(selector labels.Selector) (ret []*v1.Service, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all Services in the indexer.
-func (s *serviceLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.Service, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.Service))
 	})
@@ -90,11 +80,6 @@ type serviceNamespaceLister struct {
 
 // List lists all Services in the indexer for a given namespace.
 func (s serviceNamespaceLister) List(selector labels.Selector) (ret []*v1.Service, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all Services in the indexer for a given namespace.
-func (s serviceNamespaceLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.Service, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.Service))
 	})
@@ -103,11 +88,6 @@ func (s serviceNamespaceLister) ListWithContext(ctx context.Context, selector la
 
 // Get retrieves the Service from the indexer for a given namespace and name.
 func (s serviceNamespaceLister) Get(name string) (*v1.Service, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the Service from the indexer for a given namespace and name.
-func (s serviceNamespaceLister) GetWithContext(ctx context.Context, name string) (*v1.Service, error) {
 	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/core/v1/serviceaccount.go
+++ b/staging/src/k8s.io/client-go/listers/core/v1/serviceaccount.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1
 
 import (
-	"context"
-
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,9 +31,6 @@ type ServiceAccountLister interface {
 	// List lists all ServiceAccounts in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1.ServiceAccount, err error)
-	// ListWithContext lists all ServiceAccounts in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.ServiceAccount, err error)
 	// ServiceAccounts returns an object that can list and get ServiceAccounts.
 	ServiceAccounts(namespace string) ServiceAccountNamespaceLister
 	ServiceAccountListerExpansion
@@ -53,11 +48,6 @@ func NewServiceAccountLister(indexer cache.Indexer) ServiceAccountLister {
 
 // List lists all ServiceAccounts in the indexer.
 func (s *serviceAccountLister) List(selector labels.Selector) (ret []*v1.ServiceAccount, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all ServiceAccounts in the indexer.
-func (s *serviceAccountLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.ServiceAccount, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.ServiceAccount))
 	})
@@ -90,11 +80,6 @@ type serviceAccountNamespaceLister struct {
 
 // List lists all ServiceAccounts in the indexer for a given namespace.
 func (s serviceAccountNamespaceLister) List(selector labels.Selector) (ret []*v1.ServiceAccount, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all ServiceAccounts in the indexer for a given namespace.
-func (s serviceAccountNamespaceLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.ServiceAccount, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.ServiceAccount))
 	})
@@ -103,11 +88,6 @@ func (s serviceAccountNamespaceLister) ListWithContext(ctx context.Context, sele
 
 // Get retrieves the ServiceAccount from the indexer for a given namespace and name.
 func (s serviceAccountNamespaceLister) Get(name string) (*v1.ServiceAccount, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the ServiceAccount from the indexer for a given namespace and name.
-func (s serviceAccountNamespaceLister) GetWithContext(ctx context.Context, name string) (*v1.ServiceAccount, error) {
 	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/discovery/v1/endpointslice.go
+++ b/staging/src/k8s.io/client-go/listers/discovery/v1/endpointslice.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1
 
 import (
-	"context"
-
 	v1 "k8s.io/api/discovery/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,9 +31,6 @@ type EndpointSliceLister interface {
 	// List lists all EndpointSlices in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1.EndpointSlice, err error)
-	// ListWithContext lists all EndpointSlices in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.EndpointSlice, err error)
 	// EndpointSlices returns an object that can list and get EndpointSlices.
 	EndpointSlices(namespace string) EndpointSliceNamespaceLister
 	EndpointSliceListerExpansion
@@ -53,11 +48,6 @@ func NewEndpointSliceLister(indexer cache.Indexer) EndpointSliceLister {
 
 // List lists all EndpointSlices in the indexer.
 func (s *endpointSliceLister) List(selector labels.Selector) (ret []*v1.EndpointSlice, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all EndpointSlices in the indexer.
-func (s *endpointSliceLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.EndpointSlice, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.EndpointSlice))
 	})
@@ -90,11 +80,6 @@ type endpointSliceNamespaceLister struct {
 
 // List lists all EndpointSlices in the indexer for a given namespace.
 func (s endpointSliceNamespaceLister) List(selector labels.Selector) (ret []*v1.EndpointSlice, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all EndpointSlices in the indexer for a given namespace.
-func (s endpointSliceNamespaceLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.EndpointSlice, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.EndpointSlice))
 	})
@@ -103,11 +88,6 @@ func (s endpointSliceNamespaceLister) ListWithContext(ctx context.Context, selec
 
 // Get retrieves the EndpointSlice from the indexer for a given namespace and name.
 func (s endpointSliceNamespaceLister) Get(name string) (*v1.EndpointSlice, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the EndpointSlice from the indexer for a given namespace and name.
-func (s endpointSliceNamespaceLister) GetWithContext(ctx context.Context, name string) (*v1.EndpointSlice, error) {
 	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/discovery/v1beta1/endpointslice.go
+++ b/staging/src/k8s.io/client-go/listers/discovery/v1beta1/endpointslice.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1beta1
 
 import (
-	"context"
-
 	v1beta1 "k8s.io/api/discovery/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,9 +31,6 @@ type EndpointSliceLister interface {
 	// List lists all EndpointSlices in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1beta1.EndpointSlice, err error)
-	// ListWithContext lists all EndpointSlices in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.EndpointSlice, err error)
 	// EndpointSlices returns an object that can list and get EndpointSlices.
 	EndpointSlices(namespace string) EndpointSliceNamespaceLister
 	EndpointSliceListerExpansion
@@ -53,11 +48,6 @@ func NewEndpointSliceLister(indexer cache.Indexer) EndpointSliceLister {
 
 // List lists all EndpointSlices in the indexer.
 func (s *endpointSliceLister) List(selector labels.Selector) (ret []*v1beta1.EndpointSlice, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all EndpointSlices in the indexer.
-func (s *endpointSliceLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.EndpointSlice, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1beta1.EndpointSlice))
 	})
@@ -90,11 +80,6 @@ type endpointSliceNamespaceLister struct {
 
 // List lists all EndpointSlices in the indexer for a given namespace.
 func (s endpointSliceNamespaceLister) List(selector labels.Selector) (ret []*v1beta1.EndpointSlice, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all EndpointSlices in the indexer for a given namespace.
-func (s endpointSliceNamespaceLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.EndpointSlice, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1beta1.EndpointSlice))
 	})
@@ -103,11 +88,6 @@ func (s endpointSliceNamespaceLister) ListWithContext(ctx context.Context, selec
 
 // Get retrieves the EndpointSlice from the indexer for a given namespace and name.
 func (s endpointSliceNamespaceLister) Get(name string) (*v1beta1.EndpointSlice, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the EndpointSlice from the indexer for a given namespace and name.
-func (s endpointSliceNamespaceLister) GetWithContext(ctx context.Context, name string) (*v1beta1.EndpointSlice, error) {
 	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/events/v1/event.go
+++ b/staging/src/k8s.io/client-go/listers/events/v1/event.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1
 
 import (
-	"context"
-
 	v1 "k8s.io/api/events/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,9 +31,6 @@ type EventLister interface {
 	// List lists all Events in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1.Event, err error)
-	// ListWithContext lists all Events in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.Event, err error)
 	// Events returns an object that can list and get Events.
 	Events(namespace string) EventNamespaceLister
 	EventListerExpansion
@@ -53,11 +48,6 @@ func NewEventLister(indexer cache.Indexer) EventLister {
 
 // List lists all Events in the indexer.
 func (s *eventLister) List(selector labels.Selector) (ret []*v1.Event, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all Events in the indexer.
-func (s *eventLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.Event, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.Event))
 	})
@@ -90,11 +80,6 @@ type eventNamespaceLister struct {
 
 // List lists all Events in the indexer for a given namespace.
 func (s eventNamespaceLister) List(selector labels.Selector) (ret []*v1.Event, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all Events in the indexer for a given namespace.
-func (s eventNamespaceLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.Event, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.Event))
 	})
@@ -103,11 +88,6 @@ func (s eventNamespaceLister) ListWithContext(ctx context.Context, selector labe
 
 // Get retrieves the Event from the indexer for a given namespace and name.
 func (s eventNamespaceLister) Get(name string) (*v1.Event, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the Event from the indexer for a given namespace and name.
-func (s eventNamespaceLister) GetWithContext(ctx context.Context, name string) (*v1.Event, error) {
 	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/events/v1beta1/event.go
+++ b/staging/src/k8s.io/client-go/listers/events/v1beta1/event.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1beta1
 
 import (
-	"context"
-
 	v1beta1 "k8s.io/api/events/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,9 +31,6 @@ type EventLister interface {
 	// List lists all Events in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1beta1.Event, err error)
-	// ListWithContext lists all Events in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.Event, err error)
 	// Events returns an object that can list and get Events.
 	Events(namespace string) EventNamespaceLister
 	EventListerExpansion
@@ -53,11 +48,6 @@ func NewEventLister(indexer cache.Indexer) EventLister {
 
 // List lists all Events in the indexer.
 func (s *eventLister) List(selector labels.Selector) (ret []*v1beta1.Event, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all Events in the indexer.
-func (s *eventLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.Event, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1beta1.Event))
 	})
@@ -90,11 +80,6 @@ type eventNamespaceLister struct {
 
 // List lists all Events in the indexer for a given namespace.
 func (s eventNamespaceLister) List(selector labels.Selector) (ret []*v1beta1.Event, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all Events in the indexer for a given namespace.
-func (s eventNamespaceLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.Event, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1beta1.Event))
 	})
@@ -103,11 +88,6 @@ func (s eventNamespaceLister) ListWithContext(ctx context.Context, selector labe
 
 // Get retrieves the Event from the indexer for a given namespace and name.
 func (s eventNamespaceLister) Get(name string) (*v1beta1.Event, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the Event from the indexer for a given namespace and name.
-func (s eventNamespaceLister) GetWithContext(ctx context.Context, name string) (*v1beta1.Event, error) {
 	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/extensions/v1beta1/daemonset.go
+++ b/staging/src/k8s.io/client-go/listers/extensions/v1beta1/daemonset.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1beta1
 
 import (
-	"context"
-
 	v1beta1 "k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,9 +31,6 @@ type DaemonSetLister interface {
 	// List lists all DaemonSets in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1beta1.DaemonSet, err error)
-	// ListWithContext lists all DaemonSets in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.DaemonSet, err error)
 	// DaemonSets returns an object that can list and get DaemonSets.
 	DaemonSets(namespace string) DaemonSetNamespaceLister
 	DaemonSetListerExpansion
@@ -53,11 +48,6 @@ func NewDaemonSetLister(indexer cache.Indexer) DaemonSetLister {
 
 // List lists all DaemonSets in the indexer.
 func (s *daemonSetLister) List(selector labels.Selector) (ret []*v1beta1.DaemonSet, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all DaemonSets in the indexer.
-func (s *daemonSetLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.DaemonSet, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1beta1.DaemonSet))
 	})
@@ -90,11 +80,6 @@ type daemonSetNamespaceLister struct {
 
 // List lists all DaemonSets in the indexer for a given namespace.
 func (s daemonSetNamespaceLister) List(selector labels.Selector) (ret []*v1beta1.DaemonSet, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all DaemonSets in the indexer for a given namespace.
-func (s daemonSetNamespaceLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.DaemonSet, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1beta1.DaemonSet))
 	})
@@ -103,11 +88,6 @@ func (s daemonSetNamespaceLister) ListWithContext(ctx context.Context, selector 
 
 // Get retrieves the DaemonSet from the indexer for a given namespace and name.
 func (s daemonSetNamespaceLister) Get(name string) (*v1beta1.DaemonSet, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the DaemonSet from the indexer for a given namespace and name.
-func (s daemonSetNamespaceLister) GetWithContext(ctx context.Context, name string) (*v1beta1.DaemonSet, error) {
 	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/extensions/v1beta1/deployment.go
+++ b/staging/src/k8s.io/client-go/listers/extensions/v1beta1/deployment.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1beta1
 
 import (
-	"context"
-
 	v1beta1 "k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,9 +31,6 @@ type DeploymentLister interface {
 	// List lists all Deployments in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1beta1.Deployment, err error)
-	// ListWithContext lists all Deployments in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.Deployment, err error)
 	// Deployments returns an object that can list and get Deployments.
 	Deployments(namespace string) DeploymentNamespaceLister
 	DeploymentListerExpansion
@@ -53,11 +48,6 @@ func NewDeploymentLister(indexer cache.Indexer) DeploymentLister {
 
 // List lists all Deployments in the indexer.
 func (s *deploymentLister) List(selector labels.Selector) (ret []*v1beta1.Deployment, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all Deployments in the indexer.
-func (s *deploymentLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.Deployment, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1beta1.Deployment))
 	})
@@ -90,11 +80,6 @@ type deploymentNamespaceLister struct {
 
 // List lists all Deployments in the indexer for a given namespace.
 func (s deploymentNamespaceLister) List(selector labels.Selector) (ret []*v1beta1.Deployment, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all Deployments in the indexer for a given namespace.
-func (s deploymentNamespaceLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.Deployment, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1beta1.Deployment))
 	})
@@ -103,11 +88,6 @@ func (s deploymentNamespaceLister) ListWithContext(ctx context.Context, selector
 
 // Get retrieves the Deployment from the indexer for a given namespace and name.
 func (s deploymentNamespaceLister) Get(name string) (*v1beta1.Deployment, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the Deployment from the indexer for a given namespace and name.
-func (s deploymentNamespaceLister) GetWithContext(ctx context.Context, name string) (*v1beta1.Deployment, error) {
 	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/extensions/v1beta1/ingress.go
+++ b/staging/src/k8s.io/client-go/listers/extensions/v1beta1/ingress.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1beta1
 
 import (
-	"context"
-
 	v1beta1 "k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,9 +31,6 @@ type IngressLister interface {
 	// List lists all Ingresses in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1beta1.Ingress, err error)
-	// ListWithContext lists all Ingresses in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.Ingress, err error)
 	// Ingresses returns an object that can list and get Ingresses.
 	Ingresses(namespace string) IngressNamespaceLister
 	IngressListerExpansion
@@ -53,11 +48,6 @@ func NewIngressLister(indexer cache.Indexer) IngressLister {
 
 // List lists all Ingresses in the indexer.
 func (s *ingressLister) List(selector labels.Selector) (ret []*v1beta1.Ingress, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all Ingresses in the indexer.
-func (s *ingressLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.Ingress, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1beta1.Ingress))
 	})
@@ -90,11 +80,6 @@ type ingressNamespaceLister struct {
 
 // List lists all Ingresses in the indexer for a given namespace.
 func (s ingressNamespaceLister) List(selector labels.Selector) (ret []*v1beta1.Ingress, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all Ingresses in the indexer for a given namespace.
-func (s ingressNamespaceLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.Ingress, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1beta1.Ingress))
 	})
@@ -103,11 +88,6 @@ func (s ingressNamespaceLister) ListWithContext(ctx context.Context, selector la
 
 // Get retrieves the Ingress from the indexer for a given namespace and name.
 func (s ingressNamespaceLister) Get(name string) (*v1beta1.Ingress, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the Ingress from the indexer for a given namespace and name.
-func (s ingressNamespaceLister) GetWithContext(ctx context.Context, name string) (*v1beta1.Ingress, error) {
 	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/extensions/v1beta1/networkpolicy.go
+++ b/staging/src/k8s.io/client-go/listers/extensions/v1beta1/networkpolicy.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1beta1
 
 import (
-	"context"
-
 	v1beta1 "k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,9 +31,6 @@ type NetworkPolicyLister interface {
 	// List lists all NetworkPolicies in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1beta1.NetworkPolicy, err error)
-	// ListWithContext lists all NetworkPolicies in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.NetworkPolicy, err error)
 	// NetworkPolicies returns an object that can list and get NetworkPolicies.
 	NetworkPolicies(namespace string) NetworkPolicyNamespaceLister
 	NetworkPolicyListerExpansion
@@ -53,11 +48,6 @@ func NewNetworkPolicyLister(indexer cache.Indexer) NetworkPolicyLister {
 
 // List lists all NetworkPolicies in the indexer.
 func (s *networkPolicyLister) List(selector labels.Selector) (ret []*v1beta1.NetworkPolicy, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all NetworkPolicies in the indexer.
-func (s *networkPolicyLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.NetworkPolicy, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1beta1.NetworkPolicy))
 	})
@@ -90,11 +80,6 @@ type networkPolicyNamespaceLister struct {
 
 // List lists all NetworkPolicies in the indexer for a given namespace.
 func (s networkPolicyNamespaceLister) List(selector labels.Selector) (ret []*v1beta1.NetworkPolicy, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all NetworkPolicies in the indexer for a given namespace.
-func (s networkPolicyNamespaceLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.NetworkPolicy, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1beta1.NetworkPolicy))
 	})
@@ -103,11 +88,6 @@ func (s networkPolicyNamespaceLister) ListWithContext(ctx context.Context, selec
 
 // Get retrieves the NetworkPolicy from the indexer for a given namespace and name.
 func (s networkPolicyNamespaceLister) Get(name string) (*v1beta1.NetworkPolicy, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the NetworkPolicy from the indexer for a given namespace and name.
-func (s networkPolicyNamespaceLister) GetWithContext(ctx context.Context, name string) (*v1beta1.NetworkPolicy, error) {
 	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/extensions/v1beta1/podsecuritypolicy.go
+++ b/staging/src/k8s.io/client-go/listers/extensions/v1beta1/podsecuritypolicy.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1beta1
 
 import (
-	"context"
-
 	v1beta1 "k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,15 +31,9 @@ type PodSecurityPolicyLister interface {
 	// List lists all PodSecurityPolicies in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1beta1.PodSecurityPolicy, err error)
-	// ListWithContext lists all PodSecurityPolicies in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.PodSecurityPolicy, err error)
 	// Get retrieves the PodSecurityPolicy from the index for a given name.
 	// Objects returned here must be treated as read-only.
 	Get(name string) (*v1beta1.PodSecurityPolicy, error)
-	// GetWithContext retrieves the PodSecurityPolicy from the index for a given name.
-	// Objects returned here must be treated as read-only.
-	GetWithContext(ctx context.Context, name string) (*v1beta1.PodSecurityPolicy, error)
 	PodSecurityPolicyListerExpansion
 }
 
@@ -57,11 +49,6 @@ func NewPodSecurityPolicyLister(indexer cache.Indexer) PodSecurityPolicyLister {
 
 // List lists all PodSecurityPolicies in the indexer.
 func (s *podSecurityPolicyLister) List(selector labels.Selector) (ret []*v1beta1.PodSecurityPolicy, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all PodSecurityPolicies in the indexer.
-func (s *podSecurityPolicyLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.PodSecurityPolicy, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1beta1.PodSecurityPolicy))
 	})
@@ -70,11 +57,6 @@ func (s *podSecurityPolicyLister) ListWithContext(ctx context.Context, selector 
 
 // Get retrieves the PodSecurityPolicy from the index for a given name.
 func (s *podSecurityPolicyLister) Get(name string) (*v1beta1.PodSecurityPolicy, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the PodSecurityPolicy from the index for a given name.
-func (s *podSecurityPolicyLister) GetWithContext(ctx context.Context, name string) (*v1beta1.PodSecurityPolicy, error) {
 	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/extensions/v1beta1/replicaset.go
+++ b/staging/src/k8s.io/client-go/listers/extensions/v1beta1/replicaset.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1beta1
 
 import (
-	"context"
-
 	v1beta1 "k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,9 +31,6 @@ type ReplicaSetLister interface {
 	// List lists all ReplicaSets in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1beta1.ReplicaSet, err error)
-	// ListWithContext lists all ReplicaSets in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.ReplicaSet, err error)
 	// ReplicaSets returns an object that can list and get ReplicaSets.
 	ReplicaSets(namespace string) ReplicaSetNamespaceLister
 	ReplicaSetListerExpansion
@@ -53,11 +48,6 @@ func NewReplicaSetLister(indexer cache.Indexer) ReplicaSetLister {
 
 // List lists all ReplicaSets in the indexer.
 func (s *replicaSetLister) List(selector labels.Selector) (ret []*v1beta1.ReplicaSet, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all ReplicaSets in the indexer.
-func (s *replicaSetLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.ReplicaSet, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1beta1.ReplicaSet))
 	})
@@ -90,11 +80,6 @@ type replicaSetNamespaceLister struct {
 
 // List lists all ReplicaSets in the indexer for a given namespace.
 func (s replicaSetNamespaceLister) List(selector labels.Selector) (ret []*v1beta1.ReplicaSet, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all ReplicaSets in the indexer for a given namespace.
-func (s replicaSetNamespaceLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.ReplicaSet, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1beta1.ReplicaSet))
 	})
@@ -103,11 +88,6 @@ func (s replicaSetNamespaceLister) ListWithContext(ctx context.Context, selector
 
 // Get retrieves the ReplicaSet from the indexer for a given namespace and name.
 func (s replicaSetNamespaceLister) Get(name string) (*v1beta1.ReplicaSet, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the ReplicaSet from the indexer for a given namespace and name.
-func (s replicaSetNamespaceLister) GetWithContext(ctx context.Context, name string) (*v1beta1.ReplicaSet, error) {
 	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/flowcontrol/v1alpha1/flowschema.go
+++ b/staging/src/k8s.io/client-go/listers/flowcontrol/v1alpha1/flowschema.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"context"
-
 	v1alpha1 "k8s.io/api/flowcontrol/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,15 +31,9 @@ type FlowSchemaLister interface {
 	// List lists all FlowSchemas in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1alpha1.FlowSchema, err error)
-	// ListWithContext lists all FlowSchemas in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1alpha1.FlowSchema, err error)
 	// Get retrieves the FlowSchema from the index for a given name.
 	// Objects returned here must be treated as read-only.
 	Get(name string) (*v1alpha1.FlowSchema, error)
-	// GetWithContext retrieves the FlowSchema from the index for a given name.
-	// Objects returned here must be treated as read-only.
-	GetWithContext(ctx context.Context, name string) (*v1alpha1.FlowSchema, error)
 	FlowSchemaListerExpansion
 }
 
@@ -57,11 +49,6 @@ func NewFlowSchemaLister(indexer cache.Indexer) FlowSchemaLister {
 
 // List lists all FlowSchemas in the indexer.
 func (s *flowSchemaLister) List(selector labels.Selector) (ret []*v1alpha1.FlowSchema, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all FlowSchemas in the indexer.
-func (s *flowSchemaLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1alpha1.FlowSchema, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1alpha1.FlowSchema))
 	})
@@ -70,11 +57,6 @@ func (s *flowSchemaLister) ListWithContext(ctx context.Context, selector labels.
 
 // Get retrieves the FlowSchema from the index for a given name.
 func (s *flowSchemaLister) Get(name string) (*v1alpha1.FlowSchema, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the FlowSchema from the index for a given name.
-func (s *flowSchemaLister) GetWithContext(ctx context.Context, name string) (*v1alpha1.FlowSchema, error) {
 	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/flowcontrol/v1alpha1/prioritylevelconfiguration.go
+++ b/staging/src/k8s.io/client-go/listers/flowcontrol/v1alpha1/prioritylevelconfiguration.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"context"
-
 	v1alpha1 "k8s.io/api/flowcontrol/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,15 +31,9 @@ type PriorityLevelConfigurationLister interface {
 	// List lists all PriorityLevelConfigurations in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1alpha1.PriorityLevelConfiguration, err error)
-	// ListWithContext lists all PriorityLevelConfigurations in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1alpha1.PriorityLevelConfiguration, err error)
 	// Get retrieves the PriorityLevelConfiguration from the index for a given name.
 	// Objects returned here must be treated as read-only.
 	Get(name string) (*v1alpha1.PriorityLevelConfiguration, error)
-	// GetWithContext retrieves the PriorityLevelConfiguration from the index for a given name.
-	// Objects returned here must be treated as read-only.
-	GetWithContext(ctx context.Context, name string) (*v1alpha1.PriorityLevelConfiguration, error)
 	PriorityLevelConfigurationListerExpansion
 }
 
@@ -57,11 +49,6 @@ func NewPriorityLevelConfigurationLister(indexer cache.Indexer) PriorityLevelCon
 
 // List lists all PriorityLevelConfigurations in the indexer.
 func (s *priorityLevelConfigurationLister) List(selector labels.Selector) (ret []*v1alpha1.PriorityLevelConfiguration, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all PriorityLevelConfigurations in the indexer.
-func (s *priorityLevelConfigurationLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1alpha1.PriorityLevelConfiguration, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1alpha1.PriorityLevelConfiguration))
 	})
@@ -70,11 +57,6 @@ func (s *priorityLevelConfigurationLister) ListWithContext(ctx context.Context, 
 
 // Get retrieves the PriorityLevelConfiguration from the index for a given name.
 func (s *priorityLevelConfigurationLister) Get(name string) (*v1alpha1.PriorityLevelConfiguration, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the PriorityLevelConfiguration from the index for a given name.
-func (s *priorityLevelConfigurationLister) GetWithContext(ctx context.Context, name string) (*v1alpha1.PriorityLevelConfiguration, error) {
 	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/flowcontrol/v1beta1/flowschema.go
+++ b/staging/src/k8s.io/client-go/listers/flowcontrol/v1beta1/flowschema.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1beta1
 
 import (
-	"context"
-
 	v1beta1 "k8s.io/api/flowcontrol/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,15 +31,9 @@ type FlowSchemaLister interface {
 	// List lists all FlowSchemas in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1beta1.FlowSchema, err error)
-	// ListWithContext lists all FlowSchemas in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.FlowSchema, err error)
 	// Get retrieves the FlowSchema from the index for a given name.
 	// Objects returned here must be treated as read-only.
 	Get(name string) (*v1beta1.FlowSchema, error)
-	// GetWithContext retrieves the FlowSchema from the index for a given name.
-	// Objects returned here must be treated as read-only.
-	GetWithContext(ctx context.Context, name string) (*v1beta1.FlowSchema, error)
 	FlowSchemaListerExpansion
 }
 
@@ -57,11 +49,6 @@ func NewFlowSchemaLister(indexer cache.Indexer) FlowSchemaLister {
 
 // List lists all FlowSchemas in the indexer.
 func (s *flowSchemaLister) List(selector labels.Selector) (ret []*v1beta1.FlowSchema, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all FlowSchemas in the indexer.
-func (s *flowSchemaLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.FlowSchema, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1beta1.FlowSchema))
 	})
@@ -70,11 +57,6 @@ func (s *flowSchemaLister) ListWithContext(ctx context.Context, selector labels.
 
 // Get retrieves the FlowSchema from the index for a given name.
 func (s *flowSchemaLister) Get(name string) (*v1beta1.FlowSchema, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the FlowSchema from the index for a given name.
-func (s *flowSchemaLister) GetWithContext(ctx context.Context, name string) (*v1beta1.FlowSchema, error) {
 	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/flowcontrol/v1beta1/prioritylevelconfiguration.go
+++ b/staging/src/k8s.io/client-go/listers/flowcontrol/v1beta1/prioritylevelconfiguration.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1beta1
 
 import (
-	"context"
-
 	v1beta1 "k8s.io/api/flowcontrol/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,15 +31,9 @@ type PriorityLevelConfigurationLister interface {
 	// List lists all PriorityLevelConfigurations in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1beta1.PriorityLevelConfiguration, err error)
-	// ListWithContext lists all PriorityLevelConfigurations in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.PriorityLevelConfiguration, err error)
 	// Get retrieves the PriorityLevelConfiguration from the index for a given name.
 	// Objects returned here must be treated as read-only.
 	Get(name string) (*v1beta1.PriorityLevelConfiguration, error)
-	// GetWithContext retrieves the PriorityLevelConfiguration from the index for a given name.
-	// Objects returned here must be treated as read-only.
-	GetWithContext(ctx context.Context, name string) (*v1beta1.PriorityLevelConfiguration, error)
 	PriorityLevelConfigurationListerExpansion
 }
 
@@ -57,11 +49,6 @@ func NewPriorityLevelConfigurationLister(indexer cache.Indexer) PriorityLevelCon
 
 // List lists all PriorityLevelConfigurations in the indexer.
 func (s *priorityLevelConfigurationLister) List(selector labels.Selector) (ret []*v1beta1.PriorityLevelConfiguration, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all PriorityLevelConfigurations in the indexer.
-func (s *priorityLevelConfigurationLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.PriorityLevelConfiguration, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1beta1.PriorityLevelConfiguration))
 	})
@@ -70,11 +57,6 @@ func (s *priorityLevelConfigurationLister) ListWithContext(ctx context.Context, 
 
 // Get retrieves the PriorityLevelConfiguration from the index for a given name.
 func (s *priorityLevelConfigurationLister) Get(name string) (*v1beta1.PriorityLevelConfiguration, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the PriorityLevelConfiguration from the index for a given name.
-func (s *priorityLevelConfigurationLister) GetWithContext(ctx context.Context, name string) (*v1beta1.PriorityLevelConfiguration, error) {
 	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/flowcontrol/v1beta2/flowschema.go
+++ b/staging/src/k8s.io/client-go/listers/flowcontrol/v1beta2/flowschema.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1beta2
 
 import (
-	"context"
-
 	v1beta2 "k8s.io/api/flowcontrol/v1beta2"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,15 +31,9 @@ type FlowSchemaLister interface {
 	// List lists all FlowSchemas in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1beta2.FlowSchema, err error)
-	// ListWithContext lists all FlowSchemas in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta2.FlowSchema, err error)
 	// Get retrieves the FlowSchema from the index for a given name.
 	// Objects returned here must be treated as read-only.
 	Get(name string) (*v1beta2.FlowSchema, error)
-	// GetWithContext retrieves the FlowSchema from the index for a given name.
-	// Objects returned here must be treated as read-only.
-	GetWithContext(ctx context.Context, name string) (*v1beta2.FlowSchema, error)
 	FlowSchemaListerExpansion
 }
 
@@ -57,11 +49,6 @@ func NewFlowSchemaLister(indexer cache.Indexer) FlowSchemaLister {
 
 // List lists all FlowSchemas in the indexer.
 func (s *flowSchemaLister) List(selector labels.Selector) (ret []*v1beta2.FlowSchema, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all FlowSchemas in the indexer.
-func (s *flowSchemaLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta2.FlowSchema, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1beta2.FlowSchema))
 	})
@@ -70,11 +57,6 @@ func (s *flowSchemaLister) ListWithContext(ctx context.Context, selector labels.
 
 // Get retrieves the FlowSchema from the index for a given name.
 func (s *flowSchemaLister) Get(name string) (*v1beta2.FlowSchema, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the FlowSchema from the index for a given name.
-func (s *flowSchemaLister) GetWithContext(ctx context.Context, name string) (*v1beta2.FlowSchema, error) {
 	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/flowcontrol/v1beta2/prioritylevelconfiguration.go
+++ b/staging/src/k8s.io/client-go/listers/flowcontrol/v1beta2/prioritylevelconfiguration.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1beta2
 
 import (
-	"context"
-
 	v1beta2 "k8s.io/api/flowcontrol/v1beta2"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,15 +31,9 @@ type PriorityLevelConfigurationLister interface {
 	// List lists all PriorityLevelConfigurations in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1beta2.PriorityLevelConfiguration, err error)
-	// ListWithContext lists all PriorityLevelConfigurations in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta2.PriorityLevelConfiguration, err error)
 	// Get retrieves the PriorityLevelConfiguration from the index for a given name.
 	// Objects returned here must be treated as read-only.
 	Get(name string) (*v1beta2.PriorityLevelConfiguration, error)
-	// GetWithContext retrieves the PriorityLevelConfiguration from the index for a given name.
-	// Objects returned here must be treated as read-only.
-	GetWithContext(ctx context.Context, name string) (*v1beta2.PriorityLevelConfiguration, error)
 	PriorityLevelConfigurationListerExpansion
 }
 
@@ -57,11 +49,6 @@ func NewPriorityLevelConfigurationLister(indexer cache.Indexer) PriorityLevelCon
 
 // List lists all PriorityLevelConfigurations in the indexer.
 func (s *priorityLevelConfigurationLister) List(selector labels.Selector) (ret []*v1beta2.PriorityLevelConfiguration, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all PriorityLevelConfigurations in the indexer.
-func (s *priorityLevelConfigurationLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta2.PriorityLevelConfiguration, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1beta2.PriorityLevelConfiguration))
 	})
@@ -70,11 +57,6 @@ func (s *priorityLevelConfigurationLister) ListWithContext(ctx context.Context, 
 
 // Get retrieves the PriorityLevelConfiguration from the index for a given name.
 func (s *priorityLevelConfigurationLister) Get(name string) (*v1beta2.PriorityLevelConfiguration, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the PriorityLevelConfiguration from the index for a given name.
-func (s *priorityLevelConfigurationLister) GetWithContext(ctx context.Context, name string) (*v1beta2.PriorityLevelConfiguration, error) {
 	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/imagepolicy/v1alpha1/imagereview.go
+++ b/staging/src/k8s.io/client-go/listers/imagepolicy/v1alpha1/imagereview.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"context"
-
 	v1alpha1 "k8s.io/api/imagepolicy/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,15 +31,9 @@ type ImageReviewLister interface {
 	// List lists all ImageReviews in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1alpha1.ImageReview, err error)
-	// ListWithContext lists all ImageReviews in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1alpha1.ImageReview, err error)
 	// Get retrieves the ImageReview from the index for a given name.
 	// Objects returned here must be treated as read-only.
 	Get(name string) (*v1alpha1.ImageReview, error)
-	// GetWithContext retrieves the ImageReview from the index for a given name.
-	// Objects returned here must be treated as read-only.
-	GetWithContext(ctx context.Context, name string) (*v1alpha1.ImageReview, error)
 	ImageReviewListerExpansion
 }
 
@@ -57,11 +49,6 @@ func NewImageReviewLister(indexer cache.Indexer) ImageReviewLister {
 
 // List lists all ImageReviews in the indexer.
 func (s *imageReviewLister) List(selector labels.Selector) (ret []*v1alpha1.ImageReview, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all ImageReviews in the indexer.
-func (s *imageReviewLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1alpha1.ImageReview, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1alpha1.ImageReview))
 	})
@@ -70,11 +57,6 @@ func (s *imageReviewLister) ListWithContext(ctx context.Context, selector labels
 
 // Get retrieves the ImageReview from the index for a given name.
 func (s *imageReviewLister) Get(name string) (*v1alpha1.ImageReview, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the ImageReview from the index for a given name.
-func (s *imageReviewLister) GetWithContext(ctx context.Context, name string) (*v1alpha1.ImageReview, error) {
 	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/networking/v1/ingress.go
+++ b/staging/src/k8s.io/client-go/listers/networking/v1/ingress.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1
 
 import (
-	"context"
-
 	v1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,9 +31,6 @@ type IngressLister interface {
 	// List lists all Ingresses in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1.Ingress, err error)
-	// ListWithContext lists all Ingresses in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.Ingress, err error)
 	// Ingresses returns an object that can list and get Ingresses.
 	Ingresses(namespace string) IngressNamespaceLister
 	IngressListerExpansion
@@ -53,11 +48,6 @@ func NewIngressLister(indexer cache.Indexer) IngressLister {
 
 // List lists all Ingresses in the indexer.
 func (s *ingressLister) List(selector labels.Selector) (ret []*v1.Ingress, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all Ingresses in the indexer.
-func (s *ingressLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.Ingress, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.Ingress))
 	})
@@ -90,11 +80,6 @@ type ingressNamespaceLister struct {
 
 // List lists all Ingresses in the indexer for a given namespace.
 func (s ingressNamespaceLister) List(selector labels.Selector) (ret []*v1.Ingress, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all Ingresses in the indexer for a given namespace.
-func (s ingressNamespaceLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.Ingress, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.Ingress))
 	})
@@ -103,11 +88,6 @@ func (s ingressNamespaceLister) ListWithContext(ctx context.Context, selector la
 
 // Get retrieves the Ingress from the indexer for a given namespace and name.
 func (s ingressNamespaceLister) Get(name string) (*v1.Ingress, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the Ingress from the indexer for a given namespace and name.
-func (s ingressNamespaceLister) GetWithContext(ctx context.Context, name string) (*v1.Ingress, error) {
 	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/networking/v1/ingressclass.go
+++ b/staging/src/k8s.io/client-go/listers/networking/v1/ingressclass.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1
 
 import (
-	"context"
-
 	v1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,15 +31,9 @@ type IngressClassLister interface {
 	// List lists all IngressClasses in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1.IngressClass, err error)
-	// ListWithContext lists all IngressClasses in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.IngressClass, err error)
 	// Get retrieves the IngressClass from the index for a given name.
 	// Objects returned here must be treated as read-only.
 	Get(name string) (*v1.IngressClass, error)
-	// GetWithContext retrieves the IngressClass from the index for a given name.
-	// Objects returned here must be treated as read-only.
-	GetWithContext(ctx context.Context, name string) (*v1.IngressClass, error)
 	IngressClassListerExpansion
 }
 
@@ -57,11 +49,6 @@ func NewIngressClassLister(indexer cache.Indexer) IngressClassLister {
 
 // List lists all IngressClasses in the indexer.
 func (s *ingressClassLister) List(selector labels.Selector) (ret []*v1.IngressClass, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all IngressClasses in the indexer.
-func (s *ingressClassLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.IngressClass, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.IngressClass))
 	})
@@ -70,11 +57,6 @@ func (s *ingressClassLister) ListWithContext(ctx context.Context, selector label
 
 // Get retrieves the IngressClass from the index for a given name.
 func (s *ingressClassLister) Get(name string) (*v1.IngressClass, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the IngressClass from the index for a given name.
-func (s *ingressClassLister) GetWithContext(ctx context.Context, name string) (*v1.IngressClass, error) {
 	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/networking/v1/networkpolicy.go
+++ b/staging/src/k8s.io/client-go/listers/networking/v1/networkpolicy.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1
 
 import (
-	"context"
-
 	v1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,9 +31,6 @@ type NetworkPolicyLister interface {
 	// List lists all NetworkPolicies in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1.NetworkPolicy, err error)
-	// ListWithContext lists all NetworkPolicies in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.NetworkPolicy, err error)
 	// NetworkPolicies returns an object that can list and get NetworkPolicies.
 	NetworkPolicies(namespace string) NetworkPolicyNamespaceLister
 	NetworkPolicyListerExpansion
@@ -53,11 +48,6 @@ func NewNetworkPolicyLister(indexer cache.Indexer) NetworkPolicyLister {
 
 // List lists all NetworkPolicies in the indexer.
 func (s *networkPolicyLister) List(selector labels.Selector) (ret []*v1.NetworkPolicy, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all NetworkPolicies in the indexer.
-func (s *networkPolicyLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.NetworkPolicy, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.NetworkPolicy))
 	})
@@ -90,11 +80,6 @@ type networkPolicyNamespaceLister struct {
 
 // List lists all NetworkPolicies in the indexer for a given namespace.
 func (s networkPolicyNamespaceLister) List(selector labels.Selector) (ret []*v1.NetworkPolicy, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all NetworkPolicies in the indexer for a given namespace.
-func (s networkPolicyNamespaceLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.NetworkPolicy, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.NetworkPolicy))
 	})
@@ -103,11 +88,6 @@ func (s networkPolicyNamespaceLister) ListWithContext(ctx context.Context, selec
 
 // Get retrieves the NetworkPolicy from the indexer for a given namespace and name.
 func (s networkPolicyNamespaceLister) Get(name string) (*v1.NetworkPolicy, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the NetworkPolicy from the indexer for a given namespace and name.
-func (s networkPolicyNamespaceLister) GetWithContext(ctx context.Context, name string) (*v1.NetworkPolicy, error) {
 	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/networking/v1beta1/ingress.go
+++ b/staging/src/k8s.io/client-go/listers/networking/v1beta1/ingress.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1beta1
 
 import (
-	"context"
-
 	v1beta1 "k8s.io/api/networking/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,9 +31,6 @@ type IngressLister interface {
 	// List lists all Ingresses in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1beta1.Ingress, err error)
-	// ListWithContext lists all Ingresses in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.Ingress, err error)
 	// Ingresses returns an object that can list and get Ingresses.
 	Ingresses(namespace string) IngressNamespaceLister
 	IngressListerExpansion
@@ -53,11 +48,6 @@ func NewIngressLister(indexer cache.Indexer) IngressLister {
 
 // List lists all Ingresses in the indexer.
 func (s *ingressLister) List(selector labels.Selector) (ret []*v1beta1.Ingress, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all Ingresses in the indexer.
-func (s *ingressLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.Ingress, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1beta1.Ingress))
 	})
@@ -90,11 +80,6 @@ type ingressNamespaceLister struct {
 
 // List lists all Ingresses in the indexer for a given namespace.
 func (s ingressNamespaceLister) List(selector labels.Selector) (ret []*v1beta1.Ingress, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all Ingresses in the indexer for a given namespace.
-func (s ingressNamespaceLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.Ingress, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1beta1.Ingress))
 	})
@@ -103,11 +88,6 @@ func (s ingressNamespaceLister) ListWithContext(ctx context.Context, selector la
 
 // Get retrieves the Ingress from the indexer for a given namespace and name.
 func (s ingressNamespaceLister) Get(name string) (*v1beta1.Ingress, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the Ingress from the indexer for a given namespace and name.
-func (s ingressNamespaceLister) GetWithContext(ctx context.Context, name string) (*v1beta1.Ingress, error) {
 	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/networking/v1beta1/ingressclass.go
+++ b/staging/src/k8s.io/client-go/listers/networking/v1beta1/ingressclass.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1beta1
 
 import (
-	"context"
-
 	v1beta1 "k8s.io/api/networking/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,15 +31,9 @@ type IngressClassLister interface {
 	// List lists all IngressClasses in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1beta1.IngressClass, err error)
-	// ListWithContext lists all IngressClasses in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.IngressClass, err error)
 	// Get retrieves the IngressClass from the index for a given name.
 	// Objects returned here must be treated as read-only.
 	Get(name string) (*v1beta1.IngressClass, error)
-	// GetWithContext retrieves the IngressClass from the index for a given name.
-	// Objects returned here must be treated as read-only.
-	GetWithContext(ctx context.Context, name string) (*v1beta1.IngressClass, error)
 	IngressClassListerExpansion
 }
 
@@ -57,11 +49,6 @@ func NewIngressClassLister(indexer cache.Indexer) IngressClassLister {
 
 // List lists all IngressClasses in the indexer.
 func (s *ingressClassLister) List(selector labels.Selector) (ret []*v1beta1.IngressClass, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all IngressClasses in the indexer.
-func (s *ingressClassLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.IngressClass, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1beta1.IngressClass))
 	})
@@ -70,11 +57,6 @@ func (s *ingressClassLister) ListWithContext(ctx context.Context, selector label
 
 // Get retrieves the IngressClass from the index for a given name.
 func (s *ingressClassLister) Get(name string) (*v1beta1.IngressClass, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the IngressClass from the index for a given name.
-func (s *ingressClassLister) GetWithContext(ctx context.Context, name string) (*v1beta1.IngressClass, error) {
 	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/node/v1/runtimeclass.go
+++ b/staging/src/k8s.io/client-go/listers/node/v1/runtimeclass.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1
 
 import (
-	"context"
-
 	v1 "k8s.io/api/node/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,15 +31,9 @@ type RuntimeClassLister interface {
 	// List lists all RuntimeClasses in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1.RuntimeClass, err error)
-	// ListWithContext lists all RuntimeClasses in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.RuntimeClass, err error)
 	// Get retrieves the RuntimeClass from the index for a given name.
 	// Objects returned here must be treated as read-only.
 	Get(name string) (*v1.RuntimeClass, error)
-	// GetWithContext retrieves the RuntimeClass from the index for a given name.
-	// Objects returned here must be treated as read-only.
-	GetWithContext(ctx context.Context, name string) (*v1.RuntimeClass, error)
 	RuntimeClassListerExpansion
 }
 
@@ -57,11 +49,6 @@ func NewRuntimeClassLister(indexer cache.Indexer) RuntimeClassLister {
 
 // List lists all RuntimeClasses in the indexer.
 func (s *runtimeClassLister) List(selector labels.Selector) (ret []*v1.RuntimeClass, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all RuntimeClasses in the indexer.
-func (s *runtimeClassLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.RuntimeClass, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.RuntimeClass))
 	})
@@ -70,11 +57,6 @@ func (s *runtimeClassLister) ListWithContext(ctx context.Context, selector label
 
 // Get retrieves the RuntimeClass from the index for a given name.
 func (s *runtimeClassLister) Get(name string) (*v1.RuntimeClass, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the RuntimeClass from the index for a given name.
-func (s *runtimeClassLister) GetWithContext(ctx context.Context, name string) (*v1.RuntimeClass, error) {
 	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/node/v1alpha1/runtimeclass.go
+++ b/staging/src/k8s.io/client-go/listers/node/v1alpha1/runtimeclass.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"context"
-
 	v1alpha1 "k8s.io/api/node/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,15 +31,9 @@ type RuntimeClassLister interface {
 	// List lists all RuntimeClasses in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1alpha1.RuntimeClass, err error)
-	// ListWithContext lists all RuntimeClasses in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1alpha1.RuntimeClass, err error)
 	// Get retrieves the RuntimeClass from the index for a given name.
 	// Objects returned here must be treated as read-only.
 	Get(name string) (*v1alpha1.RuntimeClass, error)
-	// GetWithContext retrieves the RuntimeClass from the index for a given name.
-	// Objects returned here must be treated as read-only.
-	GetWithContext(ctx context.Context, name string) (*v1alpha1.RuntimeClass, error)
 	RuntimeClassListerExpansion
 }
 
@@ -57,11 +49,6 @@ func NewRuntimeClassLister(indexer cache.Indexer) RuntimeClassLister {
 
 // List lists all RuntimeClasses in the indexer.
 func (s *runtimeClassLister) List(selector labels.Selector) (ret []*v1alpha1.RuntimeClass, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all RuntimeClasses in the indexer.
-func (s *runtimeClassLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1alpha1.RuntimeClass, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1alpha1.RuntimeClass))
 	})
@@ -70,11 +57,6 @@ func (s *runtimeClassLister) ListWithContext(ctx context.Context, selector label
 
 // Get retrieves the RuntimeClass from the index for a given name.
 func (s *runtimeClassLister) Get(name string) (*v1alpha1.RuntimeClass, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the RuntimeClass from the index for a given name.
-func (s *runtimeClassLister) GetWithContext(ctx context.Context, name string) (*v1alpha1.RuntimeClass, error) {
 	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/node/v1beta1/runtimeclass.go
+++ b/staging/src/k8s.io/client-go/listers/node/v1beta1/runtimeclass.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1beta1
 
 import (
-	"context"
-
 	v1beta1 "k8s.io/api/node/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,15 +31,9 @@ type RuntimeClassLister interface {
 	// List lists all RuntimeClasses in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1beta1.RuntimeClass, err error)
-	// ListWithContext lists all RuntimeClasses in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.RuntimeClass, err error)
 	// Get retrieves the RuntimeClass from the index for a given name.
 	// Objects returned here must be treated as read-only.
 	Get(name string) (*v1beta1.RuntimeClass, error)
-	// GetWithContext retrieves the RuntimeClass from the index for a given name.
-	// Objects returned here must be treated as read-only.
-	GetWithContext(ctx context.Context, name string) (*v1beta1.RuntimeClass, error)
 	RuntimeClassListerExpansion
 }
 
@@ -57,11 +49,6 @@ func NewRuntimeClassLister(indexer cache.Indexer) RuntimeClassLister {
 
 // List lists all RuntimeClasses in the indexer.
 func (s *runtimeClassLister) List(selector labels.Selector) (ret []*v1beta1.RuntimeClass, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all RuntimeClasses in the indexer.
-func (s *runtimeClassLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.RuntimeClass, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1beta1.RuntimeClass))
 	})
@@ -70,11 +57,6 @@ func (s *runtimeClassLister) ListWithContext(ctx context.Context, selector label
 
 // Get retrieves the RuntimeClass from the index for a given name.
 func (s *runtimeClassLister) Get(name string) (*v1beta1.RuntimeClass, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the RuntimeClass from the index for a given name.
-func (s *runtimeClassLister) GetWithContext(ctx context.Context, name string) (*v1beta1.RuntimeClass, error) {
 	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/policy/v1/eviction.go
+++ b/staging/src/k8s.io/client-go/listers/policy/v1/eviction.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1
 
 import (
-	"context"
-
 	v1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,9 +31,6 @@ type EvictionLister interface {
 	// List lists all Evictions in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1.Eviction, err error)
-	// ListWithContext lists all Evictions in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.Eviction, err error)
 	// Evictions returns an object that can list and get Evictions.
 	Evictions(namespace string) EvictionNamespaceLister
 	EvictionListerExpansion
@@ -53,11 +48,6 @@ func NewEvictionLister(indexer cache.Indexer) EvictionLister {
 
 // List lists all Evictions in the indexer.
 func (s *evictionLister) List(selector labels.Selector) (ret []*v1.Eviction, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all Evictions in the indexer.
-func (s *evictionLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.Eviction, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.Eviction))
 	})
@@ -90,11 +80,6 @@ type evictionNamespaceLister struct {
 
 // List lists all Evictions in the indexer for a given namespace.
 func (s evictionNamespaceLister) List(selector labels.Selector) (ret []*v1.Eviction, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all Evictions in the indexer for a given namespace.
-func (s evictionNamespaceLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.Eviction, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.Eviction))
 	})
@@ -103,11 +88,6 @@ func (s evictionNamespaceLister) ListWithContext(ctx context.Context, selector l
 
 // Get retrieves the Eviction from the indexer for a given namespace and name.
 func (s evictionNamespaceLister) Get(name string) (*v1.Eviction, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the Eviction from the indexer for a given namespace and name.
-func (s evictionNamespaceLister) GetWithContext(ctx context.Context, name string) (*v1.Eviction, error) {
 	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/policy/v1/poddisruptionbudget.go
+++ b/staging/src/k8s.io/client-go/listers/policy/v1/poddisruptionbudget.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1
 
 import (
-	"context"
-
 	v1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,9 +31,6 @@ type PodDisruptionBudgetLister interface {
 	// List lists all PodDisruptionBudgets in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1.PodDisruptionBudget, err error)
-	// ListWithContext lists all PodDisruptionBudgets in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.PodDisruptionBudget, err error)
 	// PodDisruptionBudgets returns an object that can list and get PodDisruptionBudgets.
 	PodDisruptionBudgets(namespace string) PodDisruptionBudgetNamespaceLister
 	PodDisruptionBudgetListerExpansion
@@ -53,11 +48,6 @@ func NewPodDisruptionBudgetLister(indexer cache.Indexer) PodDisruptionBudgetList
 
 // List lists all PodDisruptionBudgets in the indexer.
 func (s *podDisruptionBudgetLister) List(selector labels.Selector) (ret []*v1.PodDisruptionBudget, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all PodDisruptionBudgets in the indexer.
-func (s *podDisruptionBudgetLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.PodDisruptionBudget, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.PodDisruptionBudget))
 	})
@@ -90,11 +80,6 @@ type podDisruptionBudgetNamespaceLister struct {
 
 // List lists all PodDisruptionBudgets in the indexer for a given namespace.
 func (s podDisruptionBudgetNamespaceLister) List(selector labels.Selector) (ret []*v1.PodDisruptionBudget, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all PodDisruptionBudgets in the indexer for a given namespace.
-func (s podDisruptionBudgetNamespaceLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.PodDisruptionBudget, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.PodDisruptionBudget))
 	})
@@ -103,11 +88,6 @@ func (s podDisruptionBudgetNamespaceLister) ListWithContext(ctx context.Context,
 
 // Get retrieves the PodDisruptionBudget from the indexer for a given namespace and name.
 func (s podDisruptionBudgetNamespaceLister) Get(name string) (*v1.PodDisruptionBudget, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the PodDisruptionBudget from the indexer for a given namespace and name.
-func (s podDisruptionBudgetNamespaceLister) GetWithContext(ctx context.Context, name string) (*v1.PodDisruptionBudget, error) {
 	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/policy/v1beta1/eviction.go
+++ b/staging/src/k8s.io/client-go/listers/policy/v1beta1/eviction.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1beta1
 
 import (
-	"context"
-
 	v1beta1 "k8s.io/api/policy/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,9 +31,6 @@ type EvictionLister interface {
 	// List lists all Evictions in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1beta1.Eviction, err error)
-	// ListWithContext lists all Evictions in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.Eviction, err error)
 	// Evictions returns an object that can list and get Evictions.
 	Evictions(namespace string) EvictionNamespaceLister
 	EvictionListerExpansion
@@ -53,11 +48,6 @@ func NewEvictionLister(indexer cache.Indexer) EvictionLister {
 
 // List lists all Evictions in the indexer.
 func (s *evictionLister) List(selector labels.Selector) (ret []*v1beta1.Eviction, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all Evictions in the indexer.
-func (s *evictionLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.Eviction, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1beta1.Eviction))
 	})
@@ -90,11 +80,6 @@ type evictionNamespaceLister struct {
 
 // List lists all Evictions in the indexer for a given namespace.
 func (s evictionNamespaceLister) List(selector labels.Selector) (ret []*v1beta1.Eviction, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all Evictions in the indexer for a given namespace.
-func (s evictionNamespaceLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.Eviction, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1beta1.Eviction))
 	})
@@ -103,11 +88,6 @@ func (s evictionNamespaceLister) ListWithContext(ctx context.Context, selector l
 
 // Get retrieves the Eviction from the indexer for a given namespace and name.
 func (s evictionNamespaceLister) Get(name string) (*v1beta1.Eviction, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the Eviction from the indexer for a given namespace and name.
-func (s evictionNamespaceLister) GetWithContext(ctx context.Context, name string) (*v1beta1.Eviction, error) {
 	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/policy/v1beta1/poddisruptionbudget.go
+++ b/staging/src/k8s.io/client-go/listers/policy/v1beta1/poddisruptionbudget.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1beta1
 
 import (
-	"context"
-
 	v1beta1 "k8s.io/api/policy/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,9 +31,6 @@ type PodDisruptionBudgetLister interface {
 	// List lists all PodDisruptionBudgets in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1beta1.PodDisruptionBudget, err error)
-	// ListWithContext lists all PodDisruptionBudgets in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.PodDisruptionBudget, err error)
 	// PodDisruptionBudgets returns an object that can list and get PodDisruptionBudgets.
 	PodDisruptionBudgets(namespace string) PodDisruptionBudgetNamespaceLister
 	PodDisruptionBudgetListerExpansion
@@ -53,11 +48,6 @@ func NewPodDisruptionBudgetLister(indexer cache.Indexer) PodDisruptionBudgetList
 
 // List lists all PodDisruptionBudgets in the indexer.
 func (s *podDisruptionBudgetLister) List(selector labels.Selector) (ret []*v1beta1.PodDisruptionBudget, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all PodDisruptionBudgets in the indexer.
-func (s *podDisruptionBudgetLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.PodDisruptionBudget, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1beta1.PodDisruptionBudget))
 	})
@@ -90,11 +80,6 @@ type podDisruptionBudgetNamespaceLister struct {
 
 // List lists all PodDisruptionBudgets in the indexer for a given namespace.
 func (s podDisruptionBudgetNamespaceLister) List(selector labels.Selector) (ret []*v1beta1.PodDisruptionBudget, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all PodDisruptionBudgets in the indexer for a given namespace.
-func (s podDisruptionBudgetNamespaceLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.PodDisruptionBudget, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1beta1.PodDisruptionBudget))
 	})
@@ -103,11 +88,6 @@ func (s podDisruptionBudgetNamespaceLister) ListWithContext(ctx context.Context,
 
 // Get retrieves the PodDisruptionBudget from the indexer for a given namespace and name.
 func (s podDisruptionBudgetNamespaceLister) Get(name string) (*v1beta1.PodDisruptionBudget, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the PodDisruptionBudget from the indexer for a given namespace and name.
-func (s podDisruptionBudgetNamespaceLister) GetWithContext(ctx context.Context, name string) (*v1beta1.PodDisruptionBudget, error) {
 	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/policy/v1beta1/podsecuritypolicy.go
+++ b/staging/src/k8s.io/client-go/listers/policy/v1beta1/podsecuritypolicy.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1beta1
 
 import (
-	"context"
-
 	v1beta1 "k8s.io/api/policy/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,15 +31,9 @@ type PodSecurityPolicyLister interface {
 	// List lists all PodSecurityPolicies in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1beta1.PodSecurityPolicy, err error)
-	// ListWithContext lists all PodSecurityPolicies in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.PodSecurityPolicy, err error)
 	// Get retrieves the PodSecurityPolicy from the index for a given name.
 	// Objects returned here must be treated as read-only.
 	Get(name string) (*v1beta1.PodSecurityPolicy, error)
-	// GetWithContext retrieves the PodSecurityPolicy from the index for a given name.
-	// Objects returned here must be treated as read-only.
-	GetWithContext(ctx context.Context, name string) (*v1beta1.PodSecurityPolicy, error)
 	PodSecurityPolicyListerExpansion
 }
 
@@ -57,11 +49,6 @@ func NewPodSecurityPolicyLister(indexer cache.Indexer) PodSecurityPolicyLister {
 
 // List lists all PodSecurityPolicies in the indexer.
 func (s *podSecurityPolicyLister) List(selector labels.Selector) (ret []*v1beta1.PodSecurityPolicy, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all PodSecurityPolicies in the indexer.
-func (s *podSecurityPolicyLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.PodSecurityPolicy, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1beta1.PodSecurityPolicy))
 	})
@@ -70,11 +57,6 @@ func (s *podSecurityPolicyLister) ListWithContext(ctx context.Context, selector 
 
 // Get retrieves the PodSecurityPolicy from the index for a given name.
 func (s *podSecurityPolicyLister) Get(name string) (*v1beta1.PodSecurityPolicy, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the PodSecurityPolicy from the index for a given name.
-func (s *podSecurityPolicyLister) GetWithContext(ctx context.Context, name string) (*v1beta1.PodSecurityPolicy, error) {
 	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/rbac/v1/clusterrole.go
+++ b/staging/src/k8s.io/client-go/listers/rbac/v1/clusterrole.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1
 
 import (
-	"context"
-
 	v1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,15 +31,9 @@ type ClusterRoleLister interface {
 	// List lists all ClusterRoles in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1.ClusterRole, err error)
-	// ListWithContext lists all ClusterRoles in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.ClusterRole, err error)
 	// Get retrieves the ClusterRole from the index for a given name.
 	// Objects returned here must be treated as read-only.
 	Get(name string) (*v1.ClusterRole, error)
-	// GetWithContext retrieves the ClusterRole from the index for a given name.
-	// Objects returned here must be treated as read-only.
-	GetWithContext(ctx context.Context, name string) (*v1.ClusterRole, error)
 	ClusterRoleListerExpansion
 }
 
@@ -57,11 +49,6 @@ func NewClusterRoleLister(indexer cache.Indexer) ClusterRoleLister {
 
 // List lists all ClusterRoles in the indexer.
 func (s *clusterRoleLister) List(selector labels.Selector) (ret []*v1.ClusterRole, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all ClusterRoles in the indexer.
-func (s *clusterRoleLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.ClusterRole, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.ClusterRole))
 	})
@@ -70,11 +57,6 @@ func (s *clusterRoleLister) ListWithContext(ctx context.Context, selector labels
 
 // Get retrieves the ClusterRole from the index for a given name.
 func (s *clusterRoleLister) Get(name string) (*v1.ClusterRole, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the ClusterRole from the index for a given name.
-func (s *clusterRoleLister) GetWithContext(ctx context.Context, name string) (*v1.ClusterRole, error) {
 	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/rbac/v1/clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/listers/rbac/v1/clusterrolebinding.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1
 
 import (
-	"context"
-
 	v1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,15 +31,9 @@ type ClusterRoleBindingLister interface {
 	// List lists all ClusterRoleBindings in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1.ClusterRoleBinding, err error)
-	// ListWithContext lists all ClusterRoleBindings in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.ClusterRoleBinding, err error)
 	// Get retrieves the ClusterRoleBinding from the index for a given name.
 	// Objects returned here must be treated as read-only.
 	Get(name string) (*v1.ClusterRoleBinding, error)
-	// GetWithContext retrieves the ClusterRoleBinding from the index for a given name.
-	// Objects returned here must be treated as read-only.
-	GetWithContext(ctx context.Context, name string) (*v1.ClusterRoleBinding, error)
 	ClusterRoleBindingListerExpansion
 }
 
@@ -57,11 +49,6 @@ func NewClusterRoleBindingLister(indexer cache.Indexer) ClusterRoleBindingLister
 
 // List lists all ClusterRoleBindings in the indexer.
 func (s *clusterRoleBindingLister) List(selector labels.Selector) (ret []*v1.ClusterRoleBinding, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all ClusterRoleBindings in the indexer.
-func (s *clusterRoleBindingLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.ClusterRoleBinding, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.ClusterRoleBinding))
 	})
@@ -70,11 +57,6 @@ func (s *clusterRoleBindingLister) ListWithContext(ctx context.Context, selector
 
 // Get retrieves the ClusterRoleBinding from the index for a given name.
 func (s *clusterRoleBindingLister) Get(name string) (*v1.ClusterRoleBinding, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the ClusterRoleBinding from the index for a given name.
-func (s *clusterRoleBindingLister) GetWithContext(ctx context.Context, name string) (*v1.ClusterRoleBinding, error) {
 	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/rbac/v1/role.go
+++ b/staging/src/k8s.io/client-go/listers/rbac/v1/role.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1
 
 import (
-	"context"
-
 	v1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,9 +31,6 @@ type RoleLister interface {
 	// List lists all Roles in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1.Role, err error)
-	// ListWithContext lists all Roles in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.Role, err error)
 	// Roles returns an object that can list and get Roles.
 	Roles(namespace string) RoleNamespaceLister
 	RoleListerExpansion
@@ -53,11 +48,6 @@ func NewRoleLister(indexer cache.Indexer) RoleLister {
 
 // List lists all Roles in the indexer.
 func (s *roleLister) List(selector labels.Selector) (ret []*v1.Role, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all Roles in the indexer.
-func (s *roleLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.Role, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.Role))
 	})
@@ -90,11 +80,6 @@ type roleNamespaceLister struct {
 
 // List lists all Roles in the indexer for a given namespace.
 func (s roleNamespaceLister) List(selector labels.Selector) (ret []*v1.Role, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all Roles in the indexer for a given namespace.
-func (s roleNamespaceLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.Role, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.Role))
 	})
@@ -103,11 +88,6 @@ func (s roleNamespaceLister) ListWithContext(ctx context.Context, selector label
 
 // Get retrieves the Role from the indexer for a given namespace and name.
 func (s roleNamespaceLister) Get(name string) (*v1.Role, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the Role from the indexer for a given namespace and name.
-func (s roleNamespaceLister) GetWithContext(ctx context.Context, name string) (*v1.Role, error) {
 	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/rbac/v1/rolebinding.go
+++ b/staging/src/k8s.io/client-go/listers/rbac/v1/rolebinding.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1
 
 import (
-	"context"
-
 	v1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,9 +31,6 @@ type RoleBindingLister interface {
 	// List lists all RoleBindings in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1.RoleBinding, err error)
-	// ListWithContext lists all RoleBindings in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.RoleBinding, err error)
 	// RoleBindings returns an object that can list and get RoleBindings.
 	RoleBindings(namespace string) RoleBindingNamespaceLister
 	RoleBindingListerExpansion
@@ -53,11 +48,6 @@ func NewRoleBindingLister(indexer cache.Indexer) RoleBindingLister {
 
 // List lists all RoleBindings in the indexer.
 func (s *roleBindingLister) List(selector labels.Selector) (ret []*v1.RoleBinding, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all RoleBindings in the indexer.
-func (s *roleBindingLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.RoleBinding, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.RoleBinding))
 	})
@@ -90,11 +80,6 @@ type roleBindingNamespaceLister struct {
 
 // List lists all RoleBindings in the indexer for a given namespace.
 func (s roleBindingNamespaceLister) List(selector labels.Selector) (ret []*v1.RoleBinding, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all RoleBindings in the indexer for a given namespace.
-func (s roleBindingNamespaceLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.RoleBinding, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.RoleBinding))
 	})
@@ -103,11 +88,6 @@ func (s roleBindingNamespaceLister) ListWithContext(ctx context.Context, selecto
 
 // Get retrieves the RoleBinding from the indexer for a given namespace and name.
 func (s roleBindingNamespaceLister) Get(name string) (*v1.RoleBinding, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the RoleBinding from the indexer for a given namespace and name.
-func (s roleBindingNamespaceLister) GetWithContext(ctx context.Context, name string) (*v1.RoleBinding, error) {
 	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/rbac/v1alpha1/clusterrole.go
+++ b/staging/src/k8s.io/client-go/listers/rbac/v1alpha1/clusterrole.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"context"
-
 	v1alpha1 "k8s.io/api/rbac/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,15 +31,9 @@ type ClusterRoleLister interface {
 	// List lists all ClusterRoles in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1alpha1.ClusterRole, err error)
-	// ListWithContext lists all ClusterRoles in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1alpha1.ClusterRole, err error)
 	// Get retrieves the ClusterRole from the index for a given name.
 	// Objects returned here must be treated as read-only.
 	Get(name string) (*v1alpha1.ClusterRole, error)
-	// GetWithContext retrieves the ClusterRole from the index for a given name.
-	// Objects returned here must be treated as read-only.
-	GetWithContext(ctx context.Context, name string) (*v1alpha1.ClusterRole, error)
 	ClusterRoleListerExpansion
 }
 
@@ -57,11 +49,6 @@ func NewClusterRoleLister(indexer cache.Indexer) ClusterRoleLister {
 
 // List lists all ClusterRoles in the indexer.
 func (s *clusterRoleLister) List(selector labels.Selector) (ret []*v1alpha1.ClusterRole, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all ClusterRoles in the indexer.
-func (s *clusterRoleLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1alpha1.ClusterRole, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1alpha1.ClusterRole))
 	})
@@ -70,11 +57,6 @@ func (s *clusterRoleLister) ListWithContext(ctx context.Context, selector labels
 
 // Get retrieves the ClusterRole from the index for a given name.
 func (s *clusterRoleLister) Get(name string) (*v1alpha1.ClusterRole, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the ClusterRole from the index for a given name.
-func (s *clusterRoleLister) GetWithContext(ctx context.Context, name string) (*v1alpha1.ClusterRole, error) {
 	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/rbac/v1alpha1/clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/listers/rbac/v1alpha1/clusterrolebinding.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"context"
-
 	v1alpha1 "k8s.io/api/rbac/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,15 +31,9 @@ type ClusterRoleBindingLister interface {
 	// List lists all ClusterRoleBindings in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1alpha1.ClusterRoleBinding, err error)
-	// ListWithContext lists all ClusterRoleBindings in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1alpha1.ClusterRoleBinding, err error)
 	// Get retrieves the ClusterRoleBinding from the index for a given name.
 	// Objects returned here must be treated as read-only.
 	Get(name string) (*v1alpha1.ClusterRoleBinding, error)
-	// GetWithContext retrieves the ClusterRoleBinding from the index for a given name.
-	// Objects returned here must be treated as read-only.
-	GetWithContext(ctx context.Context, name string) (*v1alpha1.ClusterRoleBinding, error)
 	ClusterRoleBindingListerExpansion
 }
 
@@ -57,11 +49,6 @@ func NewClusterRoleBindingLister(indexer cache.Indexer) ClusterRoleBindingLister
 
 // List lists all ClusterRoleBindings in the indexer.
 func (s *clusterRoleBindingLister) List(selector labels.Selector) (ret []*v1alpha1.ClusterRoleBinding, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all ClusterRoleBindings in the indexer.
-func (s *clusterRoleBindingLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1alpha1.ClusterRoleBinding, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1alpha1.ClusterRoleBinding))
 	})
@@ -70,11 +57,6 @@ func (s *clusterRoleBindingLister) ListWithContext(ctx context.Context, selector
 
 // Get retrieves the ClusterRoleBinding from the index for a given name.
 func (s *clusterRoleBindingLister) Get(name string) (*v1alpha1.ClusterRoleBinding, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the ClusterRoleBinding from the index for a given name.
-func (s *clusterRoleBindingLister) GetWithContext(ctx context.Context, name string) (*v1alpha1.ClusterRoleBinding, error) {
 	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/rbac/v1alpha1/role.go
+++ b/staging/src/k8s.io/client-go/listers/rbac/v1alpha1/role.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"context"
-
 	v1alpha1 "k8s.io/api/rbac/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,9 +31,6 @@ type RoleLister interface {
 	// List lists all Roles in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1alpha1.Role, err error)
-	// ListWithContext lists all Roles in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1alpha1.Role, err error)
 	// Roles returns an object that can list and get Roles.
 	Roles(namespace string) RoleNamespaceLister
 	RoleListerExpansion
@@ -53,11 +48,6 @@ func NewRoleLister(indexer cache.Indexer) RoleLister {
 
 // List lists all Roles in the indexer.
 func (s *roleLister) List(selector labels.Selector) (ret []*v1alpha1.Role, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all Roles in the indexer.
-func (s *roleLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1alpha1.Role, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1alpha1.Role))
 	})
@@ -90,11 +80,6 @@ type roleNamespaceLister struct {
 
 // List lists all Roles in the indexer for a given namespace.
 func (s roleNamespaceLister) List(selector labels.Selector) (ret []*v1alpha1.Role, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all Roles in the indexer for a given namespace.
-func (s roleNamespaceLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1alpha1.Role, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1alpha1.Role))
 	})
@@ -103,11 +88,6 @@ func (s roleNamespaceLister) ListWithContext(ctx context.Context, selector label
 
 // Get retrieves the Role from the indexer for a given namespace and name.
 func (s roleNamespaceLister) Get(name string) (*v1alpha1.Role, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the Role from the indexer for a given namespace and name.
-func (s roleNamespaceLister) GetWithContext(ctx context.Context, name string) (*v1alpha1.Role, error) {
 	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/rbac/v1alpha1/rolebinding.go
+++ b/staging/src/k8s.io/client-go/listers/rbac/v1alpha1/rolebinding.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"context"
-
 	v1alpha1 "k8s.io/api/rbac/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,9 +31,6 @@ type RoleBindingLister interface {
 	// List lists all RoleBindings in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1alpha1.RoleBinding, err error)
-	// ListWithContext lists all RoleBindings in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1alpha1.RoleBinding, err error)
 	// RoleBindings returns an object that can list and get RoleBindings.
 	RoleBindings(namespace string) RoleBindingNamespaceLister
 	RoleBindingListerExpansion
@@ -53,11 +48,6 @@ func NewRoleBindingLister(indexer cache.Indexer) RoleBindingLister {
 
 // List lists all RoleBindings in the indexer.
 func (s *roleBindingLister) List(selector labels.Selector) (ret []*v1alpha1.RoleBinding, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all RoleBindings in the indexer.
-func (s *roleBindingLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1alpha1.RoleBinding, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1alpha1.RoleBinding))
 	})
@@ -90,11 +80,6 @@ type roleBindingNamespaceLister struct {
 
 // List lists all RoleBindings in the indexer for a given namespace.
 func (s roleBindingNamespaceLister) List(selector labels.Selector) (ret []*v1alpha1.RoleBinding, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all RoleBindings in the indexer for a given namespace.
-func (s roleBindingNamespaceLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1alpha1.RoleBinding, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1alpha1.RoleBinding))
 	})
@@ -103,11 +88,6 @@ func (s roleBindingNamespaceLister) ListWithContext(ctx context.Context, selecto
 
 // Get retrieves the RoleBinding from the indexer for a given namespace and name.
 func (s roleBindingNamespaceLister) Get(name string) (*v1alpha1.RoleBinding, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the RoleBinding from the indexer for a given namespace and name.
-func (s roleBindingNamespaceLister) GetWithContext(ctx context.Context, name string) (*v1alpha1.RoleBinding, error) {
 	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/rbac/v1beta1/clusterrole.go
+++ b/staging/src/k8s.io/client-go/listers/rbac/v1beta1/clusterrole.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1beta1
 
 import (
-	"context"
-
 	v1beta1 "k8s.io/api/rbac/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,15 +31,9 @@ type ClusterRoleLister interface {
 	// List lists all ClusterRoles in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1beta1.ClusterRole, err error)
-	// ListWithContext lists all ClusterRoles in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.ClusterRole, err error)
 	// Get retrieves the ClusterRole from the index for a given name.
 	// Objects returned here must be treated as read-only.
 	Get(name string) (*v1beta1.ClusterRole, error)
-	// GetWithContext retrieves the ClusterRole from the index for a given name.
-	// Objects returned here must be treated as read-only.
-	GetWithContext(ctx context.Context, name string) (*v1beta1.ClusterRole, error)
 	ClusterRoleListerExpansion
 }
 
@@ -57,11 +49,6 @@ func NewClusterRoleLister(indexer cache.Indexer) ClusterRoleLister {
 
 // List lists all ClusterRoles in the indexer.
 func (s *clusterRoleLister) List(selector labels.Selector) (ret []*v1beta1.ClusterRole, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all ClusterRoles in the indexer.
-func (s *clusterRoleLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.ClusterRole, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1beta1.ClusterRole))
 	})
@@ -70,11 +57,6 @@ func (s *clusterRoleLister) ListWithContext(ctx context.Context, selector labels
 
 // Get retrieves the ClusterRole from the index for a given name.
 func (s *clusterRoleLister) Get(name string) (*v1beta1.ClusterRole, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the ClusterRole from the index for a given name.
-func (s *clusterRoleLister) GetWithContext(ctx context.Context, name string) (*v1beta1.ClusterRole, error) {
 	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/rbac/v1beta1/clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/listers/rbac/v1beta1/clusterrolebinding.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1beta1
 
 import (
-	"context"
-
 	v1beta1 "k8s.io/api/rbac/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,15 +31,9 @@ type ClusterRoleBindingLister interface {
 	// List lists all ClusterRoleBindings in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1beta1.ClusterRoleBinding, err error)
-	// ListWithContext lists all ClusterRoleBindings in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.ClusterRoleBinding, err error)
 	// Get retrieves the ClusterRoleBinding from the index for a given name.
 	// Objects returned here must be treated as read-only.
 	Get(name string) (*v1beta1.ClusterRoleBinding, error)
-	// GetWithContext retrieves the ClusterRoleBinding from the index for a given name.
-	// Objects returned here must be treated as read-only.
-	GetWithContext(ctx context.Context, name string) (*v1beta1.ClusterRoleBinding, error)
 	ClusterRoleBindingListerExpansion
 }
 
@@ -57,11 +49,6 @@ func NewClusterRoleBindingLister(indexer cache.Indexer) ClusterRoleBindingLister
 
 // List lists all ClusterRoleBindings in the indexer.
 func (s *clusterRoleBindingLister) List(selector labels.Selector) (ret []*v1beta1.ClusterRoleBinding, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all ClusterRoleBindings in the indexer.
-func (s *clusterRoleBindingLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.ClusterRoleBinding, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1beta1.ClusterRoleBinding))
 	})
@@ -70,11 +57,6 @@ func (s *clusterRoleBindingLister) ListWithContext(ctx context.Context, selector
 
 // Get retrieves the ClusterRoleBinding from the index for a given name.
 func (s *clusterRoleBindingLister) Get(name string) (*v1beta1.ClusterRoleBinding, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the ClusterRoleBinding from the index for a given name.
-func (s *clusterRoleBindingLister) GetWithContext(ctx context.Context, name string) (*v1beta1.ClusterRoleBinding, error) {
 	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/rbac/v1beta1/role.go
+++ b/staging/src/k8s.io/client-go/listers/rbac/v1beta1/role.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1beta1
 
 import (
-	"context"
-
 	v1beta1 "k8s.io/api/rbac/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,9 +31,6 @@ type RoleLister interface {
 	// List lists all Roles in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1beta1.Role, err error)
-	// ListWithContext lists all Roles in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.Role, err error)
 	// Roles returns an object that can list and get Roles.
 	Roles(namespace string) RoleNamespaceLister
 	RoleListerExpansion
@@ -53,11 +48,6 @@ func NewRoleLister(indexer cache.Indexer) RoleLister {
 
 // List lists all Roles in the indexer.
 func (s *roleLister) List(selector labels.Selector) (ret []*v1beta1.Role, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all Roles in the indexer.
-func (s *roleLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.Role, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1beta1.Role))
 	})
@@ -90,11 +80,6 @@ type roleNamespaceLister struct {
 
 // List lists all Roles in the indexer for a given namespace.
 func (s roleNamespaceLister) List(selector labels.Selector) (ret []*v1beta1.Role, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all Roles in the indexer for a given namespace.
-func (s roleNamespaceLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.Role, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1beta1.Role))
 	})
@@ -103,11 +88,6 @@ func (s roleNamespaceLister) ListWithContext(ctx context.Context, selector label
 
 // Get retrieves the Role from the indexer for a given namespace and name.
 func (s roleNamespaceLister) Get(name string) (*v1beta1.Role, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the Role from the indexer for a given namespace and name.
-func (s roleNamespaceLister) GetWithContext(ctx context.Context, name string) (*v1beta1.Role, error) {
 	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/rbac/v1beta1/rolebinding.go
+++ b/staging/src/k8s.io/client-go/listers/rbac/v1beta1/rolebinding.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1beta1
 
 import (
-	"context"
-
 	v1beta1 "k8s.io/api/rbac/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,9 +31,6 @@ type RoleBindingLister interface {
 	// List lists all RoleBindings in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1beta1.RoleBinding, err error)
-	// ListWithContext lists all RoleBindings in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.RoleBinding, err error)
 	// RoleBindings returns an object that can list and get RoleBindings.
 	RoleBindings(namespace string) RoleBindingNamespaceLister
 	RoleBindingListerExpansion
@@ -53,11 +48,6 @@ func NewRoleBindingLister(indexer cache.Indexer) RoleBindingLister {
 
 // List lists all RoleBindings in the indexer.
 func (s *roleBindingLister) List(selector labels.Selector) (ret []*v1beta1.RoleBinding, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all RoleBindings in the indexer.
-func (s *roleBindingLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.RoleBinding, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1beta1.RoleBinding))
 	})
@@ -90,11 +80,6 @@ type roleBindingNamespaceLister struct {
 
 // List lists all RoleBindings in the indexer for a given namespace.
 func (s roleBindingNamespaceLister) List(selector labels.Selector) (ret []*v1beta1.RoleBinding, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all RoleBindings in the indexer for a given namespace.
-func (s roleBindingNamespaceLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.RoleBinding, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1beta1.RoleBinding))
 	})
@@ -103,11 +88,6 @@ func (s roleBindingNamespaceLister) ListWithContext(ctx context.Context, selecto
 
 // Get retrieves the RoleBinding from the indexer for a given namespace and name.
 func (s roleBindingNamespaceLister) Get(name string) (*v1beta1.RoleBinding, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the RoleBinding from the indexer for a given namespace and name.
-func (s roleBindingNamespaceLister) GetWithContext(ctx context.Context, name string) (*v1beta1.RoleBinding, error) {
 	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/scheduling/v1/priorityclass.go
+++ b/staging/src/k8s.io/client-go/listers/scheduling/v1/priorityclass.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1
 
 import (
-	"context"
-
 	v1 "k8s.io/api/scheduling/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,15 +31,9 @@ type PriorityClassLister interface {
 	// List lists all PriorityClasses in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1.PriorityClass, err error)
-	// ListWithContext lists all PriorityClasses in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.PriorityClass, err error)
 	// Get retrieves the PriorityClass from the index for a given name.
 	// Objects returned here must be treated as read-only.
 	Get(name string) (*v1.PriorityClass, error)
-	// GetWithContext retrieves the PriorityClass from the index for a given name.
-	// Objects returned here must be treated as read-only.
-	GetWithContext(ctx context.Context, name string) (*v1.PriorityClass, error)
 	PriorityClassListerExpansion
 }
 
@@ -57,11 +49,6 @@ func NewPriorityClassLister(indexer cache.Indexer) PriorityClassLister {
 
 // List lists all PriorityClasses in the indexer.
 func (s *priorityClassLister) List(selector labels.Selector) (ret []*v1.PriorityClass, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all PriorityClasses in the indexer.
-func (s *priorityClassLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.PriorityClass, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.PriorityClass))
 	})
@@ -70,11 +57,6 @@ func (s *priorityClassLister) ListWithContext(ctx context.Context, selector labe
 
 // Get retrieves the PriorityClass from the index for a given name.
 func (s *priorityClassLister) Get(name string) (*v1.PriorityClass, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the PriorityClass from the index for a given name.
-func (s *priorityClassLister) GetWithContext(ctx context.Context, name string) (*v1.PriorityClass, error) {
 	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/scheduling/v1alpha1/priorityclass.go
+++ b/staging/src/k8s.io/client-go/listers/scheduling/v1alpha1/priorityclass.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"context"
-
 	v1alpha1 "k8s.io/api/scheduling/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,15 +31,9 @@ type PriorityClassLister interface {
 	// List lists all PriorityClasses in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1alpha1.PriorityClass, err error)
-	// ListWithContext lists all PriorityClasses in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1alpha1.PriorityClass, err error)
 	// Get retrieves the PriorityClass from the index for a given name.
 	// Objects returned here must be treated as read-only.
 	Get(name string) (*v1alpha1.PriorityClass, error)
-	// GetWithContext retrieves the PriorityClass from the index for a given name.
-	// Objects returned here must be treated as read-only.
-	GetWithContext(ctx context.Context, name string) (*v1alpha1.PriorityClass, error)
 	PriorityClassListerExpansion
 }
 
@@ -57,11 +49,6 @@ func NewPriorityClassLister(indexer cache.Indexer) PriorityClassLister {
 
 // List lists all PriorityClasses in the indexer.
 func (s *priorityClassLister) List(selector labels.Selector) (ret []*v1alpha1.PriorityClass, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all PriorityClasses in the indexer.
-func (s *priorityClassLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1alpha1.PriorityClass, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1alpha1.PriorityClass))
 	})
@@ -70,11 +57,6 @@ func (s *priorityClassLister) ListWithContext(ctx context.Context, selector labe
 
 // Get retrieves the PriorityClass from the index for a given name.
 func (s *priorityClassLister) Get(name string) (*v1alpha1.PriorityClass, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the PriorityClass from the index for a given name.
-func (s *priorityClassLister) GetWithContext(ctx context.Context, name string) (*v1alpha1.PriorityClass, error) {
 	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/scheduling/v1beta1/priorityclass.go
+++ b/staging/src/k8s.io/client-go/listers/scheduling/v1beta1/priorityclass.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1beta1
 
 import (
-	"context"
-
 	v1beta1 "k8s.io/api/scheduling/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,15 +31,9 @@ type PriorityClassLister interface {
 	// List lists all PriorityClasses in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1beta1.PriorityClass, err error)
-	// ListWithContext lists all PriorityClasses in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.PriorityClass, err error)
 	// Get retrieves the PriorityClass from the index for a given name.
 	// Objects returned here must be treated as read-only.
 	Get(name string) (*v1beta1.PriorityClass, error)
-	// GetWithContext retrieves the PriorityClass from the index for a given name.
-	// Objects returned here must be treated as read-only.
-	GetWithContext(ctx context.Context, name string) (*v1beta1.PriorityClass, error)
 	PriorityClassListerExpansion
 }
 
@@ -57,11 +49,6 @@ func NewPriorityClassLister(indexer cache.Indexer) PriorityClassLister {
 
 // List lists all PriorityClasses in the indexer.
 func (s *priorityClassLister) List(selector labels.Selector) (ret []*v1beta1.PriorityClass, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all PriorityClasses in the indexer.
-func (s *priorityClassLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.PriorityClass, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1beta1.PriorityClass))
 	})
@@ -70,11 +57,6 @@ func (s *priorityClassLister) ListWithContext(ctx context.Context, selector labe
 
 // Get retrieves the PriorityClass from the index for a given name.
 func (s *priorityClassLister) Get(name string) (*v1beta1.PriorityClass, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the PriorityClass from the index for a given name.
-func (s *priorityClassLister) GetWithContext(ctx context.Context, name string) (*v1beta1.PriorityClass, error) {
 	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/storage/v1/csidriver.go
+++ b/staging/src/k8s.io/client-go/listers/storage/v1/csidriver.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1
 
 import (
-	"context"
-
 	v1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,15 +31,9 @@ type CSIDriverLister interface {
 	// List lists all CSIDrivers in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1.CSIDriver, err error)
-	// ListWithContext lists all CSIDrivers in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.CSIDriver, err error)
 	// Get retrieves the CSIDriver from the index for a given name.
 	// Objects returned here must be treated as read-only.
 	Get(name string) (*v1.CSIDriver, error)
-	// GetWithContext retrieves the CSIDriver from the index for a given name.
-	// Objects returned here must be treated as read-only.
-	GetWithContext(ctx context.Context, name string) (*v1.CSIDriver, error)
 	CSIDriverListerExpansion
 }
 
@@ -57,11 +49,6 @@ func NewCSIDriverLister(indexer cache.Indexer) CSIDriverLister {
 
 // List lists all CSIDrivers in the indexer.
 func (s *cSIDriverLister) List(selector labels.Selector) (ret []*v1.CSIDriver, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all CSIDrivers in the indexer.
-func (s *cSIDriverLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.CSIDriver, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.CSIDriver))
 	})
@@ -70,11 +57,6 @@ func (s *cSIDriverLister) ListWithContext(ctx context.Context, selector labels.S
 
 // Get retrieves the CSIDriver from the index for a given name.
 func (s *cSIDriverLister) Get(name string) (*v1.CSIDriver, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the CSIDriver from the index for a given name.
-func (s *cSIDriverLister) GetWithContext(ctx context.Context, name string) (*v1.CSIDriver, error) {
 	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/storage/v1/csinode.go
+++ b/staging/src/k8s.io/client-go/listers/storage/v1/csinode.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1
 
 import (
-	"context"
-
 	v1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,15 +31,9 @@ type CSINodeLister interface {
 	// List lists all CSINodes in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1.CSINode, err error)
-	// ListWithContext lists all CSINodes in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.CSINode, err error)
 	// Get retrieves the CSINode from the index for a given name.
 	// Objects returned here must be treated as read-only.
 	Get(name string) (*v1.CSINode, error)
-	// GetWithContext retrieves the CSINode from the index for a given name.
-	// Objects returned here must be treated as read-only.
-	GetWithContext(ctx context.Context, name string) (*v1.CSINode, error)
 	CSINodeListerExpansion
 }
 
@@ -57,11 +49,6 @@ func NewCSINodeLister(indexer cache.Indexer) CSINodeLister {
 
 // List lists all CSINodes in the indexer.
 func (s *cSINodeLister) List(selector labels.Selector) (ret []*v1.CSINode, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all CSINodes in the indexer.
-func (s *cSINodeLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.CSINode, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.CSINode))
 	})
@@ -70,11 +57,6 @@ func (s *cSINodeLister) ListWithContext(ctx context.Context, selector labels.Sel
 
 // Get retrieves the CSINode from the index for a given name.
 func (s *cSINodeLister) Get(name string) (*v1.CSINode, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the CSINode from the index for a given name.
-func (s *cSINodeLister) GetWithContext(ctx context.Context, name string) (*v1.CSINode, error) {
 	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/storage/v1/storageclass.go
+++ b/staging/src/k8s.io/client-go/listers/storage/v1/storageclass.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1
 
 import (
-	"context"
-
 	v1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,15 +31,9 @@ type StorageClassLister interface {
 	// List lists all StorageClasses in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1.StorageClass, err error)
-	// ListWithContext lists all StorageClasses in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.StorageClass, err error)
 	// Get retrieves the StorageClass from the index for a given name.
 	// Objects returned here must be treated as read-only.
 	Get(name string) (*v1.StorageClass, error)
-	// GetWithContext retrieves the StorageClass from the index for a given name.
-	// Objects returned here must be treated as read-only.
-	GetWithContext(ctx context.Context, name string) (*v1.StorageClass, error)
 	StorageClassListerExpansion
 }
 
@@ -57,11 +49,6 @@ func NewStorageClassLister(indexer cache.Indexer) StorageClassLister {
 
 // List lists all StorageClasses in the indexer.
 func (s *storageClassLister) List(selector labels.Selector) (ret []*v1.StorageClass, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all StorageClasses in the indexer.
-func (s *storageClassLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.StorageClass, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.StorageClass))
 	})
@@ -70,11 +57,6 @@ func (s *storageClassLister) ListWithContext(ctx context.Context, selector label
 
 // Get retrieves the StorageClass from the index for a given name.
 func (s *storageClassLister) Get(name string) (*v1.StorageClass, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the StorageClass from the index for a given name.
-func (s *storageClassLister) GetWithContext(ctx context.Context, name string) (*v1.StorageClass, error) {
 	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/storage/v1/volumeattachment.go
+++ b/staging/src/k8s.io/client-go/listers/storage/v1/volumeattachment.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1
 
 import (
-	"context"
-
 	v1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,15 +31,9 @@ type VolumeAttachmentLister interface {
 	// List lists all VolumeAttachments in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1.VolumeAttachment, err error)
-	// ListWithContext lists all VolumeAttachments in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.VolumeAttachment, err error)
 	// Get retrieves the VolumeAttachment from the index for a given name.
 	// Objects returned here must be treated as read-only.
 	Get(name string) (*v1.VolumeAttachment, error)
-	// GetWithContext retrieves the VolumeAttachment from the index for a given name.
-	// Objects returned here must be treated as read-only.
-	GetWithContext(ctx context.Context, name string) (*v1.VolumeAttachment, error)
 	VolumeAttachmentListerExpansion
 }
 
@@ -57,11 +49,6 @@ func NewVolumeAttachmentLister(indexer cache.Indexer) VolumeAttachmentLister {
 
 // List lists all VolumeAttachments in the indexer.
 func (s *volumeAttachmentLister) List(selector labels.Selector) (ret []*v1.VolumeAttachment, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all VolumeAttachments in the indexer.
-func (s *volumeAttachmentLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.VolumeAttachment, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.VolumeAttachment))
 	})
@@ -70,11 +57,6 @@ func (s *volumeAttachmentLister) ListWithContext(ctx context.Context, selector l
 
 // Get retrieves the VolumeAttachment from the index for a given name.
 func (s *volumeAttachmentLister) Get(name string) (*v1.VolumeAttachment, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the VolumeAttachment from the index for a given name.
-func (s *volumeAttachmentLister) GetWithContext(ctx context.Context, name string) (*v1.VolumeAttachment, error) {
 	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/storage/v1alpha1/csistoragecapacity.go
+++ b/staging/src/k8s.io/client-go/listers/storage/v1alpha1/csistoragecapacity.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"context"
-
 	v1alpha1 "k8s.io/api/storage/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,9 +31,6 @@ type CSIStorageCapacityLister interface {
 	// List lists all CSIStorageCapacities in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1alpha1.CSIStorageCapacity, err error)
-	// ListWithContext lists all CSIStorageCapacities in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1alpha1.CSIStorageCapacity, err error)
 	// CSIStorageCapacities returns an object that can list and get CSIStorageCapacities.
 	CSIStorageCapacities(namespace string) CSIStorageCapacityNamespaceLister
 	CSIStorageCapacityListerExpansion
@@ -53,11 +48,6 @@ func NewCSIStorageCapacityLister(indexer cache.Indexer) CSIStorageCapacityLister
 
 // List lists all CSIStorageCapacities in the indexer.
 func (s *cSIStorageCapacityLister) List(selector labels.Selector) (ret []*v1alpha1.CSIStorageCapacity, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all CSIStorageCapacities in the indexer.
-func (s *cSIStorageCapacityLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1alpha1.CSIStorageCapacity, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1alpha1.CSIStorageCapacity))
 	})
@@ -90,11 +80,6 @@ type cSIStorageCapacityNamespaceLister struct {
 
 // List lists all CSIStorageCapacities in the indexer for a given namespace.
 func (s cSIStorageCapacityNamespaceLister) List(selector labels.Selector) (ret []*v1alpha1.CSIStorageCapacity, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all CSIStorageCapacities in the indexer for a given namespace.
-func (s cSIStorageCapacityNamespaceLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1alpha1.CSIStorageCapacity, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1alpha1.CSIStorageCapacity))
 	})
@@ -103,11 +88,6 @@ func (s cSIStorageCapacityNamespaceLister) ListWithContext(ctx context.Context, 
 
 // Get retrieves the CSIStorageCapacity from the indexer for a given namespace and name.
 func (s cSIStorageCapacityNamespaceLister) Get(name string) (*v1alpha1.CSIStorageCapacity, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the CSIStorageCapacity from the indexer for a given namespace and name.
-func (s cSIStorageCapacityNamespaceLister) GetWithContext(ctx context.Context, name string) (*v1alpha1.CSIStorageCapacity, error) {
 	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/storage/v1alpha1/volumeattachment.go
+++ b/staging/src/k8s.io/client-go/listers/storage/v1alpha1/volumeattachment.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"context"
-
 	v1alpha1 "k8s.io/api/storage/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,15 +31,9 @@ type VolumeAttachmentLister interface {
 	// List lists all VolumeAttachments in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1alpha1.VolumeAttachment, err error)
-	// ListWithContext lists all VolumeAttachments in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1alpha1.VolumeAttachment, err error)
 	// Get retrieves the VolumeAttachment from the index for a given name.
 	// Objects returned here must be treated as read-only.
 	Get(name string) (*v1alpha1.VolumeAttachment, error)
-	// GetWithContext retrieves the VolumeAttachment from the index for a given name.
-	// Objects returned here must be treated as read-only.
-	GetWithContext(ctx context.Context, name string) (*v1alpha1.VolumeAttachment, error)
 	VolumeAttachmentListerExpansion
 }
 
@@ -57,11 +49,6 @@ func NewVolumeAttachmentLister(indexer cache.Indexer) VolumeAttachmentLister {
 
 // List lists all VolumeAttachments in the indexer.
 func (s *volumeAttachmentLister) List(selector labels.Selector) (ret []*v1alpha1.VolumeAttachment, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all VolumeAttachments in the indexer.
-func (s *volumeAttachmentLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1alpha1.VolumeAttachment, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1alpha1.VolumeAttachment))
 	})
@@ -70,11 +57,6 @@ func (s *volumeAttachmentLister) ListWithContext(ctx context.Context, selector l
 
 // Get retrieves the VolumeAttachment from the index for a given name.
 func (s *volumeAttachmentLister) Get(name string) (*v1alpha1.VolumeAttachment, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the VolumeAttachment from the index for a given name.
-func (s *volumeAttachmentLister) GetWithContext(ctx context.Context, name string) (*v1alpha1.VolumeAttachment, error) {
 	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/storage/v1beta1/csidriver.go
+++ b/staging/src/k8s.io/client-go/listers/storage/v1beta1/csidriver.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1beta1
 
 import (
-	"context"
-
 	v1beta1 "k8s.io/api/storage/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,15 +31,9 @@ type CSIDriverLister interface {
 	// List lists all CSIDrivers in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1beta1.CSIDriver, err error)
-	// ListWithContext lists all CSIDrivers in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.CSIDriver, err error)
 	// Get retrieves the CSIDriver from the index for a given name.
 	// Objects returned here must be treated as read-only.
 	Get(name string) (*v1beta1.CSIDriver, error)
-	// GetWithContext retrieves the CSIDriver from the index for a given name.
-	// Objects returned here must be treated as read-only.
-	GetWithContext(ctx context.Context, name string) (*v1beta1.CSIDriver, error)
 	CSIDriverListerExpansion
 }
 
@@ -57,11 +49,6 @@ func NewCSIDriverLister(indexer cache.Indexer) CSIDriverLister {
 
 // List lists all CSIDrivers in the indexer.
 func (s *cSIDriverLister) List(selector labels.Selector) (ret []*v1beta1.CSIDriver, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all CSIDrivers in the indexer.
-func (s *cSIDriverLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.CSIDriver, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1beta1.CSIDriver))
 	})
@@ -70,11 +57,6 @@ func (s *cSIDriverLister) ListWithContext(ctx context.Context, selector labels.S
 
 // Get retrieves the CSIDriver from the index for a given name.
 func (s *cSIDriverLister) Get(name string) (*v1beta1.CSIDriver, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the CSIDriver from the index for a given name.
-func (s *cSIDriverLister) GetWithContext(ctx context.Context, name string) (*v1beta1.CSIDriver, error) {
 	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/storage/v1beta1/csinode.go
+++ b/staging/src/k8s.io/client-go/listers/storage/v1beta1/csinode.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1beta1
 
 import (
-	"context"
-
 	v1beta1 "k8s.io/api/storage/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,15 +31,9 @@ type CSINodeLister interface {
 	// List lists all CSINodes in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1beta1.CSINode, err error)
-	// ListWithContext lists all CSINodes in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.CSINode, err error)
 	// Get retrieves the CSINode from the index for a given name.
 	// Objects returned here must be treated as read-only.
 	Get(name string) (*v1beta1.CSINode, error)
-	// GetWithContext retrieves the CSINode from the index for a given name.
-	// Objects returned here must be treated as read-only.
-	GetWithContext(ctx context.Context, name string) (*v1beta1.CSINode, error)
 	CSINodeListerExpansion
 }
 
@@ -57,11 +49,6 @@ func NewCSINodeLister(indexer cache.Indexer) CSINodeLister {
 
 // List lists all CSINodes in the indexer.
 func (s *cSINodeLister) List(selector labels.Selector) (ret []*v1beta1.CSINode, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all CSINodes in the indexer.
-func (s *cSINodeLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.CSINode, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1beta1.CSINode))
 	})
@@ -70,11 +57,6 @@ func (s *cSINodeLister) ListWithContext(ctx context.Context, selector labels.Sel
 
 // Get retrieves the CSINode from the index for a given name.
 func (s *cSINodeLister) Get(name string) (*v1beta1.CSINode, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the CSINode from the index for a given name.
-func (s *cSINodeLister) GetWithContext(ctx context.Context, name string) (*v1beta1.CSINode, error) {
 	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/storage/v1beta1/csistoragecapacity.go
+++ b/staging/src/k8s.io/client-go/listers/storage/v1beta1/csistoragecapacity.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1beta1
 
 import (
-	"context"
-
 	v1beta1 "k8s.io/api/storage/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,9 +31,6 @@ type CSIStorageCapacityLister interface {
 	// List lists all CSIStorageCapacities in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1beta1.CSIStorageCapacity, err error)
-	// ListWithContext lists all CSIStorageCapacities in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.CSIStorageCapacity, err error)
 	// CSIStorageCapacities returns an object that can list and get CSIStorageCapacities.
 	CSIStorageCapacities(namespace string) CSIStorageCapacityNamespaceLister
 	CSIStorageCapacityListerExpansion
@@ -53,11 +48,6 @@ func NewCSIStorageCapacityLister(indexer cache.Indexer) CSIStorageCapacityLister
 
 // List lists all CSIStorageCapacities in the indexer.
 func (s *cSIStorageCapacityLister) List(selector labels.Selector) (ret []*v1beta1.CSIStorageCapacity, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all CSIStorageCapacities in the indexer.
-func (s *cSIStorageCapacityLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.CSIStorageCapacity, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1beta1.CSIStorageCapacity))
 	})
@@ -90,11 +80,6 @@ type cSIStorageCapacityNamespaceLister struct {
 
 // List lists all CSIStorageCapacities in the indexer for a given namespace.
 func (s cSIStorageCapacityNamespaceLister) List(selector labels.Selector) (ret []*v1beta1.CSIStorageCapacity, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all CSIStorageCapacities in the indexer for a given namespace.
-func (s cSIStorageCapacityNamespaceLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.CSIStorageCapacity, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1beta1.CSIStorageCapacity))
 	})
@@ -103,11 +88,6 @@ func (s cSIStorageCapacityNamespaceLister) ListWithContext(ctx context.Context, 
 
 // Get retrieves the CSIStorageCapacity from the indexer for a given namespace and name.
 func (s cSIStorageCapacityNamespaceLister) Get(name string) (*v1beta1.CSIStorageCapacity, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the CSIStorageCapacity from the indexer for a given namespace and name.
-func (s cSIStorageCapacityNamespaceLister) GetWithContext(ctx context.Context, name string) (*v1beta1.CSIStorageCapacity, error) {
 	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/storage/v1beta1/storageclass.go
+++ b/staging/src/k8s.io/client-go/listers/storage/v1beta1/storageclass.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1beta1
 
 import (
-	"context"
-
 	v1beta1 "k8s.io/api/storage/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,15 +31,9 @@ type StorageClassLister interface {
 	// List lists all StorageClasses in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1beta1.StorageClass, err error)
-	// ListWithContext lists all StorageClasses in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.StorageClass, err error)
 	// Get retrieves the StorageClass from the index for a given name.
 	// Objects returned here must be treated as read-only.
 	Get(name string) (*v1beta1.StorageClass, error)
-	// GetWithContext retrieves the StorageClass from the index for a given name.
-	// Objects returned here must be treated as read-only.
-	GetWithContext(ctx context.Context, name string) (*v1beta1.StorageClass, error)
 	StorageClassListerExpansion
 }
 
@@ -57,11 +49,6 @@ func NewStorageClassLister(indexer cache.Indexer) StorageClassLister {
 
 // List lists all StorageClasses in the indexer.
 func (s *storageClassLister) List(selector labels.Selector) (ret []*v1beta1.StorageClass, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all StorageClasses in the indexer.
-func (s *storageClassLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.StorageClass, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1beta1.StorageClass))
 	})
@@ -70,11 +57,6 @@ func (s *storageClassLister) ListWithContext(ctx context.Context, selector label
 
 // Get retrieves the StorageClass from the index for a given name.
 func (s *storageClassLister) Get(name string) (*v1beta1.StorageClass, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the StorageClass from the index for a given name.
-func (s *storageClassLister) GetWithContext(ctx context.Context, name string) (*v1beta1.StorageClass, error) {
 	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/listers/storage/v1beta1/volumeattachment.go
+++ b/staging/src/k8s.io/client-go/listers/storage/v1beta1/volumeattachment.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1beta1
 
 import (
-	"context"
-
 	v1beta1 "k8s.io/api/storage/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,15 +31,9 @@ type VolumeAttachmentLister interface {
 	// List lists all VolumeAttachments in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1beta1.VolumeAttachment, err error)
-	// ListWithContext lists all VolumeAttachments in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.VolumeAttachment, err error)
 	// Get retrieves the VolumeAttachment from the index for a given name.
 	// Objects returned here must be treated as read-only.
 	Get(name string) (*v1beta1.VolumeAttachment, error)
-	// GetWithContext retrieves the VolumeAttachment from the index for a given name.
-	// Objects returned here must be treated as read-only.
-	GetWithContext(ctx context.Context, name string) (*v1beta1.VolumeAttachment, error)
 	VolumeAttachmentListerExpansion
 }
 
@@ -57,11 +49,6 @@ func NewVolumeAttachmentLister(indexer cache.Indexer) VolumeAttachmentLister {
 
 // List lists all VolumeAttachments in the indexer.
 func (s *volumeAttachmentLister) List(selector labels.Selector) (ret []*v1beta1.VolumeAttachment, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all VolumeAttachments in the indexer.
-func (s *volumeAttachmentLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.VolumeAttachment, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1beta1.VolumeAttachment))
 	})
@@ -70,11 +57,6 @@ func (s *volumeAttachmentLister) ListWithContext(ctx context.Context, selector l
 
 // Get retrieves the VolumeAttachment from the index for a given name.
 func (s *volumeAttachmentLister) Get(name string) (*v1beta1.VolumeAttachment, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the VolumeAttachment from the index for a given name.
-func (s *volumeAttachmentLister) GetWithContext(ctx context.Context, name string) (*v1beta1.VolumeAttachment, error) {
 	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/code-generator/cmd/lister-gen/generators/lister.go
+++ b/staging/src/k8s.io/code-generator/cmd/lister-gen/generators/lister.go
@@ -214,9 +214,6 @@ func (g *listerGenerator) Imports(c *generator.Context) (imports []string) {
 	imports = append(imports, "k8s.io/apimachinery/pkg/labels")
 	// for Indexer
 	imports = append(imports, "k8s.io/client-go/tools/cache")
-
-	imports = append(imports, "context")
-
 	return
 }
 
@@ -244,11 +241,9 @@ func (g *listerGenerator) GenerateType(c *generator.Context, t *types.Type, w io
 	sw.Do(typeListerStruct, m)
 	sw.Do(typeListerConstructor, m)
 	sw.Do(typeLister_List, m)
-	sw.Do(typeLister_ListWithContext, m)
 
 	if tags.NonNamespaced {
 		sw.Do(typeLister_NonNamespacedGet, m)
-		sw.Do(typeLister_NonNamespacedGetWithContext, m)
 		return sw.Error()
 	}
 
@@ -256,9 +251,7 @@ func (g *listerGenerator) GenerateType(c *generator.Context, t *types.Type, w io
 	sw.Do(namespaceListerInterface, m)
 	sw.Do(namespaceListerStruct, m)
 	sw.Do(namespaceLister_List, m)
-	sw.Do(namespaceLister_ListWithContext, m)
 	sw.Do(namespaceLister_Get, m)
-	sw.Do(namespaceLister_GetWithContext, m)
 
 	return sw.Error()
 }
@@ -270,9 +263,6 @@ type $.type|public$Lister interface {
 	// List lists all $.type|publicPlural$ in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*$.type|raw$, err error)
-	// ListWithContext lists all $.type|publicPlural$ in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*$.type|raw$, err error)
 	// $.type|publicPlural$ returns an object that can list and get $.type|publicPlural$.
 	$.type|publicPlural$(namespace string) $.type|public$NamespaceLister
 	$.type|public$ListerExpansion
@@ -286,15 +276,9 @@ type $.type|public$Lister interface {
 	// List lists all $.type|publicPlural$ in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*$.type|raw$, err error)
-	// ListWithContext lists all $.type|publicPlural$ in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*$.type|raw$, err error)
 	// Get retrieves the $.type|public$ from the index for a given name.
 	// Objects returned here must be treated as read-only.
 	Get(name string) (*$.type|raw$, error)
-	// GetWithContext retrieves the $.type|public$ from the index for a given name.
-	// Objects returned here must be treated as read-only.
-	GetWithContext(ctx context.Context, name string) (*$.type|raw$, error)
 	$.type|public$ListerExpansion
 }
 `
@@ -313,20 +297,13 @@ func New$.type|public$Lister(indexer cache.Indexer) $.type|public$Lister {
 }
 `
 
-var typeLister_ListWithContext = `
-// ListWithContext lists all $.type|publicPlural$ in the indexer.
-func (s *$.type|private$Lister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*$.type|raw$, err error) {
+var typeLister_List = `
+// List lists all $.type|publicPlural$ in the indexer.
+func (s *$.type|private$Lister) List(selector labels.Selector) (ret []*$.type|raw$, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*$.type|raw$))
 	})
 	return ret, err
-}
-`
-
-var typeLister_List = `
-// List lists all $.type|publicPlural$ in the indexer.
-func (s *$.type|private$Lister) List(selector labels.Selector) (ret []*$.type|raw$, err error) {
-	return s.ListWithContext(context.Background(), selector)
 }
 `
 
@@ -337,9 +314,9 @@ func (s *$.type|private$Lister) $.type|publicPlural$(namespace string) $.type|pu
 }
 `
 
-var typeLister_NonNamespacedGetWithContext = `
-// GetWithContext retrieves the $.type|public$ from the index for a given name.
-func (s *$.type|private$Lister) GetWithContext(ctx context.Context, name string) (*$.type|raw$, error) {
+var typeLister_NonNamespacedGet = `
+// Get retrieves the $.type|public$ from the index for a given name.
+func (s *$.type|private$Lister) Get(name string) (*$.type|raw$, error) {
   obj, exists, err := s.indexer.GetByKey(name)
   if err != nil {
     return nil, err
@@ -348,13 +325,6 @@ func (s *$.type|private$Lister) GetWithContext(ctx context.Context, name string)
     return nil, errors.NewNotFound($.Resource|raw$("$.type|lowercaseSingular$"), name)
   }
   return obj.(*$.type|raw$), nil
-}
-`
-
-var typeLister_NonNamespacedGet = `
-// Get retrieves the $.type|public$ from the index for a given name.
-func (s *$.type|private$Lister) Get(name string) (*$.type|raw$, error) {
-	return s.GetWithContext(context.Background(), name)
 }
 `
 
@@ -381,9 +351,9 @@ type $.type|private$NamespaceLister struct {
 }
 `
 
-var namespaceLister_ListWithContext = `
-// ListWithContext lists all $.type|publicPlural$ in the indexer for a given namespace.
-func (s $.type|private$NamespaceLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*$.type|raw$, err error) {
+var namespaceLister_List = `
+// List lists all $.type|publicPlural$ in the indexer for a given namespace.
+func (s $.type|private$NamespaceLister) List(selector labels.Selector) (ret []*$.type|raw$, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
 		ret = append(ret, m.(*$.type|raw$))
 	})
@@ -391,16 +361,9 @@ func (s $.type|private$NamespaceLister) ListWithContext(ctx context.Context, sel
 }
 `
 
-var namespaceLister_List = `
-// List lists all $.type|publicPlural$ in the indexer for a given namespace.
-func (s $.type|private$NamespaceLister) List(selector labels.Selector) (ret []*$.type|raw$, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-`
-
-var namespaceLister_GetWithContext = `
-// GetWithContext retrieves the $.type|public$ from the indexer for a given namespace and name.
-func (s $.type|private$NamespaceLister) GetWithContext(ctx context.Context, name string) (*$.type|raw$, error) {
+var namespaceLister_Get = `
+// Get retrieves the $.type|public$ from the indexer for a given namespace and name.
+func (s $.type|private$NamespaceLister) Get(name string) (*$.type|raw$, error) {
 	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
 	if err != nil {
 		return nil, err
@@ -409,11 +372,5 @@ func (s $.type|private$NamespaceLister) GetWithContext(ctx context.Context, name
 		return nil, errors.NewNotFound($.Resource|raw$("$.type|lowercaseSingular$"), name)
 	}
 	return obj.(*$.type|raw$), nil
-}
-`
-var namespaceLister_Get = `
-// Get retrieves the $.type|public$ from the indexer for a given namespace and name.
-func (s $.type|private$NamespaceLister) Get(name string) (*$.type|raw$, error) {
-	return s.GetWithContext(context.Background(), name)
 }
 `

--- a/staging/src/k8s.io/code-generator/examples/HyphenGroup/listers/example/v1/clustertesttype.go
+++ b/staging/src/k8s.io/code-generator/examples/HyphenGroup/listers/example/v1/clustertesttype.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1
 
 import (
-	"context"
-
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
@@ -33,15 +31,9 @@ type ClusterTestTypeLister interface {
 	// List lists all ClusterTestTypes in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1.ClusterTestType, err error)
-	// ListWithContext lists all ClusterTestTypes in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.ClusterTestType, err error)
 	// Get retrieves the ClusterTestType from the index for a given name.
 	// Objects returned here must be treated as read-only.
 	Get(name string) (*v1.ClusterTestType, error)
-	// GetWithContext retrieves the ClusterTestType from the index for a given name.
-	// Objects returned here must be treated as read-only.
-	GetWithContext(ctx context.Context, name string) (*v1.ClusterTestType, error)
 	ClusterTestTypeListerExpansion
 }
 
@@ -57,11 +49,6 @@ func NewClusterTestTypeLister(indexer cache.Indexer) ClusterTestTypeLister {
 
 // List lists all ClusterTestTypes in the indexer.
 func (s *clusterTestTypeLister) List(selector labels.Selector) (ret []*v1.ClusterTestType, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all ClusterTestTypes in the indexer.
-func (s *clusterTestTypeLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.ClusterTestType, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.ClusterTestType))
 	})
@@ -70,11 +57,6 @@ func (s *clusterTestTypeLister) ListWithContext(ctx context.Context, selector la
 
 // Get retrieves the ClusterTestType from the index for a given name.
 func (s *clusterTestTypeLister) Get(name string) (*v1.ClusterTestType, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the ClusterTestType from the index for a given name.
-func (s *clusterTestTypeLister) GetWithContext(ctx context.Context, name string) (*v1.ClusterTestType, error) {
 	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/code-generator/examples/HyphenGroup/listers/example/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/HyphenGroup/listers/example/v1/testtype.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1
 
 import (
-	"context"
-
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
@@ -33,9 +31,6 @@ type TestTypeLister interface {
 	// List lists all TestTypes in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1.TestType, err error)
-	// ListWithContext lists all TestTypes in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.TestType, err error)
 	// TestTypes returns an object that can list and get TestTypes.
 	TestTypes(namespace string) TestTypeNamespaceLister
 	TestTypeListerExpansion
@@ -53,11 +48,6 @@ func NewTestTypeLister(indexer cache.Indexer) TestTypeLister {
 
 // List lists all TestTypes in the indexer.
 func (s *testTypeLister) List(selector labels.Selector) (ret []*v1.TestType, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all TestTypes in the indexer.
-func (s *testTypeLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.TestType, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.TestType))
 	})
@@ -90,11 +80,6 @@ type testTypeNamespaceLister struct {
 
 // List lists all TestTypes in the indexer for a given namespace.
 func (s testTypeNamespaceLister) List(selector labels.Selector) (ret []*v1.TestType, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all TestTypes in the indexer for a given namespace.
-func (s testTypeNamespaceLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.TestType, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.TestType))
 	})
@@ -103,11 +88,6 @@ func (s testTypeNamespaceLister) ListWithContext(ctx context.Context, selector l
 
 // Get retrieves the TestType from the indexer for a given namespace and name.
 func (s testTypeNamespaceLister) Get(name string) (*v1.TestType, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the TestType from the indexer for a given namespace and name.
-func (s testTypeNamespaceLister) GetWithContext(ctx context.Context, name string) (*v1.TestType, error) {
 	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/code-generator/examples/MixedCase/listers/example/v1/clustertesttype.go
+++ b/staging/src/k8s.io/code-generator/examples/MixedCase/listers/example/v1/clustertesttype.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1
 
 import (
-	"context"
-
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
@@ -33,15 +31,9 @@ type ClusterTestTypeLister interface {
 	// List lists all ClusterTestTypes in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1.ClusterTestType, err error)
-	// ListWithContext lists all ClusterTestTypes in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.ClusterTestType, err error)
 	// Get retrieves the ClusterTestType from the index for a given name.
 	// Objects returned here must be treated as read-only.
 	Get(name string) (*v1.ClusterTestType, error)
-	// GetWithContext retrieves the ClusterTestType from the index for a given name.
-	// Objects returned here must be treated as read-only.
-	GetWithContext(ctx context.Context, name string) (*v1.ClusterTestType, error)
 	ClusterTestTypeListerExpansion
 }
 
@@ -57,11 +49,6 @@ func NewClusterTestTypeLister(indexer cache.Indexer) ClusterTestTypeLister {
 
 // List lists all ClusterTestTypes in the indexer.
 func (s *clusterTestTypeLister) List(selector labels.Selector) (ret []*v1.ClusterTestType, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all ClusterTestTypes in the indexer.
-func (s *clusterTestTypeLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.ClusterTestType, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.ClusterTestType))
 	})
@@ -70,11 +57,6 @@ func (s *clusterTestTypeLister) ListWithContext(ctx context.Context, selector la
 
 // Get retrieves the ClusterTestType from the index for a given name.
 func (s *clusterTestTypeLister) Get(name string) (*v1.ClusterTestType, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the ClusterTestType from the index for a given name.
-func (s *clusterTestTypeLister) GetWithContext(ctx context.Context, name string) (*v1.ClusterTestType, error) {
 	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/code-generator/examples/MixedCase/listers/example/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/MixedCase/listers/example/v1/testtype.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1
 
 import (
-	"context"
-
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
@@ -33,9 +31,6 @@ type TestTypeLister interface {
 	// List lists all TestTypes in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1.TestType, err error)
-	// ListWithContext lists all TestTypes in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.TestType, err error)
 	// TestTypes returns an object that can list and get TestTypes.
 	TestTypes(namespace string) TestTypeNamespaceLister
 	TestTypeListerExpansion
@@ -53,11 +48,6 @@ func NewTestTypeLister(indexer cache.Indexer) TestTypeLister {
 
 // List lists all TestTypes in the indexer.
 func (s *testTypeLister) List(selector labels.Selector) (ret []*v1.TestType, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all TestTypes in the indexer.
-func (s *testTypeLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.TestType, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.TestType))
 	})
@@ -90,11 +80,6 @@ type testTypeNamespaceLister struct {
 
 // List lists all TestTypes in the indexer for a given namespace.
 func (s testTypeNamespaceLister) List(selector labels.Selector) (ret []*v1.TestType, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all TestTypes in the indexer for a given namespace.
-func (s testTypeNamespaceLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.TestType, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.TestType))
 	})
@@ -103,11 +88,6 @@ func (s testTypeNamespaceLister) ListWithContext(ctx context.Context, selector l
 
 // Get retrieves the TestType from the indexer for a given namespace and name.
 func (s testTypeNamespaceLister) Get(name string) (*v1.TestType, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the TestType from the indexer for a given namespace and name.
-func (s testTypeNamespaceLister) GetWithContext(ctx context.Context, name string) (*v1.TestType, error) {
 	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/code-generator/examples/apiserver/listers/example/internalversion/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/listers/example/internalversion/testtype.go
@@ -19,8 +19,6 @@ limitations under the License.
 package internalversion
 
 import (
-	"context"
-
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
@@ -33,9 +31,6 @@ type TestTypeLister interface {
 	// List lists all TestTypes in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*example.TestType, err error)
-	// ListWithContext lists all TestTypes in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*example.TestType, err error)
 	// TestTypes returns an object that can list and get TestTypes.
 	TestTypes(namespace string) TestTypeNamespaceLister
 	TestTypeListerExpansion
@@ -53,11 +48,6 @@ func NewTestTypeLister(indexer cache.Indexer) TestTypeLister {
 
 // List lists all TestTypes in the indexer.
 func (s *testTypeLister) List(selector labels.Selector) (ret []*example.TestType, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all TestTypes in the indexer.
-func (s *testTypeLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*example.TestType, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*example.TestType))
 	})
@@ -90,11 +80,6 @@ type testTypeNamespaceLister struct {
 
 // List lists all TestTypes in the indexer for a given namespace.
 func (s testTypeNamespaceLister) List(selector labels.Selector) (ret []*example.TestType, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all TestTypes in the indexer for a given namespace.
-func (s testTypeNamespaceLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*example.TestType, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
 		ret = append(ret, m.(*example.TestType))
 	})
@@ -103,11 +88,6 @@ func (s testTypeNamespaceLister) ListWithContext(ctx context.Context, selector l
 
 // Get retrieves the TestType from the indexer for a given namespace and name.
 func (s testTypeNamespaceLister) Get(name string) (*example.TestType, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the TestType from the indexer for a given namespace and name.
-func (s testTypeNamespaceLister) GetWithContext(ctx context.Context, name string) (*example.TestType, error) {
 	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/code-generator/examples/apiserver/listers/example/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/listers/example/v1/testtype.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1
 
 import (
-	"context"
-
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
@@ -33,9 +31,6 @@ type TestTypeLister interface {
 	// List lists all TestTypes in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1.TestType, err error)
-	// ListWithContext lists all TestTypes in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.TestType, err error)
 	// TestTypes returns an object that can list and get TestTypes.
 	TestTypes(namespace string) TestTypeNamespaceLister
 	TestTypeListerExpansion
@@ -53,11 +48,6 @@ func NewTestTypeLister(indexer cache.Indexer) TestTypeLister {
 
 // List lists all TestTypes in the indexer.
 func (s *testTypeLister) List(selector labels.Selector) (ret []*v1.TestType, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all TestTypes in the indexer.
-func (s *testTypeLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.TestType, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.TestType))
 	})
@@ -90,11 +80,6 @@ type testTypeNamespaceLister struct {
 
 // List lists all TestTypes in the indexer for a given namespace.
 func (s testTypeNamespaceLister) List(selector labels.Selector) (ret []*v1.TestType, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all TestTypes in the indexer for a given namespace.
-func (s testTypeNamespaceLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.TestType, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.TestType))
 	})
@@ -103,11 +88,6 @@ func (s testTypeNamespaceLister) ListWithContext(ctx context.Context, selector l
 
 // Get retrieves the TestType from the indexer for a given namespace and name.
 func (s testTypeNamespaceLister) Get(name string) (*v1.TestType, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the TestType from the indexer for a given namespace and name.
-func (s testTypeNamespaceLister) GetWithContext(ctx context.Context, name string) (*v1.TestType, error) {
 	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/code-generator/examples/apiserver/listers/example2/internalversion/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/listers/example2/internalversion/testtype.go
@@ -19,8 +19,6 @@ limitations under the License.
 package internalversion
 
 import (
-	"context"
-
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
@@ -33,15 +31,9 @@ type TestTypeLister interface {
 	// List lists all TestTypes in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*example2.TestType, err error)
-	// ListWithContext lists all TestTypes in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*example2.TestType, err error)
 	// Get retrieves the TestType from the index for a given name.
 	// Objects returned here must be treated as read-only.
 	Get(name string) (*example2.TestType, error)
-	// GetWithContext retrieves the TestType from the index for a given name.
-	// Objects returned here must be treated as read-only.
-	GetWithContext(ctx context.Context, name string) (*example2.TestType, error)
 	TestTypeListerExpansion
 }
 
@@ -57,11 +49,6 @@ func NewTestTypeLister(indexer cache.Indexer) TestTypeLister {
 
 // List lists all TestTypes in the indexer.
 func (s *testTypeLister) List(selector labels.Selector) (ret []*example2.TestType, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all TestTypes in the indexer.
-func (s *testTypeLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*example2.TestType, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*example2.TestType))
 	})
@@ -70,11 +57,6 @@ func (s *testTypeLister) ListWithContext(ctx context.Context, selector labels.Se
 
 // Get retrieves the TestType from the index for a given name.
 func (s *testTypeLister) Get(name string) (*example2.TestType, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the TestType from the index for a given name.
-func (s *testTypeLister) GetWithContext(ctx context.Context, name string) (*example2.TestType, error) {
 	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/code-generator/examples/apiserver/listers/example2/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/listers/example2/v1/testtype.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1
 
 import (
-	"context"
-
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
@@ -33,9 +31,6 @@ type TestTypeLister interface {
 	// List lists all TestTypes in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1.TestType, err error)
-	// ListWithContext lists all TestTypes in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.TestType, err error)
 	// TestTypes returns an object that can list and get TestTypes.
 	TestTypes(namespace string) TestTypeNamespaceLister
 	TestTypeListerExpansion
@@ -53,11 +48,6 @@ func NewTestTypeLister(indexer cache.Indexer) TestTypeLister {
 
 // List lists all TestTypes in the indexer.
 func (s *testTypeLister) List(selector labels.Selector) (ret []*v1.TestType, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all TestTypes in the indexer.
-func (s *testTypeLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.TestType, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.TestType))
 	})
@@ -90,11 +80,6 @@ type testTypeNamespaceLister struct {
 
 // List lists all TestTypes in the indexer for a given namespace.
 func (s testTypeNamespaceLister) List(selector labels.Selector) (ret []*v1.TestType, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all TestTypes in the indexer for a given namespace.
-func (s testTypeNamespaceLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.TestType, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.TestType))
 	})
@@ -103,11 +88,6 @@ func (s testTypeNamespaceLister) ListWithContext(ctx context.Context, selector l
 
 // Get retrieves the TestType from the indexer for a given namespace and name.
 func (s testTypeNamespaceLister) Get(name string) (*v1.TestType, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the TestType from the indexer for a given namespace and name.
-func (s testTypeNamespaceLister) GetWithContext(ctx context.Context, name string) (*v1.TestType, error) {
 	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/code-generator/examples/apiserver/listers/example3.io/internalversion/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/listers/example3.io/internalversion/testtype.go
@@ -19,8 +19,6 @@ limitations under the License.
 package internalversion
 
 import (
-	"context"
-
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
@@ -33,9 +31,6 @@ type TestTypeLister interface {
 	// List lists all TestTypes in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*example3io.TestType, err error)
-	// ListWithContext lists all TestTypes in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*example3io.TestType, err error)
 	// TestTypes returns an object that can list and get TestTypes.
 	TestTypes(namespace string) TestTypeNamespaceLister
 	TestTypeListerExpansion
@@ -53,11 +48,6 @@ func NewTestTypeLister(indexer cache.Indexer) TestTypeLister {
 
 // List lists all TestTypes in the indexer.
 func (s *testTypeLister) List(selector labels.Selector) (ret []*example3io.TestType, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all TestTypes in the indexer.
-func (s *testTypeLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*example3io.TestType, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*example3io.TestType))
 	})
@@ -90,11 +80,6 @@ type testTypeNamespaceLister struct {
 
 // List lists all TestTypes in the indexer for a given namespace.
 func (s testTypeNamespaceLister) List(selector labels.Selector) (ret []*example3io.TestType, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all TestTypes in the indexer for a given namespace.
-func (s testTypeNamespaceLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*example3io.TestType, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
 		ret = append(ret, m.(*example3io.TestType))
 	})
@@ -103,11 +88,6 @@ func (s testTypeNamespaceLister) ListWithContext(ctx context.Context, selector l
 
 // Get retrieves the TestType from the indexer for a given namespace and name.
 func (s testTypeNamespaceLister) Get(name string) (*example3io.TestType, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the TestType from the indexer for a given namespace and name.
-func (s testTypeNamespaceLister) GetWithContext(ctx context.Context, name string) (*example3io.TestType, error) {
 	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/code-generator/examples/apiserver/listers/example3.io/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/listers/example3.io/v1/testtype.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1
 
 import (
-	"context"
-
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
@@ -33,9 +31,6 @@ type TestTypeLister interface {
 	// List lists all TestTypes in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1.TestType, err error)
-	// ListWithContext lists all TestTypes in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.TestType, err error)
 	// TestTypes returns an object that can list and get TestTypes.
 	TestTypes(namespace string) TestTypeNamespaceLister
 	TestTypeListerExpansion
@@ -53,11 +48,6 @@ func NewTestTypeLister(indexer cache.Indexer) TestTypeLister {
 
 // List lists all TestTypes in the indexer.
 func (s *testTypeLister) List(selector labels.Selector) (ret []*v1.TestType, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all TestTypes in the indexer.
-func (s *testTypeLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.TestType, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.TestType))
 	})
@@ -90,11 +80,6 @@ type testTypeNamespaceLister struct {
 
 // List lists all TestTypes in the indexer for a given namespace.
 func (s testTypeNamespaceLister) List(selector labels.Selector) (ret []*v1.TestType, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all TestTypes in the indexer for a given namespace.
-func (s testTypeNamespaceLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.TestType, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.TestType))
 	})
@@ -103,11 +88,6 @@ func (s testTypeNamespaceLister) ListWithContext(ctx context.Context, selector l
 
 // Get retrieves the TestType from the indexer for a given namespace and name.
 func (s testTypeNamespaceLister) Get(name string) (*v1.TestType, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the TestType from the indexer for a given namespace and name.
-func (s testTypeNamespaceLister) GetWithContext(ctx context.Context, name string) (*v1.TestType, error) {
 	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/code-generator/examples/crd/listers/example/v1/clustertesttype.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/listers/example/v1/clustertesttype.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1
 
 import (
-	"context"
-
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
@@ -33,15 +31,9 @@ type ClusterTestTypeLister interface {
 	// List lists all ClusterTestTypes in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1.ClusterTestType, err error)
-	// ListWithContext lists all ClusterTestTypes in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.ClusterTestType, err error)
 	// Get retrieves the ClusterTestType from the index for a given name.
 	// Objects returned here must be treated as read-only.
 	Get(name string) (*v1.ClusterTestType, error)
-	// GetWithContext retrieves the ClusterTestType from the index for a given name.
-	// Objects returned here must be treated as read-only.
-	GetWithContext(ctx context.Context, name string) (*v1.ClusterTestType, error)
 	ClusterTestTypeListerExpansion
 }
 
@@ -57,11 +49,6 @@ func NewClusterTestTypeLister(indexer cache.Indexer) ClusterTestTypeLister {
 
 // List lists all ClusterTestTypes in the indexer.
 func (s *clusterTestTypeLister) List(selector labels.Selector) (ret []*v1.ClusterTestType, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all ClusterTestTypes in the indexer.
-func (s *clusterTestTypeLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.ClusterTestType, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.ClusterTestType))
 	})
@@ -70,11 +57,6 @@ func (s *clusterTestTypeLister) ListWithContext(ctx context.Context, selector la
 
 // Get retrieves the ClusterTestType from the index for a given name.
 func (s *clusterTestTypeLister) Get(name string) (*v1.ClusterTestType, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the ClusterTestType from the index for a given name.
-func (s *clusterTestTypeLister) GetWithContext(ctx context.Context, name string) (*v1.ClusterTestType, error) {
 	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/code-generator/examples/crd/listers/example/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/listers/example/v1/testtype.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1
 
 import (
-	"context"
-
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
@@ -33,9 +31,6 @@ type TestTypeLister interface {
 	// List lists all TestTypes in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1.TestType, err error)
-	// ListWithContext lists all TestTypes in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.TestType, err error)
 	// TestTypes returns an object that can list and get TestTypes.
 	TestTypes(namespace string) TestTypeNamespaceLister
 	TestTypeListerExpansion
@@ -53,11 +48,6 @@ func NewTestTypeLister(indexer cache.Indexer) TestTypeLister {
 
 // List lists all TestTypes in the indexer.
 func (s *testTypeLister) List(selector labels.Selector) (ret []*v1.TestType, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all TestTypes in the indexer.
-func (s *testTypeLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.TestType, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.TestType))
 	})
@@ -90,11 +80,6 @@ type testTypeNamespaceLister struct {
 
 // List lists all TestTypes in the indexer for a given namespace.
 func (s testTypeNamespaceLister) List(selector labels.Selector) (ret []*v1.TestType, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all TestTypes in the indexer for a given namespace.
-func (s testTypeNamespaceLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.TestType, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.TestType))
 	})
@@ -103,11 +88,6 @@ func (s testTypeNamespaceLister) ListWithContext(ctx context.Context, selector l
 
 // Get retrieves the TestType from the indexer for a given namespace and name.
 func (s testTypeNamespaceLister) Get(name string) (*v1.TestType, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the TestType from the indexer for a given namespace and name.
-func (s testTypeNamespaceLister) GetWithContext(ctx context.Context, name string) (*v1.TestType, error) {
 	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/code-generator/examples/crd/listers/example2/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/listers/example2/v1/testtype.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1
 
 import (
-	"context"
-
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
@@ -33,9 +31,6 @@ type TestTypeLister interface {
 	// List lists all TestTypes in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1.TestType, err error)
-	// ListWithContext lists all TestTypes in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.TestType, err error)
 	// TestTypes returns an object that can list and get TestTypes.
 	TestTypes(namespace string) TestTypeNamespaceLister
 	TestTypeListerExpansion
@@ -53,11 +48,6 @@ func NewTestTypeLister(indexer cache.Indexer) TestTypeLister {
 
 // List lists all TestTypes in the indexer.
 func (s *testTypeLister) List(selector labels.Selector) (ret []*v1.TestType, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all TestTypes in the indexer.
-func (s *testTypeLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.TestType, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.TestType))
 	})
@@ -90,11 +80,6 @@ type testTypeNamespaceLister struct {
 
 // List lists all TestTypes in the indexer for a given namespace.
 func (s testTypeNamespaceLister) List(selector labels.Selector) (ret []*v1.TestType, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all TestTypes in the indexer for a given namespace.
-func (s testTypeNamespaceLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.TestType, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.TestType))
 	})
@@ -103,11 +88,6 @@ func (s testTypeNamespaceLister) ListWithContext(ctx context.Context, selector l
 
 // Get retrieves the TestType from the indexer for a given namespace and name.
 func (s testTypeNamespaceLister) Get(name string) (*v1.TestType, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the TestType from the indexer for a given namespace and name.
-func (s testTypeNamespaceLister) GetWithContext(ctx context.Context, name string) (*v1.TestType, error) {
 	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/listers/apiregistration/v1/apiservice.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/listers/apiregistration/v1/apiservice.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1
 
 import (
-	"context"
-
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
@@ -33,15 +31,9 @@ type APIServiceLister interface {
 	// List lists all APIServices in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1.APIService, err error)
-	// ListWithContext lists all APIServices in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.APIService, err error)
 	// Get retrieves the APIService from the index for a given name.
 	// Objects returned here must be treated as read-only.
 	Get(name string) (*v1.APIService, error)
-	// GetWithContext retrieves the APIService from the index for a given name.
-	// Objects returned here must be treated as read-only.
-	GetWithContext(ctx context.Context, name string) (*v1.APIService, error)
 	APIServiceListerExpansion
 }
 
@@ -57,11 +49,6 @@ func NewAPIServiceLister(indexer cache.Indexer) APIServiceLister {
 
 // List lists all APIServices in the indexer.
 func (s *aPIServiceLister) List(selector labels.Selector) (ret []*v1.APIService, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all APIServices in the indexer.
-func (s *aPIServiceLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1.APIService, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.APIService))
 	})
@@ -70,11 +57,6 @@ func (s *aPIServiceLister) ListWithContext(ctx context.Context, selector labels.
 
 // Get retrieves the APIService from the index for a given name.
 func (s *aPIServiceLister) Get(name string) (*v1.APIService, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the APIService from the index for a given name.
-func (s *aPIServiceLister) GetWithContext(ctx context.Context, name string) (*v1.APIService, error) {
 	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/listers/apiregistration/v1beta1/apiservice.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/listers/apiregistration/v1beta1/apiservice.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1beta1
 
 import (
-	"context"
-
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
@@ -33,15 +31,9 @@ type APIServiceLister interface {
 	// List lists all APIServices in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1beta1.APIService, err error)
-	// ListWithContext lists all APIServices in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.APIService, err error)
 	// Get retrieves the APIService from the index for a given name.
 	// Objects returned here must be treated as read-only.
 	Get(name string) (*v1beta1.APIService, error)
-	// GetWithContext retrieves the APIService from the index for a given name.
-	// Objects returned here must be treated as read-only.
-	GetWithContext(ctx context.Context, name string) (*v1beta1.APIService, error)
 	APIServiceListerExpansion
 }
 
@@ -57,11 +49,6 @@ func NewAPIServiceLister(indexer cache.Indexer) APIServiceLister {
 
 // List lists all APIServices in the indexer.
 func (s *aPIServiceLister) List(selector labels.Selector) (ret []*v1beta1.APIService, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all APIServices in the indexer.
-func (s *aPIServiceLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.APIService, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1beta1.APIService))
 	})
@@ -70,11 +57,6 @@ func (s *aPIServiceLister) ListWithContext(ctx context.Context, selector labels.
 
 // Get retrieves the APIService from the index for a given name.
 func (s *aPIServiceLister) Get(name string) (*v1beta1.APIService, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the APIService from the index for a given name.
-func (s *aPIServiceLister) GetWithContext(ctx context.Context, name string) (*v1beta1.APIService, error) {
 	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/listers/wardle/v1alpha1/fischer.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/listers/wardle/v1alpha1/fischer.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"context"
-
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
@@ -33,15 +31,9 @@ type FischerLister interface {
 	// List lists all Fischers in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1alpha1.Fischer, err error)
-	// ListWithContext lists all Fischers in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1alpha1.Fischer, err error)
 	// Get retrieves the Fischer from the index for a given name.
 	// Objects returned here must be treated as read-only.
 	Get(name string) (*v1alpha1.Fischer, error)
-	// GetWithContext retrieves the Fischer from the index for a given name.
-	// Objects returned here must be treated as read-only.
-	GetWithContext(ctx context.Context, name string) (*v1alpha1.Fischer, error)
 	FischerListerExpansion
 }
 
@@ -57,11 +49,6 @@ func NewFischerLister(indexer cache.Indexer) FischerLister {
 
 // List lists all Fischers in the indexer.
 func (s *fischerLister) List(selector labels.Selector) (ret []*v1alpha1.Fischer, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all Fischers in the indexer.
-func (s *fischerLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1alpha1.Fischer, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1alpha1.Fischer))
 	})
@@ -70,11 +57,6 @@ func (s *fischerLister) ListWithContext(ctx context.Context, selector labels.Sel
 
 // Get retrieves the Fischer from the index for a given name.
 func (s *fischerLister) Get(name string) (*v1alpha1.Fischer, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the Fischer from the index for a given name.
-func (s *fischerLister) GetWithContext(ctx context.Context, name string) (*v1alpha1.Fischer, error) {
 	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/listers/wardle/v1alpha1/flunder.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/listers/wardle/v1alpha1/flunder.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"context"
-
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
@@ -33,9 +31,6 @@ type FlunderLister interface {
 	// List lists all Flunders in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1alpha1.Flunder, err error)
-	// ListWithContext lists all Flunders in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1alpha1.Flunder, err error)
 	// Flunders returns an object that can list and get Flunders.
 	Flunders(namespace string) FlunderNamespaceLister
 	FlunderListerExpansion
@@ -53,11 +48,6 @@ func NewFlunderLister(indexer cache.Indexer) FlunderLister {
 
 // List lists all Flunders in the indexer.
 func (s *flunderLister) List(selector labels.Selector) (ret []*v1alpha1.Flunder, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all Flunders in the indexer.
-func (s *flunderLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1alpha1.Flunder, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1alpha1.Flunder))
 	})
@@ -90,11 +80,6 @@ type flunderNamespaceLister struct {
 
 // List lists all Flunders in the indexer for a given namespace.
 func (s flunderNamespaceLister) List(selector labels.Selector) (ret []*v1alpha1.Flunder, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all Flunders in the indexer for a given namespace.
-func (s flunderNamespaceLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1alpha1.Flunder, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1alpha1.Flunder))
 	})
@@ -103,11 +88,6 @@ func (s flunderNamespaceLister) ListWithContext(ctx context.Context, selector la
 
 // Get retrieves the Flunder from the indexer for a given namespace and name.
 func (s flunderNamespaceLister) Get(name string) (*v1alpha1.Flunder, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the Flunder from the indexer for a given namespace and name.
-func (s flunderNamespaceLister) GetWithContext(ctx context.Context, name string) (*v1alpha1.Flunder, error) {
 	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/listers/wardle/v1beta1/flunder.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/listers/wardle/v1beta1/flunder.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1beta1
 
 import (
-	"context"
-
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
@@ -33,9 +31,6 @@ type FlunderLister interface {
 	// List lists all Flunders in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1beta1.Flunder, err error)
-	// ListWithContext lists all Flunders in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.Flunder, err error)
 	// Flunders returns an object that can list and get Flunders.
 	Flunders(namespace string) FlunderNamespaceLister
 	FlunderListerExpansion
@@ -53,11 +48,6 @@ func NewFlunderLister(indexer cache.Indexer) FlunderLister {
 
 // List lists all Flunders in the indexer.
 func (s *flunderLister) List(selector labels.Selector) (ret []*v1beta1.Flunder, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all Flunders in the indexer.
-func (s *flunderLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.Flunder, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1beta1.Flunder))
 	})
@@ -90,11 +80,6 @@ type flunderNamespaceLister struct {
 
 // List lists all Flunders in the indexer for a given namespace.
 func (s flunderNamespaceLister) List(selector labels.Selector) (ret []*v1beta1.Flunder, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all Flunders in the indexer for a given namespace.
-func (s flunderNamespaceLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1beta1.Flunder, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1beta1.Flunder))
 	})
@@ -103,11 +88,6 @@ func (s flunderNamespaceLister) ListWithContext(ctx context.Context, selector la
 
 // Get retrieves the Flunder from the indexer for a given namespace and name.
 func (s flunderNamespaceLister) Get(name string) (*v1beta1.Flunder, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the Flunder from the indexer for a given namespace and name.
-func (s flunderNamespaceLister) GetWithContext(ctx context.Context, name string) (*v1beta1.Flunder, error) {
 	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/sample-controller/pkg/generated/listers/samplecontroller/v1alpha1/foo.go
+++ b/staging/src/k8s.io/sample-controller/pkg/generated/listers/samplecontroller/v1alpha1/foo.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"context"
-
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
@@ -33,9 +31,6 @@ type FooLister interface {
 	// List lists all Foos in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1alpha1.Foo, err error)
-	// ListWithContext lists all Foos in the indexer.
-	// Objects returned here must be treated as read-only.
-	ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1alpha1.Foo, err error)
 	// Foos returns an object that can list and get Foos.
 	Foos(namespace string) FooNamespaceLister
 	FooListerExpansion
@@ -53,11 +48,6 @@ func NewFooLister(indexer cache.Indexer) FooLister {
 
 // List lists all Foos in the indexer.
 func (s *fooLister) List(selector labels.Selector) (ret []*v1alpha1.Foo, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all Foos in the indexer.
-func (s *fooLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1alpha1.Foo, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1alpha1.Foo))
 	})
@@ -90,11 +80,6 @@ type fooNamespaceLister struct {
 
 // List lists all Foos in the indexer for a given namespace.
 func (s fooNamespaceLister) List(selector labels.Selector) (ret []*v1alpha1.Foo, err error) {
-	return s.ListWithContext(context.Background(), selector)
-}
-
-// ListWithContext lists all Foos in the indexer for a given namespace.
-func (s fooNamespaceLister) ListWithContext(ctx context.Context, selector labels.Selector) (ret []*v1alpha1.Foo, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1alpha1.Foo))
 	})
@@ -103,11 +88,6 @@ func (s fooNamespaceLister) ListWithContext(ctx context.Context, selector labels
 
 // Get retrieves the Foo from the indexer for a given namespace and name.
 func (s fooNamespaceLister) Get(name string) (*v1alpha1.Foo, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithContext retrieves the Foo from the indexer for a given namespace and name.
-func (s fooNamespaceLister) GetWithContext(ctx context.Context, name string) (*v1alpha1.Foo, error) {
 	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
- HACK(undo): lister-gen: remove lister WithContext methods
- Update codegen
- HACK(undo): remove ListWithContext from hand written lister
- UPSTREAM: <carry>: kcp-aware CRD handling