### PR TITLE
WIP: replace kcp.dev by kcp.io

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -54,7 +54,7 @@ require (
 	github.com/ishidawataru/sctp v0.0.0-20190723014705-7c296d48a2b5
 	github.com/kcp-dev/apimachinery/v2 v2.0.0-alpha.0
 	github.com/kcp-dev/client-go v0.0.0-20221215092857-c1e5154a9825
-	github.com/kcp-dev/logicalcluster/v3 v3.0.0
+	github.com/kcp-dev/logicalcluster/v3 v3.0.2
 	github.com/libopenstorage/openstorage v1.0.0
 	github.com/lithammer/dedent v1.1.0
 	github.com/lpabon/godbc v0.1.1 // indirect
@@ -306,7 +306,7 @@ replace (
 	github.com/kcp-dev/apimachinery/v2 => github.com/kcp-dev/apimachinery/v2 v2.0.0-alpha.0
 	github.com/kcp-dev/client-go => github.com/kcp-dev/client-go v0.0.0-20221025140308-a18ccea074a6
 	github.com/kcp-dev/logicalcluster/v2 => github.com/kcp-dev/logicalcluster/v2 v2.0.0-alpha.1
-	github.com/kcp-dev/logicalcluster/v3 => github.com/kcp-dev/logicalcluster/v3 v3.0.0
+	github.com/kcp-dev/logicalcluster/v3 => github.com/kcp-dev/logicalcluster/v3 v3.0.2
 	github.com/kisielk/errcheck => github.com/kisielk/errcheck v1.5.0
 	github.com/kisielk/gotool => github.com/kisielk/gotool v1.0.0
 	github.com/konsorten/go-windows-terminal-sequences => github.com/konsorten/go-windows-terminal-sequences v1.0.2

--- a/go.sum
+++ b/go.sum
@@ -283,8 +283,8 @@ github.com/kcp-dev/client-go v0.0.0-20221025140308-a18ccea074a6 h1:Dxst7pq601Y7z
 github.com/kcp-dev/client-go v0.0.0-20221025140308-a18ccea074a6/go.mod h1:Qmq1OxUOSdVQ8YIGnjbya5Xt04KMJ5fN41QvErl/XnI=
 github.com/kcp-dev/logicalcluster/v2 v2.0.0-alpha.1 h1:6EMfOioekQNrpcHEK7k2ANBWogFMlf+3xTB3CC4k+2s=
 github.com/kcp-dev/logicalcluster/v2 v2.0.0-alpha.1/go.mod h1:lfWJL764jKFJxZWOGuFuT3PCCLPo6lV5Cl8P7u9T05g=
-github.com/kcp-dev/logicalcluster/v3 v3.0.0 h1:tH6M2NuA11eLMsxii9IDOGo64X8B+P3e3pC6W2oEsx8=
-github.com/kcp-dev/logicalcluster/v3 v3.0.0/go.mod h1:6rb68Tntup98cRr9+50rvSDxUbfqrC1yQ/T6RiZcSgA=
+github.com/kcp-dev/logicalcluster/v3 v3.0.2 h1:U7wnYPgZLJt/X2G1/SYnynW6WnRmohxIvKaMwNL9BHM=
+github.com/kcp-dev/logicalcluster/v3 v3.0.2/go.mod h1:6rb68Tntup98cRr9+50rvSDxUbfqrC1yQ/T6RiZcSgA=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=

--- a/pkg/controller/resourcequota/resource_quota_controller.go
+++ b/pkg/controller/resourcequota/resource_quota_controller.go
@@ -334,7 +334,7 @@ func (rq *Controller) syncResourceQuotaFromKey(ctx context.Context, key string) 
 
 const (
 	kcpClusterScopedQuotaNamespace                 = "admin"
-	kcpExperimentalClusterScopedQuotaAnnotationKey = "experimental.quota.kcp.dev/cluster-scoped"
+	kcpExperimentalClusterScopedQuotaAnnotationKey = "experimental.quota.kcp.io/cluster-scoped"
 )
 
 // syncResourceQuota runs a complete sync of resource quota status across all known kinds

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation.go
@@ -66,7 +66,7 @@ func ValidateCustomResourceDefinition(ctx context.Context, obj *apiextensions.Cu
 		// KCP: loosen naming restriction for CRDs created by the apibindings controller.
 		// TODO(ncdc): a user could potentially set this annotation in one of their own normal CRDs. Is there any
 		// mechanism that is restricted to the system so users can't bypass the standard plural.group requirement?
-		if _, bound := obj.Annotations["apis.kcp.dev/bound-crd"]; bound {
+		if _, bound := obj.Annotations["apis.kcp.io/bound-crd"]; bound {
 			return ret
 		}
 

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/kcp_rest_options_getter.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/kcp_rest_options_getter.go
@@ -43,15 +43,15 @@ func (t apiBindingAwareCRDRESTOptionsGetter) GetRESTOptions(resource schema.Grou
 
 	ret.StorageConfig.KcpExtraStorageMetadata.Cluster = genericapirequest.Cluster{Wildcard: true}
 	// Normal CRDs (not coming from an APIBinding) are stored in e.g. /registry/mygroup.io/widgets/customresources/...
-	if _, bound := t.crd.Annotations["apis.kcp.dev/bound-crd"]; !bound {
+	if _, bound := t.crd.Annotations["apis.kcp.io/bound-crd"]; !bound {
 		ret.ResourcePrefix += "/customresources"
 		return ret, nil
 	}
 
 	// Bound CRDs must have the associated identity annotation
-	apiIdentity := t.crd.Annotations["apis.kcp.dev/identity"]
+	apiIdentity := t.crd.Annotations["apis.kcp.io/identity"]
 	if apiIdentity == "" {
-		return generic.RESTOptions{}, fmt.Errorf("missing 'apis.kcp.dev/identity' annotation on CRD %s|%s for %s.%s", logicalcluster.From(t.crd), t.crd.Name, t.crd.Spec.Names.Plural, t.crd.Spec.Group)
+		return generic.RESTOptions{}, fmt.Errorf("missing 'apis.kcp.io/identity' annotation on CRD %s|%s for %s.%s", logicalcluster.From(t.crd), t.crd.Name, t.crd.Spec.Names.Plural, t.crd.Spec.Group)
 	}
 
 	// Modify the ResourcePrefix so it results in e.g. /registry/mygroup.io/widgets/identity4567/...

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/status/kcp_naming_controller_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/status/kcp_naming_controller_test.go
@@ -34,7 +34,7 @@ func newBoundCRD(resource, group string) *crdBuilder {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: uuid.New().String(),
 				Annotations: map[string]string{
-					"apis.kcp.dev/bound-crd": "",
+					"apis.kcp.io/bound-crd": "",
 				},
 			},
 			Spec: apiextensionsv1.CustomResourceDefinitionSpec{

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/status/naming_controller.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/status/naming_controller.go
@@ -136,7 +136,7 @@ func (c *NamingConditionController) calculateNamesAndConditions(in *apiextension
 	// HACK(kcp): if it's a bound CRD, reset already claimed resources and kinds to empty, because we need to support
 	// multiple bound CRDs with overlapping names. KCP admission will ensure that a workspace does not have any
 	// naming conflicts.
-	if _, kcpBoundCRD := in.Annotations["apis.kcp.dev/bound-crd"]; kcpBoundCRD {
+	if _, kcpBoundCRD := in.Annotations["apis.kcp.io/bound-crd"]; kcpBoundCRD {
 		allResources = sets.NewString()
 		allKinds = sets.NewString()
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/status_strategy_patch.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/status_strategy_patch.go
@@ -23,7 +23,7 @@ import (
 )
 
 func isSyncerViewDiffAnnotation(annotationKey string) bool {
-	return strings.SplitN(annotationKey, "/", 2)[0] == "diff.syncer.internal.kcp.dev"
+	return strings.SplitN(annotationKey, "/", 2)[0] == "diff.syncer.internal.kcp.io"
 }
 
 func getSyncerViewDiffAnnotations(newCustomResourceObject *unstructured.Unstructured) map[string]string {

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/resourcequota/resource_access.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/resourcequota/resource_access.go
@@ -105,7 +105,7 @@ func (e *quotaAccessor) checkCache(quota *corev1.ResourceQuota) *corev1.Resource
 
 const (
 	kcpClusterScopedQuotaNamespace                 = "admin"
-	kcpExperimentalClusterScopedQuotaAnnotationKey = "experimental.quota.kcp.dev/cluster-scoped"
+	kcpExperimentalClusterScopedQuotaAnnotationKey = "experimental.quota.kcp.io/cluster-scoped"
 )
 
 func (e *quotaAccessor) GetQuotas(namespace string) ([]corev1.ResourceQuota, error) {

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/request/context_shard.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/request/context_shard.go
@@ -27,7 +27,7 @@ const (
 	shardContextKey shardKey = iota
 
 	// AnnotationKey is the name of the annotation key used to denote an object's shard name.
-	AnnotationKey = "kcp.dev/shard"
+	AnnotationKey = "kcp.io/shard"
 )
 
 // Shard describes a shard


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR changes kcp.dev to kcp.io in annotations and messages. This is to align the kubernetes fork with the change rolled out in kcp.

#### Which issue(s) this PR fixes:

This PR is a follow-up of: https://github.com/kcp-dev/kcp/pull/2510

It precedes: https://github.com/kcp-dev/kcp/pull/2517
and  follows:  https://github.com/kcp-dev/logicalcluster/pull/31
 
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

Annotations are changed. This PR as the workspace refactoring require an etcd wipe.
