### PR TITLE
1.26 rebase

### DIFF
--- a/pkg/controller/resourcequota/resource_quota_monitor.go
+++ b/pkg/controller/resourcequota/resource_quota_monitor.go
@@ -232,6 +232,7 @@ func (qm *QuotaMonitor) SyncMonitors(ctx context.Context, resources map[schema.G
 	for _, monitor := range toRemove {
 		if monitor.stopCh != nil {
 			close(monitor.stopCh)
+			monitor.stopCh = nil
 		}
 	}
 
@@ -333,6 +334,7 @@ func (qm *QuotaMonitor) Run(ctx context.Context) {
 		if monitor.stopCh != nil {
 			stopped++
 			close(monitor.stopCh)
+			monitor.stopCh = nil
 		}
 	}
 	logger.Info("QuotaMonitor stopped monitors", "stopped", stopped, "total", len(monitors))


### PR DESCRIPTION
The upstream commits before "baseline kcp on 1.26" are from #133 to potentially make those easier to review. I will rewrite the commits a bit to clean things up once we're ready to proceed.