### PR TITLE
:feature: Add a parameter to deactivate server side apply.

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/apiserver.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/apiserver.go
@@ -95,6 +95,9 @@ type ExtraConfig struct {
 	// KCP
 	ClusterAwareCRDLister  kcp.ClusterAwareCRDClusterLister
 	TableConverterProvider TableConverterProvider
+	// DisableServerSideApply deactivates Server Side Apply for a specific API server instead of globally through the feature gate
+	// used with the embedded cache server in kcp
+	DisableServerSideApply bool
 }
 
 type Config struct {
@@ -241,6 +244,7 @@ func (c completedConfig) New(delegationTarget genericapiserver.DelegationTarget)
 		time.Duration(c.GenericConfig.MinRequestTimeout)*time.Second,
 		apiGroupInfo.StaticOpenAPISpec,
 		c.GenericConfig.MaxRequestBodyBytes,
+		c.ExtraConfig.DisableServerSideApply,
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR adds a parameter to deactivate server side apply.
This is required for the cache server when running in embedded mode. The server side apply feature gate is global and would apply to both kcp and the cache server.

#### Special notes for your reviewer:

This is in relation to [the APIExportEndpointSlice reconciliation PR](https://github.com/kcp-dev/kcp/pull/2432#discussion_r1042568401).

#### Does this PR introduce a user-facing change?

NONE 

Signed-off-by: Frederic Giloux <fgiloux@redhat.com>
