### PR TITLE
genericcontrolplane: enable multi-cluster hack for configmaps

### DIFF
--- a/pkg/genericcontrolplane/server.go
+++ b/pkg/genericcontrolplane/server.go
@@ -320,7 +320,7 @@ func BuildGenericConfig(
 	genericConfig.LoopbackClientConfig.DisableCompression = true
 
 	kubeClientConfig := genericConfig.LoopbackClientConfig
-	clientutils.EnableMultiCluster(genericConfig.LoopbackClientConfig, genericConfig, "namespaces", "apiservices", "customresourcedefinitions", "clusterroles", "clusterrolebindings", "roles", "rolebindings", "serviceaccounts", "secrets")
+	clientutils.EnableMultiCluster(genericConfig.LoopbackClientConfig, genericConfig, "namespaces", "apiservices", "customresourcedefinitions", "clusterroles", "clusterrolebindings", "roles", "rolebindings", "serviceaccounts", "secrets", "configmaps")
 	clientgoExternalClient, err := clientgoclientset.NewForConfig(kubeClientConfig)
 	if err != nil {
 		lastErr = fmt.Errorf("failed to create real external clientset: %v", err)


### PR DESCRIPTION
Fixes kcp-dev/kcp#2092

Error message:

```
invalid context cluster value: cluster name is empty in the request context - RequestInfo: &request.RequestInfo{IsResourceRequest:true, Path:"/api/v1/namespaces/kube-system/configmaps", ...
```

Coming from ClusterAuthenticationTrustController's configmap informer.

It seems configmaps should be included in the list of built-in resources that we enable multi-cluster awareness.

/kind bug