### PR TITLE
UPSTREAM: <carry>: include cluster name in authz SubjectAccessReview in webhooks

### DIFF
--- a/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook/webhook.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook/webhook.go
@@ -41,6 +41,7 @@ import (
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	authorizationcel "k8s.io/apiserver/pkg/authorization/cel"
+	"k8s.io/apiserver/pkg/endpoints/request"
 	genericfeatures "k8s.io/apiserver/pkg/features"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/apiserver/pkg/util/webhook"
@@ -194,6 +195,14 @@ func (w *WebhookAuthorizer) Authorize(ctx context.Context, attr authorizer.Attri
 			Groups: user.GetGroups(),
 			Extra:  convertToSARExtra(user.GetExtra()),
 		}
+	}
+
+	clusterName, err := request.ClusterNameFrom(ctx)
+	if err == nil {
+		if r.Spec.Extra == nil {
+			r.Spec.Extra = map[string]authorizationv1.ExtraValue{}
+		}
+		r.Spec.Extra["authentication.kubernetes.io/cluster-name"] = authorizationv1.ExtraValue{clusterName.Path().String()}
 	}
 
 	if attr.IsResourceRequest() {


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
I am working on enabling the authorization webhook feature in kcp, allowing to send authz requests to an external URL. To make this useful, the SubjectAccessReview (SAR) needs to also include the cluster name. Sadly there is no good way to override the way the webhook plugin constructs a SAR and it's also not trivial to just construct a different, custom webhook implementation (because it is wrapped in a reloadableAuthorizer, which would also need to be copied and adjusted to make it work).

This PR therefore represents the simplest possible approach: Take the cluster name from the context, stuff it into the Extra field, done. The key name is `authentication.kubernetes.io/cluster-name` based on https://github.com/kcp-dev/kcp/pull/3156, even though it's kinda misleading (authentication vs. authorization).

#### Does this PR introduce a user-facing change?
NB: This includes the fixup in #152
```release-note
The authz webhook plugin will include the cluster name as an extra field in the SubjectAccessReview, called `authorization.kubernetes.io/cluster-name`.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
NONE
```
