### PR TITLE
UPSTREAM 130180: Make disable lookups of SA related artifacts working

### DIFF
--- a/pkg/kubeapiserver/authenticator/config.go
+++ b/pkg/kubeapiserver/authenticator/config.go
@@ -140,7 +140,7 @@ func (config Config) New(serverLifecycle context.Context) (authenticator.Request
 		tokenAuthenticators = append(tokenAuthenticators, serviceAccountAuth)
 	}
 	if len(config.ServiceAccountIssuers) > 0 && config.ServiceAccountPublicKeysGetter != nil {
-		serviceAccountAuth, err := newServiceAccountAuthenticator(config.ServiceAccountIssuers, config.ServiceAccountPublicKeysGetter, config.APIAudiences, config.ServiceAccountTokenGetter)
+		serviceAccountAuth, err := newServiceAccountAuthenticator(config.ServiceAccountIssuers, config.ServiceAccountPublicKeysGetter, config.APIAudiences, config.ServiceAccountTokenGetter, config.ServiceAccountLookup)
 		if err != nil {
 			return nil, nil, nil, nil, err
 		}
@@ -357,11 +357,11 @@ func newLegacyServiceAccountAuthenticator(publicKeysGetter serviceaccount.Public
 }
 
 // newServiceAccountAuthenticator returns an authenticator.Token or an error
-func newServiceAccountAuthenticator(issuers []string, publicKeysGetter serviceaccount.PublicKeysGetter, apiAudiences authenticator.Audiences, serviceAccountGetter serviceaccount.ServiceAccountTokenClusterGetter) (authenticator.Token, error) {
+func newServiceAccountAuthenticator(issuers []string, publicKeysGetter serviceaccount.PublicKeysGetter, apiAudiences authenticator.Audiences, serviceAccountGetter serviceaccount.ServiceAccountTokenClusterGetter, lookup bool) (authenticator.Token, error) {
 	if publicKeysGetter == nil {
 		return nil, fmt.Errorf("no public key getter provided")
 	}
-	tokenAuthenticator := serviceaccount.JWTTokenAuthenticator(issuers, publicKeysGetter, apiAudiences, serviceaccount.NewValidator(serviceAccountGetter))
+	tokenAuthenticator := serviceaccount.JWTTokenAuthenticator(issuers, publicKeysGetter, apiAudiences, serviceaccount.NewValidator(lookup, serviceAccountGetter))
 	return tokenAuthenticator, nil
 }
 

--- a/pkg/serviceaccount/claims.go
+++ b/pkg/serviceaccount/claims.go
@@ -132,13 +132,15 @@ func Claims(sa core.ServiceAccount, pod *core.Pod, secret *core.Secret, node *co
 	return sc, pc, nil
 }
 
-func NewValidator(getter ServiceAccountTokenClusterGetter) Validator[privateClaims] {
+func NewValidator(lookup bool, getter ServiceAccountTokenClusterGetter) Validator[privateClaims] {
 	return &validator{
+		lookup: lookup,
 		getter: getter,
 	}
 }
 
 type validator struct {
+	lookup bool
 	getter ServiceAccountTokenClusterGetter
 }
 
@@ -181,22 +183,24 @@ func (v *validator) Validate(ctx context.Context, _ string, public *jwt.Claims, 
 	noderef := private.Kubernetes.Node
 	secref := private.Kubernetes.Secret
 	// Make sure service account still exists (name and UID)
-	serviceAccount, err := v.getter.Cluster(clusterName).GetServiceAccount(namespace, saref.Name)
-	if err != nil {
-		klog.V(4).Infof("Could not retrieve service account %s/%s: %v", namespace, saref.Name, err)
-		return nil, err
+	if v.lookup {
+		serviceAccount, err := v.getter.Cluster(clusterName).GetServiceAccount(namespace, saref.Name)
+		if err != nil {
+			klog.V(4).Infof("Could not retrieve service account %s/%s: %v", namespace, saref.Name, err)
+			return nil, err
+		}
+
+		if string(serviceAccount.UID) != saref.UID {
+			klog.V(4).Infof("Service account UID no longer matches %s/%s: %q != %q", namespace, saref.Name, string(serviceAccount.UID), saref.UID)
+			return nil, fmt.Errorf("service account UID (%s) does not match claim (%s)", serviceAccount.UID, saref.UID)
+		}
+		if serviceAccount.DeletionTimestamp != nil && serviceAccount.DeletionTimestamp.Time.Before(invalidIfDeletedBefore) {
+			klog.V(4).Infof("Service account has been deleted %s/%s", namespace, saref.Name)
+			return nil, fmt.Errorf("service account %s/%s has been deleted", namespace, saref.Name)
+		}
 	}
 
-	if string(serviceAccount.UID) != saref.UID {
-		klog.V(4).Infof("Service account UID no longer matches %s/%s: %q != %q", namespace, saref.Name, string(serviceAccount.UID), saref.UID)
-		return nil, fmt.Errorf("service account UID (%s) does not match claim (%s)", serviceAccount.UID, saref.UID)
-	}
-	if serviceAccount.DeletionTimestamp != nil && serviceAccount.DeletionTimestamp.Time.Before(invalidIfDeletedBefore) {
-		klog.V(4).Infof("Service account has been deleted %s/%s", namespace, saref.Name)
-		return nil, fmt.Errorf("service account %s/%s has been deleted", namespace, saref.Name)
-	}
-
-	if secref != nil {
+	if v.lookup && secref != nil {
 		// Make sure token hasn't been invalidated by deletion of the secret
 		secret, err := v.getter.Cluster(clusterName).GetSecret(namespace, secref.Name)
 		if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Makes disable serviceaccount related resources lookups working for new implementation. This was working only on legacy implementation. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
