### PR TITLE
UPSTREAM: <carry>: with shard prefix support 

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/request/context_shard.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/request/context_shard.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package request
+
+import (
+	"context"
+)
+
+type shardKey int
+
+const (
+	// shardKey is the context key for the request.
+	shardContextKey shardKey = iota
+)
+
+// Shard describes a shard
+type Shard string
+
+// Empty returns true if the name of the shard is empty.
+func (s Shard) Empty() bool {
+	return s == ""
+}
+
+// Wildcard checks if the given shard name matches wildcard.
+// If true the query applies to all shards.
+func (s Shard) Wildcard() bool {
+	return s == "*"
+}
+
+// String casts Shard to string type
+func (s Shard) String() string {
+	return string(s)
+}
+
+// WithShard returns a context that holds the given shard.
+func WithShard(parent context.Context, shard Shard) context.Context {
+	return context.WithValue(parent, shardContextKey, shard)
+}
+
+// ShardFrom returns the value of the shard key in the context, or an empty value if there is no shard key.
+func ShardFrom(ctx context.Context) Shard {
+	shard, ok := ctx.Value(shardContextKey).(Shard)
+	if !ok {
+		return ""
+	}
+	return shard
+}

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
@@ -238,15 +238,22 @@ const (
 // to resource directories enforcing namespace rules.
 func NoNamespaceKeyRootFunc(ctx context.Context, prefix string) string {
 	key := prefix
+	shard := genericapirequest.ShardFrom(ctx)
+	if shard.Wildcard() {
+		return key
+	}
 	cluster, err := genericapirequest.ValidClusterFrom(ctx)
 	if err != nil {
 		klog.Errorf("invalid context cluster value: %v", err)
 		return key
 	}
-	if cluster.Wildcard {
-		return key
+	if !shard.Empty() {
+		key += "/" + shard.String()
 	}
-	return key + "/" + cluster.Name.String()
+	if !cluster.Wildcard {
+		key += "/" + cluster.Name.String()
+	}
+	return key
 }
 
 // NamespaceKeyRootFunc is the default function for constructing storage paths

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
@@ -710,7 +710,7 @@ func (s *store) GetList(ctx context.Context, key string, opts storage.ListOption
 	if err != nil {
 		return storage.NewInternalErrorf("unable to get cluster for list key %q: %v", keyPrefix, err)
 	}
-
+	shard := genericapirequest.ShardFrom(ctx)
 	crdIndicator := kcp.CustomResourceIndicatorFrom(ctx)
 	// end kcp
 
@@ -769,7 +769,7 @@ func (s *store) GetList(ctx context.Context, key string, opts storage.ListOption
 			}
 
 			// kcp
-			clusterName := adjustClusterNameIfWildcard(cluster, crdIndicator, keyPrefix, string(kv.Key))
+			clusterName := adjustClusterNameIfWildcard(shard, cluster, crdIndicator, keyPrefix, string(kv.Key))
 
 			if err := appendListItem(v, data, uint64(kv.ModRevision), pred, s.codec, s.versioner, newItemFunc, clusterName); err != nil {
 				return err

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_patch_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_patch_test.go
@@ -30,19 +30,19 @@ func TestAdjustClusterNameIfWildcard(t *testing.T) {
 		prefix          string
 		builtInType     bool
 	}{
-		"not wildcard": {
+		"not clusterWildcard": {
 			prefix: "/registry/group/resource/identity/",
 		},
-		"wildcard, not partial": {
+		"clusterWildcard, not partial": {
 			wildcard: true,
 			prefix:   "/registry/group/resource/identity/",
 		},
-		"wildcard, partial": {
+		"clusterWildcard, partial": {
 			wildcard:        true,
 			partialMetadata: true,
 			prefix:          "/registry/group/resource/",
 		},
-		"wildcard, partial, built-in type": {
+		"clusterWildcard, partial, built-in type": {
 			wildcard:        true,
 			partialMetadata: true,
 			prefix:          "/registry/core/configmaps/",
@@ -67,9 +67,64 @@ func TestAdjustClusterNameIfWildcard(t *testing.T) {
 			}
 			expected := "root:org:ws"
 
-			clusterName := adjustClusterNameIfWildcard(cluster, !tc.builtInType, tc.prefix, key)
+			clusterName := adjustClusterNameIfWildcard(genericapirequest.Shard(""), cluster, !tc.builtInType, tc.prefix, key)
 			if e, a := expected, clusterName.String(); e != a {
 				t.Errorf("expected: %q, actual %q", e, a)
+			}
+		})
+	}
+}
+
+func TestAdjustClusterNameIfWildcardWithShardSupport(t *testing.T) {
+	tests := map[string]struct {
+		cluster             genericapirequest.Cluster
+		shard               genericapirequest.Shard
+		key                 string
+		keyPrefix           string
+		expectedClusterName string
+	}{
+		"not wildcard": {
+			cluster:             genericapirequest.Cluster{Name: logicalcluster.New("root:org:ws")},
+			shard:               "amber",
+			key:                 "/registry/group/resource:identity/amber/root:org:ws/somename",
+			keyPrefix:           "/registry/group/resource:identity/",
+			expectedClusterName: "root:org:ws",
+		},
+		"both wildcard": {
+			cluster:             genericapirequest.Cluster{Name: logicalcluster.Wildcard},
+			shard:               "*",
+			key:                 "/registry/group/resource:identity/amber/root:org:ws/somename",
+			keyPrefix:           "/registry/group/resource:identity/",
+			expectedClusterName: "root:org:ws",
+		},
+		"both wildcard, built-in type": {
+			cluster:             genericapirequest.Cluster{Name: logicalcluster.Wildcard},
+			shard:               "*",
+			key:                 "/registry/core/configmaps/amber/root:org:ws/somename",
+			keyPrefix:           "/registry/core/configmaps/",
+			expectedClusterName: "root:org:ws",
+		},
+		"only cluster wildcard": {
+			cluster:             genericapirequest.Cluster{Name: logicalcluster.Wildcard},
+			shard:               "amber",
+			key:                 "/registry/group/resource:identity/amber/root:org:ws/somename",
+			keyPrefix:           "/registry/group/resource:identity/amber/",
+			expectedClusterName: "root:org:ws",
+		},
+		"only shard wildcard": {
+			cluster:             genericapirequest.Cluster{Name: logicalcluster.New("root:org:ws")},
+			shard:               "*",
+			key:                 "/registry/core/configmaps/amber/root:org:ws/somename",
+			keyPrefix:           "/registry/group/resource:identity/",
+			expectedClusterName: "root:org:ws",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			clusterName := adjustClusterNameIfWildcard(tc.shard, &tc.cluster, false, tc.keyPrefix, tc.key)
+			if tc.expectedClusterName != clusterName.String() {
+				t.Errorf("expected: %q, actual %q", tc.expectedClusterName, clusterName)
 			}
 		})
 	}

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher_test.go
@@ -269,7 +269,7 @@ func TestWatchContextCancel(t *testing.T) {
 func TestWatchErrResultNotBlockAfterCancel(t *testing.T) {
 	origCtx, store, _ := testSetup(t)
 	ctx, cancel := context.WithCancel(origCtx)
-	w := store.watcher.createWatchChan(ctx, "/abc", 0, false, &genericapirequest.Cluster{}, false, storage.Everything)
+	w := store.watcher.createWatchChan(ctx, "/abc", 0, false, genericapirequest.Shard(""), &genericapirequest.Cluster{}, false, storage.Everything)
 	// make resutlChan and errChan blocking to ensure ordering.
 	w.resultChan = make(chan watch.Event)
 	w.errChan = make(chan error)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR adds support for setting a shard prefix to the storage layer.
The prefix is used by the cache server.
The storage layer has to understand both the cluster and the shard prefixes
because the database can be shared between the kcp and the cache server.

Once a shard name is set, the storage layer will change the key under which a resource is stored, for example:

amber/root:org/default/secret
amber/root:org/secret

Where:

- amber:     is a shard name
- root:org:  is a cluster name
- default:   is a namespace name
- secret:    is a name of a resource

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
