### PR TITLE
UPSTREAM: <carry>: no graceful deletion of the cached objects

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
@@ -966,6 +966,13 @@ func (e *Store) updateForGracefulDeletionAndFinalizers(ctx context.Context, name
 			if err != nil {
 				return nil, err
 			}
+
+			// the following annotation key indicates that the request is from the cache server
+			// in that case we've decided not to require finalization, the object will be deleted immediately
+			if _, hasShardAnnotation := existingAccessor.GetAnnotations()[genericapirequest.AnnotationKey]; hasShardAnnotation {
+				return existing, nil
+			}
+
 			needsUpdate, newFinalizers := deletionFinalizersForGarbageCollection(ctx, e, existingAccessor, options)
 			if needsUpdate {
 				existingAccessor.SetFinalizers(newFinalizers)


### PR DESCRIPTION
Allows for immediate deletion of an object with the `kcp.dev/shard` annotation key.
Even if it has pending finalizers.
This simplifies object deletion in general and the replication controllers.

part of https://github.com/kcp-dev/kcp/issues/342
