### PR TITLE
UPSTREAM: <carry>: apiextensions-apiserver allow for disabling generation repair

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/apiserver.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/apiserver.go
@@ -94,6 +94,11 @@ type ExtraConfig struct {
 	// used with the embedded cache server in kcp
 	DisableServerSideApply bool
 
+	// DisableGenerationRepair allows for disabling setting a generation during an object decoding (for objects that haven't had it)
+	// this field is meant to be set by the cache server so that built-in (assuming all CRs must have it) source objects
+	// don't differ from the replicated ones.
+	DisableGenerationRepair bool
+
 	// ConversionFactory is used to provider converters for CRs.
 	ConversionFactory conversion.Factory
 }
@@ -242,6 +247,7 @@ func (c completedConfig) New(delegationTarget genericapiserver.DelegationTarget)
 		apiGroupInfo.StaticOpenAPISpec,
 		c.GenericConfig.MaxRequestBodyBytes,
 		c.ExtraConfig.DisableServerSideApply,
+		c.ExtraConfig.DisableGenerationRepair,
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Exposes `DisableGenerationRepair` option that allows for disabling setting a generation during an object decoding (for objects that haven't had it).
This field is meant to be set by the cache server so that built-in source objects don't differ from the replicated ones.

Previously replicated objects always had the generation field set even if the source/original object hasn't had this field set (i.e. ClusterRoles).

fixes: https://github.com/kcp-dev/kcp/issues/2935