### PR TITLE
prevent conflict with pre-existing auth annotation

### DIFF
--- a/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook/webhook.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook/webhook.go
@@ -55,6 +55,9 @@ import (
 const (
 	// The maximum length of requester-controlled attributes to allow caching.
 	maxControlledAttrCacheSize = 10000
+
+	// ClusterNameKey is the logical cluster name a webhook message originates from.
+	ClusterNameKey = "authorization.kubernetes.io/cluster-name"
 )
 
 // DefaultRetryBackoff returns the default backoff parameters for webhook retry.
@@ -197,12 +200,11 @@ func (w *WebhookAuthorizer) Authorize(ctx context.Context, attr authorizer.Attri
 		}
 	}
 
-	clusterName, err := request.ClusterNameFrom(ctx)
-	if err == nil {
+	if clusterName, err := request.ClusterNameFrom(ctx); err == nil {
 		if r.Spec.Extra == nil {
 			r.Spec.Extra = map[string]authorizationv1.ExtraValue{}
 		}
-		r.Spec.Extra["authentication.kubernetes.io/cluster-name"] = authorizationv1.ExtraValue{clusterName.Path().String()}
+		r.Spec.Extra[ClusterNameKey] = authorizationv1.ExtraValue{clusterName.Path().String()}
 	}
 
 	if attr.IsResourceRequest() {


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

In #151 I accidentally used a field name that I thought was not yet merged or used in kcp. However once we bumped the k8s dependency in kcp, we swiftly noticed that the previous key was in fact already used in kcp, breaking quite a few e2e tests.

This PR rectifies that by choosing a new, unused name for the extra config key.

#### Does this PR introduce a user-facing change?
(I will update the previous PR's release-notes.)
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
