### PR TITLE
UPSTREAM: <carry>: do not set the generation for cached object

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/update.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/update.go
@@ -126,7 +126,12 @@ func BeforeUpdate(strategy RESTUpdateStrategy, ctx context.Context, obj, old run
 	if err != nil {
 		return err
 	}
-	objectMeta.SetGeneration(oldMeta.GetGeneration())
+	if len(oldMeta.GetAnnotations()[genericapirequest.AnnotationKey]) == 0 || objectMeta.GetGeneration() == 0 {
+		// the absence of the annotation indicates the object is NOT from the cache server,
+		// if the new object doesn't have its generation set, just rewrite it from the old object
+		// otherwise  we are dealing with an object from the cache server that wants its generation to be updated
+		objectMeta.SetGeneration(oldMeta.GetGeneration())
+	}
 
 	// Ensure managedFields state is removed unless ServerSideApply is enabled
 	if !utilfeature.DefaultFeatureGate.Enabled(features.ServerSideApply) {


### PR DESCRIPTION
This PR allows:
 - for setting a generation during object creation so that it matches the original object
 - for setting a generation during an update so that it matches the original one

Essentially, the generation field for cached objects won't be managed by the generic/extensions API server.

part of https://github.com/kcp-dev/kcp/issues/342
