### PR TITLE
[1.23] UPSTREAM: <carry>: don't remove dead storage for wildcard partial metadata CRDs

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go
@@ -113,6 +113,7 @@ type crdHandler struct {
 
 	crdLister             listers.CustomResourceDefinitionLister
 	clusterAwareCRDLister kcp.ClusterAwareCRDLister
+	crdIndexer            cache.Indexer
 
 	delegate          http.Handler
 	restOptionsGetter generic.RESTOptionsGetter
@@ -181,6 +182,8 @@ type crdInfo struct {
 // crdStorageMap goes from customresourcedefinition to its storage
 type crdStorageMap map[types.UID]*crdInfo
 
+const byGroupResource = "byGroupResource"
+
 func NewCustomResourceDefinitionHandler(
 	versionDiscoveryHandler *versionDiscoveryHandler,
 	groupDiscoveryHandler *groupDiscoveryHandler,
@@ -202,6 +205,7 @@ func NewCustomResourceDefinitionHandler(
 		groupDiscoveryHandler:   groupDiscoveryHandler,
 		customStorage:           atomic.Value{},
 		crdLister:               crdInformer.Lister(),
+		crdIndexer:              crdInformer.Informer().GetIndexer(),
 		delegate:                delegate,
 		restOptionsGetter:       restOptionsGetter,
 		admission:               admission,
@@ -220,6 +224,28 @@ func NewCustomResourceDefinitionHandler(
 			ret.removeDeadStorage()
 		},
 	})
+
+	// kcp: needed to be able to accurately preserve/remove storage for wildcard partial metadata requests
+	if _, exists := crdInformer.Informer().GetIndexer().GetIndexers()[byGroupResource]; !exists {
+		if err := crdInformer.Informer().GetIndexer().AddIndexers(cache.Indexers{
+			byGroupResource: func(obj interface{}) ([]string, error) {
+				crd, ok := obj.(*apiextensionsv1.CustomResourceDefinition)
+				if !ok {
+					return nil, fmt.Errorf("unable to process obj in byName index: unexpected type %T", obj)
+				}
+
+				group := crd.Spec.Group
+				if group == "" {
+					group = "core"
+				}
+
+				return []string{crd.Spec.Names.Plural + "." + group}, nil
+			},
+		}); err != nil {
+			return nil, fmt.Errorf("error adding byName index to CRD lister: %v", err)
+		}
+	}
+
 	crConverterFactory, err := conversion.NewCRConverterFactory(serviceResolver, authResolverWrapper)
 	if err != nil {
 		return nil, err
@@ -642,6 +668,26 @@ func (r *crdHandler) removeDeadStorage() {
 			storageMap2[crd.UID] = storageMap[crd.UID]
 		}
 	}
+
+	// kcp: preserve partial metadata, one per GroupResource (randomly) that has at least one CRD
+	for uid, crdInfo := range storageMap {
+		if strings.HasSuffix(string(uid), ".wildcard.partial-metadata") {
+			groupResource := strings.TrimSuffix(string(uid), ".wildcard.partial-metadata")
+
+			crdsForGroupResource, err := r.crdIndexer.ByIndex(byGroupResource, groupResource)
+			if err != nil {
+				utilruntime.HandleError(fmt.Errorf("error retrieving CRDs for %q from index: %v", groupResource, err))
+			}
+
+			if len(crdsForGroupResource) > 0 {
+				storageMap2[uid] = crdInfo
+				klog.V(6).InfoS("Preserving wildcard partial metadata storage because at least 1 CRD for this group resource still exists", "crd", groupResource)
+			} else {
+				klog.V(4).InfoS("Removing wildcard partial metadata storage because no CRDs for this group resource still exist", "crd", groupResource)
+			}
+		}
+	}
+
 	r.customStorage.Store(storageMap2)
 
 	for uid, crdInfo := range storageMap {


### PR DESCRIPTION
When recalculating the CRD storageMap, it was removing all crdInfos for
our "fake" UIDs that represent wildcard partial metadata. As a result,
any time any CRD was deleted, watches for all wildcard partial metadata
CRDs were getting stopped and restarted.

Backport of #85 to 1.23 for kcp 0.6.x