### PR TITLE
stub out destroy methods for subresource storages

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/etcd.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/etcd.go
@@ -199,6 +199,12 @@ func (r *StatusREST) New() runtime.Object {
 	return r.store.New()
 }
 
+// Destroy cleans up resources on shutdown.
+func (r *StatusREST) Destroy() {
+	// Given that underlying store is shared with REST,
+	// we don't destroy it here explicitly.
+}
+
 // Get retrieves the object from the storage. It is required to support Patch.
 func (r *StatusREST) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
 	o, err := r.store.Get(ctx, name, options)
@@ -243,6 +249,12 @@ func (r *ScaleREST) GroupVersionKind(containingGV schema.GroupVersion) schema.Gr
 // New creates a new Scale object
 func (r *ScaleREST) New() runtime.Object {
 	return &autoscalingv1.Scale{}
+}
+
+// Destroy cleans up resources on shutdown.
+func (r *ScaleREST) Destroy() {
+	// Given that underlying store is shared with REST,
+	// we don't destroy it here explicitly.
 }
 
 func (r *ScaleREST) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {


### PR DESCRIPTION
This makes the subresource storages implement `rest.Storage`, which is required for https://github.com/kcp-dev/kcp/pull/1112