### PR TITLE
UPSTREAM: <carry>: Keep system:cluster:* groups

### DIFF
--- a/pkg/registry/rbac/validation/kcp.go
+++ b/pkg/registry/rbac/validation/kcp.go
@@ -117,8 +117,13 @@ func EffectiveUsers(clusterName logicalcluster.Name, u user.Info) []user.Info {
 				}
 				for _, g := range u.GetGroups() {
 					if g == user.AllAuthenticated {
-						rewritten.Groups = []string{user.AllAuthenticated}
-						break
+						rewritten.Groups = append(rewritten.Groups, user.AllAuthenticated)
+					}
+					// system:cluster:* groups are used to allow
+					// controlling binding APIExports between workspaces
+					// via RBAC
+					if strings.HasPrefix(g, "system:cluster:") {
+						rewritten.Groups = append(rewritten.Groups, g)
 					}
 				}
 				ret = append(ret, rewritten)
@@ -147,7 +152,18 @@ func EffectiveUsers(clusterName logicalcluster.Name, u user.Info) []user.Info {
 	recursive(u)
 
 	if wantAuthenticated {
-		ret = append(ret, authenticated)
+		authed := &user.DefaultInfo{
+			Name:   user.Anonymous,
+			Groups: []string{user.AllAuthenticated},
+		}
+		for _, g := range u.GetGroups() {
+			// system:cluster:* groups are used to allow controlling
+			// binding APIExports between workspaces via RBAC
+			if strings.HasPrefix(g, "system:cluster:") {
+				authed.Groups = append(authed.Groups, g)
+			}
+		}
+		ret = append(ret, authed)
 	}
 	if wantUnauthenticated {
 		ret = append(ret, unauthenticated)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

See https://github.com/kcp-dev/kcp/issues/3513

Two types of users get to keep groups starting with `system:cluster:*`:
1. Service Accounts
2. Authenticated users not originating from the cluster the request was made from

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
