### PR TITLE
UPSTREAM: <carry>: skip subresources for wildcard partial metadata

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/conversion/kcp_wildcard_partial_metadata_converter.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/conversion/kcp_wildcard_partial_metadata_converter.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2023 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package conversion
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/endpoints/handlers"
+)
+
+type kcpWildcardPartialMetadataConverter struct {
+}
+
+func NewKCPWildcardPartialMetadataConverter() *kcpWildcardPartialMetadataConverter {
+	return &kcpWildcardPartialMetadataConverter{}
+}
+
+var _ CRConverter = &kcpWildcardPartialMetadataConverter{}
+
+// Convert is a NOP converter that additionally stores the original APIVersion of each item in the annotation
+// kcp.io/original-api-version. This is necessary for kcp with wildcard partial metadata list/watch requests.
+// For example, if the request is for /clusters/*/apis/kcp.io/v1/widgets, and it's a partial metadata request, the
+// server returns ALL widgets, regardless of their API version. But because this is a partial metadata request, the
+// API version of the returned object is always meta.k8s.io/$version (could be v1 or v1beta1). Any client needing to
+// modify or delete the returned object must know its exact API version. Therefore, we set this annotation with the
+// actual original API version of the object. Clients can use it when constructing dynamic clients to guarantee they
+// // are using the correct API version.
+func (c *kcpWildcardPartialMetadataConverter) Convert(list *unstructured.UnstructuredList, targetGV schema.GroupVersion) (*unstructured.UnstructuredList, error) {
+	for i := range list.Items {
+		item := &list.Items[i]
+
+		// First preserve the actual API version
+		annotations := item.GetAnnotations()
+		if annotations == nil {
+			annotations = make(map[string]string)
+		}
+		annotations[handlers.KCPOriginalAPIVersionAnnotation] = item.GetAPIVersion()
+		item.SetAnnotations(annotations)
+
+		// Now that we've preserved it, we can change it to the targetGV.
+		item.SetGroupVersionKind(targetGV.WithKind(item.GroupVersionKind().Kind))
+	}
+	return list, nil
+}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go
@@ -886,7 +886,7 @@ func (r *crdHandler) getOrCreateServingInfoFor(crd *apiextensionsv1.CustomResour
 	}
 
 	if strings.HasSuffix(string(crd.UID), ".wildcard.partial-metadata") {
-		converter = conversion.NewNOPConverter()
+		converter = conversion.NewKCPWildcardPartialMetadataConverter()
 	}
 
 	safeConverter, unsafeConverter, err := conversion.NewDelegatingConverter(crd, converter)

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/response.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/response.go
@@ -231,6 +231,7 @@ func asPartialObjectMetadata(result runtime.Object, groupVersion schema.GroupVer
 	}
 	partial := meta.AsPartialObjectMetadata(m)
 	partial.GetObjectKind().SetGroupVersionKind(groupVersion.WithKind("PartialObjectMetadata"))
+	setKCPOriginalAPIVersionAnnotation(result, partial)
 	return partial, nil
 }
 
@@ -251,6 +252,7 @@ func asPartialObjectMetadataList(result runtime.Object, groupVersion schema.Grou
 			}
 			partial := meta.AsPartialObjectMetadata(m)
 			partial.GetObjectKind().SetGroupVersionKind(gvk)
+			setKCPOriginalAPIVersionAnnotation(obj, partial)
 			list.Items = append(list.Items, *partial)
 			return nil
 		})
@@ -271,6 +273,7 @@ func asPartialObjectMetadataList(result runtime.Object, groupVersion schema.Grou
 			}
 			partial := meta.AsPartialObjectMetadata(m)
 			partial.GetObjectKind().SetGroupVersionKind(gvk)
+			setKCPOriginalAPIVersionAnnotation(obj, partial)
 			list.Items = append(list.Items, *partial)
 			return nil
 		})

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/response_patch.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/response_patch.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2023 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handlers
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const KCPOriginalAPIVersionAnnotation = "kcp.io/original-api-version"
+
+// setKCPOriginalAPIVersionAnnotation sets the annotation kcp.io/original-api-version on partial indicating the actual
+// API version of the original object. This is necessary for kcp with wildcard partial metadata list/watch requests.
+// For example, if the request is for /clusters/*/apis/kcp.io/v1/widgets, and it's a partial metadata request, the
+// server returns ALL widgets, regardless of their API version. But because this is a partial metadata request, the
+// API version of the returned object is always meta.k8s.io/$version (could be v1 or v1beta1). Any client needing to
+// modify or delete the returned object must know its exact API version. Therefore, we set this annotation with the
+// actual original API version of the object. Clients can use it when constructing dynamic clients to guarantee they
+// are using the correct API version.
+func setKCPOriginalAPIVersionAnnotation(original any, partial *metav1.PartialObjectMetadata) {
+	annotations := partial.GetAnnotations()
+
+	if annotations[KCPOriginalAPIVersionAnnotation] != "" {
+		// Do not overwrite the annotation if it is present. It is set by the kcpWildcardPartialMetadataConverter
+		// during the conversion process so we don't lose the original API version. Changing it here would lead to
+		// an incorrect value.
+		return
+	}
+
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+
+	t, err := meta.TypeAccessor(original)
+	if err != nil {
+		panic(fmt.Errorf("unable to get a TypeAccessor for %T: %w", original, err))
+	}
+
+	annotations[KCPOriginalAPIVersionAnnotation] = t.GetAPIVersion()
+	partial.SetAnnotations(annotations)
+}


### PR DESCRIPTION
For https://github.com/kcp-dev/kcp/pull/2751