### PR TITLE
UPSTREAM: <carry>: assign shard names to objects

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/request/context_shard.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/request/context_shard.go
@@ -25,6 +25,9 @@ type shardKey int
 const (
 	// shardKey is the context key for the request.
 	shardContextKey shardKey = iota
+
+	// AnnotationKey is the name of the annotation key used to denote an object's shard name.
+	AnnotationKey = "kcp.dev/shard"
 )
 
 // Shard describes a shard

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
@@ -156,7 +156,8 @@ func (s *store) Get(ctx context.Context, key string, opts storage.GetOptions, ou
 		return storage.NewInternalError(err.Error())
 	}
 
-	return decode(s.codec, s.versioner, data, out, kv.ModRevision, clusterName)
+	shardName := genericapirequest.ShardFrom(ctx)
+	return decode(s.codec, s.versioner, data, out, kv.ModRevision, clusterName, shardName)
 }
 
 // Create implements storage.Interface.Create.
@@ -204,7 +205,8 @@ func (s *store) Create(ctx context.Context, key string, obj, out runtime.Object,
 
 	if out != nil {
 		putResp := txnResp.Responses[0].GetResponsePut()
-		return decode(s.codec, s.versioner, data, out, putResp.Header.Revision, clusterName)
+		shardName := genericapirequest.ShardFrom(ctx)
+		return decode(s.codec, s.versioner, data, out, putResp.Header.Revision, clusterName, shardName)
 	}
 	return nil
 }
@@ -230,6 +232,7 @@ func (s *store) conditionalDelete(
 	if err != nil {
 		klog.Errorf("No cluster defined in conditionalDelete action for key %s : %s", key, err.Error())
 	}
+	shardName := genericapirequest.ShardFrom(ctx)
 
 	getCurrentState := func() (*objState, error) {
 		startTime := time.Now()
@@ -238,7 +241,7 @@ func (s *store) conditionalDelete(
 		if err != nil {
 			return nil, err
 		}
-		return s.getState(ctx, getResp, key, v, false, clusterName)
+		return s.getState(ctx, getResp, key, v, false, clusterName, shardName)
 	}
 
 	var origState *objState
@@ -322,14 +325,14 @@ func (s *store) conditionalDelete(
 		if !txnResp.Succeeded {
 			getResp := (*clientv3.GetResponse)(txnResp.Responses[0].GetResponseRange())
 			klog.V(4).Infof("deletion of %s failed because of a conflict, going to retry", key)
-			origState, err = s.getState(ctx, getResp, key, v, false, clusterName)
+			origState, err = s.getState(ctx, getResp, key, v, false, clusterName, shardName)
 			if err != nil {
 				return err
 			}
 			origStateIsCurrent = true
 			continue
 		}
-		return decode(s.codec, s.versioner, origState.data, out, origState.rev, clusterName)
+		return decode(s.codec, s.versioner, origState.data, out, origState.rev, clusterName, shardName)
 	}
 }
 
@@ -346,6 +349,7 @@ func (s *store) GuaranteedUpdate(
 	if err != nil {
 		klog.Errorf("No cluster defined in GuaranteedUpdate action for key %s : %s", key, err.Error())
 	}
+	shardName := genericapirequest.ShardFrom(ctx)
 
 	v, err := conversion.EnforcePtr(out)
 	if err != nil {
@@ -360,7 +364,7 @@ func (s *store) GuaranteedUpdate(
 		if err != nil {
 			return nil, err
 		}
-		return s.getState(ctx, getResp, key, v, ignoreNotFound, clusterName)
+		return s.getState(ctx, getResp, key, v, ignoreNotFound, clusterName, shardName)
 	}
 
 	var origState *objState
@@ -444,7 +448,7 @@ func (s *store) GuaranteedUpdate(
 			}
 			// recheck that the data from etcd is not stale before short-circuiting a write
 			if !origState.stale {
-				return decode(s.codec, s.versioner, origState.data, out, origState.rev, clusterName)
+				return decode(s.codec, s.versioner, origState.data, out, origState.rev, clusterName, shardName)
 			}
 		}
 
@@ -475,7 +479,7 @@ func (s *store) GuaranteedUpdate(
 		if !txnResp.Succeeded {
 			getResp := (*clientv3.GetResponse)(txnResp.Responses[0].GetResponseRange())
 			klog.V(4).Infof("GuaranteedUpdate of %s failed because of a conflict, going to retry", key)
-			origState, err = s.getState(ctx, getResp, key, v, ignoreNotFound, clusterName)
+			origState, err = s.getState(ctx, getResp, key, v, ignoreNotFound, clusterName, shardName)
 			if err != nil {
 				return err
 			}
@@ -485,7 +489,7 @@ func (s *store) GuaranteedUpdate(
 		}
 		putResp := txnResp.Responses[0].GetResponsePut()
 
-		return decode(s.codec, s.versioner, data, out, putResp.Header.Revision, clusterName)
+		return decode(s.codec, s.versioner, data, out, putResp.Header.Revision, clusterName, shardName)
 	}
 }
 
@@ -770,8 +774,9 @@ func (s *store) GetList(ctx context.Context, key string, opts storage.ListOption
 
 			// kcp
 			clusterName := adjustClusterNameIfWildcard(shard, cluster, crdIndicator, keyPrefix, string(kv.Key))
+			shardName := adjustShardNameIfWildcard(shard, keyPrefix, string(kv.Key))
 
-			if err := appendListItem(v, data, uint64(kv.ModRevision), pred, s.codec, s.versioner, newItemFunc, clusterName); err != nil {
+			if err := appendListItem(v, data, uint64(kv.ModRevision), pred, s.codec, s.versioner, newItemFunc, clusterName, shardName); err != nil {
 				return err
 			}
 			numEvald++
@@ -877,7 +882,7 @@ func (s *store) Watch(ctx context.Context, key string, opts storage.ListOptions)
 	return s.watcher.Watch(ctx, key, int64(rev), opts.Recursive, opts.ProgressNotify, opts.Predicate)
 }
 
-func (s *store) getState(ctx context.Context, getResp *clientv3.GetResponse, key string, v reflect.Value, ignoreNotFound bool, clusterName logicalcluster.Name) (*objState, error) {
+func (s *store) getState(ctx context.Context, getResp *clientv3.GetResponse, key string, v reflect.Value, ignoreNotFound bool, clusterName logicalcluster.Name, shardName genericapirequest.Shard) (*objState, error) {
 	state := &objState{
 		meta: &storage.ResponseMeta{},
 	}
@@ -904,7 +909,7 @@ func (s *store) getState(ctx context.Context, getResp *clientv3.GetResponse, key
 		state.meta.ResourceVersion = uint64(state.rev)
 		state.data = data
 		state.stale = stale
-		if err := decode(s.codec, s.versioner, state.data, state.obj, state.rev, clusterName); err != nil {
+		if err := decode(s.codec, s.versioner, state.data, state.obj, state.rev, clusterName, shardName); err != nil {
 			return nil, err
 		}
 	}
@@ -988,7 +993,7 @@ func (s *store) validateMinimumResourceVersion(minimumResourceVersion string, ac
 
 // decode decodes value of bytes into object. It will also set the object resource version to rev.
 // On success, objPtr would be set to the object.
-func decode(codec runtime.Codec, versioner storage.Versioner, value []byte, objPtr runtime.Object, rev int64, clusterName logicalcluster.Name) error {
+func decode(codec runtime.Codec, versioner storage.Versioner, value []byte, objPtr runtime.Object, rev int64, clusterName logicalcluster.Name, shardName genericapirequest.Shard) error {
 	if _, err := conversion.EnforcePtr(objPtr); err != nil {
 		return fmt.Errorf("unable to convert output object to pointer: %v", err)
 	}
@@ -1002,13 +1007,13 @@ func decode(codec runtime.Codec, versioner storage.Versioner, value []byte, objP
 	}
 
 	// kcp: apply clusterName to the decoded object, as the name is not persisted in storage.
-	setClusterNameOnDecodedObject(objPtr, clusterName)
+	annotateDecodedObjectWith(objPtr, clusterName, shardName)
 
 	return nil
 }
 
 // appendListItem decodes and appends the object (if it passes filter) to v, which must be a slice.
-func appendListItem(v reflect.Value, data []byte, rev uint64, pred storage.SelectionPredicate, codec runtime.Codec, versioner storage.Versioner, newItemFunc func() runtime.Object, clusterName logicalcluster.Name) error {
+func appendListItem(v reflect.Value, data []byte, rev uint64, pred storage.SelectionPredicate, codec runtime.Codec, versioner storage.Versioner, newItemFunc func() runtime.Object, clusterName logicalcluster.Name, shardName genericapirequest.Shard) error {
 	obj, _, err := codec.Decode(data, nil, newItemFunc())
 	if err != nil {
 		return err
@@ -1018,8 +1023,8 @@ func appendListItem(v reflect.Value, data []byte, rev uint64, pred storage.Selec
 		klog.Errorf("failed to update object version: %v", err)
 	}
 
-	// kcp: apply clusterName to the decoded object, as the name is not persisted in storage.
-	setClusterNameOnDecodedObject(obj, clusterName)
+	// kcp: apply clusterName and shardName to the decoded object, as the name is not persisted in storage.
+	annotateDecodedObjectWith(obj, clusterName, shardName)
 
 	if matched, err := pred.Matches(obj); err == nil && matched {
 		v.Set(reflect.Append(v, reflect.ValueOf(obj).Elem()))

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher.go
@@ -459,7 +459,8 @@ func (wc *watchChan) prepareObjs(e *event) (curObj runtime.Object, oldObj runtim
 
 		// kcp: apply clusterName to the decoded object, as the name is not persisted in storage.
 		clusterName := adjustClusterNameIfWildcard(wc.shard, wc.cluster, wc.crdRequest, wc.key, e.key)
-		setClusterNameOnDecodedObject(curObj, clusterName)
+		shardName := adjustShardNameIfWildcard(wc.shard, wc.key, e.key)
+		annotateDecodedObjectWith(curObj, clusterName, shardName)
 	}
 	// We need to decode prevValue, only if this is deletion event or
 	// the underlying filter doesn't accept all objects (otherwise we
@@ -480,7 +481,8 @@ func (wc *watchChan) prepareObjs(e *event) (curObj runtime.Object, oldObj runtim
 
 		// kcp: apply clusterName to the decoded object, as the name is not persisted in storage.
 		clusterName := adjustClusterNameIfWildcard(wc.shard, wc.cluster, wc.crdRequest, wc.key, e.key)
-		setClusterNameOnDecodedObject(oldObj, clusterName)
+		shardName := adjustShardNameIfWildcard(wc.shard, wc.key, e.key)
+		annotateDecodedObjectWith(oldObj, clusterName, shardName)
 	}
 	return curObj, oldObj, nil
 }


### PR DESCRIPTION
This PR applies a shard name to objects.
This is necessary because we don't store the shard name in the objects in the db.
Instead, we need to derive it from the storage key, and then applied after retrieving the object from storage.

Assigning the names is required to:
 - enable the watch-cache for the cache server
 - instruct the internal kube-controllers how to construct the final URL