### PR TITLE
UPSTREAM: <carry>: garbage collector monitors syncing

### DIFF
--- a/hack/kcp/garbage_collector_patch.go
+++ b/hack/kcp/garbage_collector_patch.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"go/ast"
+	"go/format"
+	"go/parser"
+	"go/token"
+	"log"
+	"strings"
+)
+
+/*
+Process:
+
+1. go run ./hack/kcp/garbage_collector_patch.go > pkg/controller/garbagecollector/garbagecollector_patch.go
+(you may need to add -mod=readonly)
+
+2. goimports -w pkg/controller/garbagecollector/garbagecollector_patch.go
+
+3. reapply patch for kcp to pkg/controller/garbagecollector/garbagecollector_patch.go
+*/
+
+func main() {
+	fileSet := token.NewFileSet()
+
+	file, err := parser.ParseFile(fileSet, "pkg/controller/garbagecollector/garbagecollector.go", nil, parser.ParseComments)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// n stores a reference to the node for the function declaration for Sync
+	var n ast.Node
+
+	ast.Inspect(file, func(node ast.Node) bool {
+		switch x := node.(type) {
+		case *ast.FuncDecl:
+			if x.Name.Name == "Sync" {
+				// Store the reference
+				n = node
+				// Stop further inspection
+				return false
+			}
+		}
+
+		// Continue recursing
+		return true
+	})
+
+	startLine := fileSet.Position(n.Pos()).Line
+	endLine := fileSet.Position(n.End()).Line
+
+	// To preserve the comments from within the function body itself, we have to write out the entire file to a buffer,
+	// then extract only the lines we care about (the function body).
+	var buf bytes.Buffer
+	if err := format.Node(&buf, fileSet, file); err != nil {
+		log.Fatal(err)
+	}
+
+	// Convert the buffer to a slice of lines, so we can grab the portion we want
+	var lines []string
+	scanner := bufio.NewScanner(&buf)
+	for scanner.Scan() {
+		lines = append(lines, scanner.Text())
+	}
+	if err := scanner.Err(); err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println(`/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package garbagecollector
+`)
+
+	// Finally, print the line range we need
+	fmt.Println(strings.Join(lines[startLine-1:endLine], "\n"))
+}

--- a/pkg/controller/garbagecollector/garbagecollector_patch.go
+++ b/pkg/controller/garbagecollector/garbagecollector_patch.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package garbagecollector
+
+import (
+	"fmt"
+	"reflect"
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+	"k8s.io/kubernetes/pkg/controller/garbagecollector/metrics"
+)
+
+func (gc *GarbageCollector) Sync(discoveryClient discovery.ServerResourcesInterface, period time.Duration, stopCh <-chan struct{}) {
+	oldResources := make(map[schema.GroupVersionResource]struct{})
+	wait.Until(func() {
+		// Get the current resource list from discovery.
+		newResources := gc.GetDeletableResources(discoveryClient)
+
+		// This can occur if there is an internal error in GetDeletableResources.
+		if len(newResources) == 0 {
+			klog.V(2).Infof("%s: no resources reported by discovery, skipping garbage collector sync", gc.clusterName)
+			metrics.GarbageCollectorResourcesSyncError.Inc()
+			return
+		}
+
+		// Decide whether discovery has reported a change.
+		if reflect.DeepEqual(oldResources, newResources) {
+			klog.V(5).Infof("%s: no resource updates from discovery, skipping garbage collector sync", gc.clusterName)
+			return
+		}
+
+		// Ensure workers are paused to avoid processing events before informers
+		// have resynced.
+		gc.workerLock.Lock()
+		defer gc.workerLock.Unlock()
+
+		// Once we get here, we should not unpause workers until we've successfully synced
+		attempt := 0
+		wait.PollImmediateUntil(100*time.Millisecond, func() (bool, error) {
+			attempt++
+
+			// On a reattempt, check if available resources have changed
+			if attempt > 1 {
+				newResources = gc.GetDeletableResources(discoveryClient)
+				if len(newResources) == 0 {
+					klog.V(2).Infof("%s: no resources reported by discovery (attempt %d)", gc.clusterName, attempt)
+					metrics.GarbageCollectorResourcesSyncError.Inc()
+					return false, nil
+				}
+			}
+
+			klog.V(2).Infof("%s: syncing garbage collector with updated resources from discovery (attempt %d): %s", gc.clusterName, attempt, printDiff(oldResources, newResources))
+
+			// Resetting the REST mapper will also invalidate the underlying discovery
+			// client. This is a leaky abstraction and assumes behavior about the REST
+			// mapper, but we'll deal with it for now.
+			gc.restMapper.Reset()
+			klog.V(4).Infof("%s: reset restmapper", gc.clusterName)
+
+			// Perform the monitor resync and wait for controllers to report cache sync.
+			//
+			// NOTE: It's possible that newResources will diverge from the resources
+			// discovered by restMapper during the call to Reset, since they are
+			// distinct discovery clients invalidated at different times. For example,
+			// newResources may contain resources not returned in the restMapper's
+			// discovery call if the resources appeared in-between the calls. In that
+			// case, the restMapper will fail to map some of newResources until the next
+			// attempt.
+			if err := gc.resyncMonitors(newResources); err != nil {
+				utilruntime.HandleError(fmt.Errorf("%s: failed to sync resource monitors (attempt %d): %v", gc.clusterName, attempt, err))
+				metrics.GarbageCollectorResourcesSyncError.Inc()
+				return false, nil
+			}
+			klog.V(4).Infof("%s: resynced monitors", gc.clusterName)
+
+			// wait for caches to fill for a while (our sync period) before attempting to rediscover resources and retry syncing.
+			// this protects us from deadlocks where available resources changed and one of our informer caches will never fill.
+			// informers keep attempting to sync in the background, so retrying doesn't interrupt them.
+			// the call to resyncMonitors on the reattempt will no-op for resources that still exist.
+			// note that workers stay paused until we successfully resync.
+			if !cache.WaitForNamedCacheSync(fmt.Sprintf("%s: garbage collector", gc.clusterName), waitForStopOrTimeout(stopCh, period), gc.dependencyGraphBuilder.IsSynced) {
+				utilruntime.HandleError(fmt.Errorf("%s: timed out waiting for dependency graph builder sync during GC sync (attempt %d)", gc.clusterName, attempt))
+				metrics.GarbageCollectorResourcesSyncError.Inc()
+				return false, nil
+			}
+
+			// success, break out of the loop
+			return true, nil
+		}, stopCh)
+
+		// Finally, keep track of our new state. Do this after all preceding steps
+		// have succeeded to ensure we'll retry on subsequent syncs if an error
+		// occurred.
+		oldResources = newResources
+		klog.V(2).Infof("%s: synced garbage collector", gc.clusterName)
+	}, period, stopCh)
+}

--- a/pkg/controller/garbagecollector/operations.go
+++ b/pkg/controller/garbagecollector/operations.go
@@ -89,11 +89,11 @@ func (gc *GarbageCollector) removeFinalizer(owner *node, targetFinalizer string)
 			return nil
 		}
 		if err != nil {
-			return fmt.Errorf("cannot finalize owner %s, because cannot get it: %v. The garbage collector will retry later", owner.identity, err)
+			return fmt.Errorf("%s: cannot finalize owner %s, because cannot get it: %v. The garbage collector will retry later", gc.clusterName, owner.identity, err)
 		}
 		accessor, err := meta.Accessor(ownerObject)
 		if err != nil {
-			return fmt.Errorf("cannot access the owner object %v: %v. The garbage collector will retry later", ownerObject, err)
+			return fmt.Errorf("%s: cannot access the owner object %v: %v. The garbage collector will retry later", gc.clusterName, ownerObject, err)
 		}
 		finalizers := accessor.GetFinalizers()
 		var newFinalizers []string
@@ -106,7 +106,7 @@ func (gc *GarbageCollector) removeFinalizer(owner *node, targetFinalizer string)
 			newFinalizers = append(newFinalizers, f)
 		}
 		if !found {
-			klog.V(5).Infof("the %s finalizer is already removed from object %s", targetFinalizer, owner.identity)
+			klog.V(5).Infof("%s: the %s finalizer is already removed from object %s", gc.clusterName, targetFinalizer, owner.identity)
 			return nil
 		}
 
@@ -118,13 +118,13 @@ func (gc *GarbageCollector) removeFinalizer(owner *node, targetFinalizer string)
 			},
 		})
 		if err != nil {
-			return fmt.Errorf("unable to finalize %s due to an error serializing patch: %v", owner.identity, err)
+			return fmt.Errorf("%s: unable to finalize %s due to an error serializing patch: %v", gc.clusterName, owner.identity, err)
 		}
 		_, err = gc.patchObject(owner.identity, patch, types.MergePatchType)
 		return err
 	})
 	if errors.IsConflict(err) {
-		return fmt.Errorf("updateMaxRetries(%d) has reached. The garbage collector will retry later for owner %v", retry.DefaultBackoff.Steps, owner.identity)
+		return fmt.Errorf("%s: updateMaxRetries(%d) has reached. The garbage collector will retry later for owner %v", gc.clusterName, retry.DefaultBackoff.Steps, owner.identity)
 	}
 	return err
 }

--- a/pkg/controller/garbagecollector/patch.go
+++ b/pkg/controller/garbagecollector/patch.go
@@ -57,7 +57,7 @@ func (gc *GarbageCollector) getMetadata(apiVersion, kind, namespace, name string
 	}
 	obj, ok := raw.(runtime.Object)
 	if !ok {
-		return nil, fmt.Errorf("expect a runtime.Object, got %v", raw)
+		return nil, fmt.Errorf("%s: expect a runtime.Object, got %v", gc.clusterName, raw)
 	}
 	return meta.Accessor(obj)
 }


### PR DESCRIPTION
Adds the ability to update garbage collector monitors for integrators.

Required for kcp-dev/kcp#2112.
