### PR TITLE
UPSTREAM: <carry>: allow for setting UID and CreationTimestamp for replicated objects

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/strategy.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/strategy.go
@@ -116,12 +116,7 @@ func (a customResourceStrategy) PrepareForCreate(ctx context.Context, obj runtim
 
 	accessor, _ := meta.Accessor(obj)
 	if _, found := accessor.GetAnnotations()[genericapirequest.AnnotationKey]; found {
-		// in general the shard annotation is not attached to objects, instead, it is assigned by the storage layer on the fly
-		// to avoid an additional UPDATE request (mismatch on the generation field) replicated objects have the shard annotation set
-		// thus we need to remove the shard annotation and simply return early so that the generation is not reset to 1
-		annotations := accessor.GetAnnotations()
-		delete(annotations, genericapirequest.AnnotationKey)
-		accessor.SetAnnotations(annotations)
+		// to avoid an additional UPDATE request (mismatch on the generation field) replicated objects have the generation field already set
 		return
 	}
 	accessor.SetGeneration(1)

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/meta.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/meta.go
@@ -21,10 +21,20 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/uuid"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 )
 
 // FillObjectMetaSystemFields populates fields that are managed by the system on ObjectMeta.
 func FillObjectMetaSystemFields(meta metav1.Object) {
+	if _, found := meta.GetAnnotations()[genericapirequest.AnnotationKey]; found {
+		// in general the shard annotation is not attached to objects, instead, it is assigned by the storage layer on the fly
+		// to avoid an additional UPDATE request (mismatch on the creationTime and UID fields) replicated objects have those fields already set
+		// thus all we have to do is to remove the shard annotation and simply return early
+		annotations := meta.GetAnnotations()
+		delete(annotations, genericapirequest.AnnotationKey)
+		meta.SetAnnotations(annotations)
+		return
+	}
 	meta.SetCreationTimestamp(metav1.Now())
 	meta.SetUID(uuid.NewUUID())
 	meta.SetSelfLink("")


### PR DESCRIPTION
to avoid an additional UPDATE request, mismatch on the CreationTime and UID fields, replicated objects have those fields already set
thus this PR allows for setting those fields during object creation if the object has the shard annotation

also, since the shard annotation is not attached to objects, it is only added by the storage layer on the fly
we need to remove the shard annotation before we actually store the object in the db.

requires https://github.com/kcp-dev/kubernetes/pull/106

part of https://github.com/kcp-dev/kcp/issues/342