### PR TITLE
UPSTREAM: <carry>: do not klog.Fatal in namespace deletion

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -53,7 +53,7 @@ require (
 	github.com/heketi/heketi v10.3.0+incompatible
 	github.com/heketi/tests v0.0.0-20151005000721-f3775cbcefd6 // indirect
 	github.com/ishidawataru/sctp v0.0.0-20190723014705-7c296d48a2b5
-	github.com/kcp-dev/logicalcluster v1.0.0
+	github.com/kcp-dev/logicalcluster v1.1.0
 	github.com/libopenstorage/openstorage v1.0.0
 	github.com/lithammer/dedent v1.1.0
 	github.com/lpabon/godbc v0.1.1 // indirect

--- a/pkg/genericcontrolplane/clientutils/multiclusterconfig.go
+++ b/pkg/genericcontrolplane/clientutils/multiclusterconfig.go
@@ -155,10 +155,10 @@ func (mcrt *multiClusterClientConfigRoundTripper) RoundTrip(req *http.Request) (
 		if headerCluster.Empty() {
 			return nil, fmt.Errorf("Cluster should not be empty for request '%s' on resource '%s' (%s)", requestInfo.Verb, requestInfo.Resource, requestInfo.Path)
 		}
-		req.Header.Add("X-Kubernetes-Cluster", headerCluster.String())
+		req.Header.Add(logicalcluster.ClusterHeader, headerCluster.String())
 	} else {
 		if contextCluster != nil && !contextCluster.Name.Empty() {
-			req.Header.Add("X-Kubernetes-Cluster", contextCluster.Name.String())
+			req.Header.Add(logicalcluster.ClusterHeader, contextCluster.Name.String())
 		}
 	}
 	if mcrt.disableSharding {

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/kcp_rest_options_getter.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/kcp_rest_options_getter.go
@@ -51,7 +51,7 @@ func (t apiBindingAwareCRDRESTOptionsGetter) GetRESTOptions(resource schema.Grou
 	// Bound CRDs must have the associated identity annotation
 	apiIdentity := t.crd.Annotations["apis.kcp.dev/identity"]
 	if apiIdentity == "" {
-		return generic.RESTOptions{}, fmt.Errorf("missing 'apis.kcp.dev/identity' annotation")
+		return generic.RESTOptions{}, fmt.Errorf("missing 'apis.kcp.dev/identity' annotation on CRD %s|%s for %s.%s", logicalcluster.From(t.crd), t.crd.Name, t.crd.Spec.Names.Plural, t.crd.Spec.Group)
 	}
 
 	// Modify the ResourcePrefix so it results in e.g. /registry/mygroup.io/widgets/identity4567/...


### PR DESCRIPTION
And 
- UPSTREAM: <carry>: SQUASH: print CRD on missing apis.kcp.dev/identity
- https://github.com/kcp-dev/kubernetes/pull/76

piggy backing on the former.