### PR TITLE
UPSTREAM: 114920: fix: applyconfiguration-gen fails on map to struct …

### DIFF
--- a/staging/src/k8s.io/code-generator/cmd/applyconfiguration-gen/generators/refgraph.go
+++ b/staging/src/k8s.io/code-generator/cmd/applyconfiguration-gen/generators/refgraph.go
@@ -86,6 +86,7 @@ func (t refGraph) applyConfigForType(field *types.Type) *types.Type {
 			return &types.Type{
 				Kind: types.Map,
 				Elem: t.applyConfigForType(field.Elem),
+				Key:  t.applyConfigForType(field.Key),
 			}
 		}
 		return field


### PR DESCRIPTION
Cherry pick kubernetes/kubernetes#114920, that's required for kcp-dev/kcp#2583.