### PR TITLE
Tie global service account test result to feature gate it relies on 

### DIFF
--- a/pkg/registry/rbac/validation/kcp_test.go
+++ b/pkg/registry/rbac/validation/kcp_test.go
@@ -11,6 +11,8 @@ import (
 	authserviceaccount "k8s.io/apiserver/pkg/authentication/serviceaccount"
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/endpoints/request"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/kubernetes/pkg/features"
 )
 
 func TestIsInScope(t *testing.T) {
@@ -145,6 +147,8 @@ func TestIsInScope(t *testing.T) {
 }
 
 func TestAppliesToUserWithWarrantsAndScopes(t *testing.T) {
+	globalsa := utilfeature.DefaultFeatureGate.Enabled(features.GlobalServiceAccount)
+
 	tests := []struct {
 		name string
 		user user.Info
@@ -266,7 +270,12 @@ func TestAppliesToUserWithWarrantsAndScopes(t *testing.T) {
 			name: "local service account as global kcp service account",
 			user: &user.DefaultInfo{Name: "system:serviceaccount:ns:sa", Extra: map[string][]string{"authentication.kcp.io/cluster-name": {"this"}}},
 			sub:  rbacv1.Subject{Kind: "User", Name: "system:kcp:serviceaccount:this:ns:sa"},
-			want: true,
+			// This test can only pass if the feature gate is enabled.
+			// Since global service accounts are not fully implemented
+			// yet the result of this test is tied to the feature gate.
+			// When the feature is fully implemented this test should
+			// run once with and once without the feature gate.
+			want: globalsa,
 		},
 		{
 			name: "foreign service account as global kcp service account",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This check was introduced when implementing the GlobalServiceAccount feature gate.
This check breaks this test: https://github.com/kcp-dev/kubernetes/blob/ffe1d7c8649b8fef60c69cf91924fb34a2c64fbb/pkg/registry/rbac/validation/kcp_test.go#L266-L269

Because the feature gate is disabled by default the `system:kcp:serviceaccount:this:ns:sa` user is not generated by the EffectiveUsers, leading to the test failing.
Instead the result now depends on the feature gate and a note is added to fix the test properly once global SA is implemented.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
