### PR TITLE
Add system:cluster:... groups to effective users

### DIFF
--- a/pkg/registry/rbac/validation/kcp.go
+++ b/pkg/registry/rbac/validation/kcp.go
@@ -3,6 +3,7 @@ package validation
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/kcp-dev/logicalcluster/v3"
@@ -31,6 +32,10 @@ const (
 	// The clusters in one extra value are or'ed, multiple extra values
 	// are and'ed.
 	ScopeExtraKey = "authentication.kcp.io/scopes"
+
+	// ClusterExtraKey is the key used in a user's "extra" to specify
+	// the origin cluster of the user.
+	ClusterExtraKey = "authentication.kcp.io/cluster-name"
 
 	// ClusterPrefix is the prefix for cluster scopes.
 	clusterPrefix = "cluster:"
@@ -79,6 +84,35 @@ func withScopesAndWarrants(appliesToUser appliesToUserFunc) appliesToUserFuncCtx
 	}
 }
 
+// EffectiveScopes takes the scopes of a user and returns the
+// intersection of all scopes.
+func EffectiveScopes(in []string) []string {
+	if len(in) == 0 {
+		return in
+	}
+
+	effectiveScopes := strings.Split(in[0], ",")
+	if len(effectiveScopes) == 0 || len(in) == 1 {
+		return effectiveScopes
+	}
+
+	for _, further := range in[1:] {
+		furtherScopes := strings.Split(further, ",")
+		newEffective := make([]string, 0, len(effectiveScopes))
+		for _, es := range effectiveScopes {
+			if slices.Contains(furtherScopes, es) {
+				newEffective = append(newEffective, es)
+			}
+		}
+		effectiveScopes = newEffective
+		if len(effectiveScopes) == 0 {
+			return []string{}
+		}
+	}
+
+	return effectiveScopes
+}
+
 var (
 	authenticated   = &user.DefaultInfo{Name: user.Anonymous, Groups: []string{user.AllAuthenticated}}
 	unauthenticated = &user.DefaultInfo{Name: user.Anonymous, Groups: []string{user.AllUnauthenticated}}
@@ -96,6 +130,10 @@ func EffectiveUsers(clusterName logicalcluster.Name, u user.Info) []user.Info {
 	recursive = func(u user.Info) {
 		if IsInScope(u, clusterName) {
 			ret = append(ret, u)
+			// TODO(ntnn): Add system:cluster:<cluster> group?
+			// Though the user is in scope so it shouldn't need the
+			// group added but it might be better for consistency?
+			// Leaving it out for now but could be revisited.
 		} else {
 			found := false
 			for _, g := range u.GetGroups() {
@@ -119,15 +157,27 @@ func EffectiveUsers(clusterName logicalcluster.Name, u user.Info) []user.Info {
 					if g == user.AllAuthenticated {
 						rewritten.Groups = append(rewritten.Groups, user.AllAuthenticated)
 					}
-					// system:cluster:* groups are used to allow
-					// controlling binding APIExports between workspaces
-					// via RBAC
-					if strings.HasPrefix(g, "system:cluster:") {
-						rewritten.Groups = append(rewritten.Groups, g)
+				}
+				// Add the system:cluster:<cluster> group if the SA has
+				// an effective scope for the cluster the effective
+				// users are calculated for.
+				for _, g := range EffectiveScopes(u.GetExtra()[ScopeExtraKey]) {
+					if strings.HasPrefix(g, clusterPrefix) {
+						rewritten.Groups = append(rewritten.Groups, "system:"+g)
 					}
 				}
 				ret = append(ret, rewritten)
 			}
+		}
+
+		if len(u.GetExtra()[WarrantExtraKey]) > 0 && len(u.GetExtra()[ClusterExtraKey]) > 0 && !IsServiceAccount(u) {
+			// Users that are not SAs and have a cluster extra key
+			// cannot have warrants, as they would be coming from
+			// per-workspace authentication.
+			// If this happens it is either a misconfiguration from the
+			// admin or a malicious actor that tries to escalate
+			// privileges through warrants.
+			return
 		}
 
 		for _, v := range u.GetExtra()[WarrantExtraKey] {
@@ -143,8 +193,16 @@ func EffectiveUsers(clusterName logicalcluster.Name, u user.Info) []user.Info {
 				Extra:  w.Extra,
 			}
 			if IsServiceAccount(wu) && len(w.Extra[authserviceaccount.ClusterNameKey]) == 0 {
-				// warrants must be scoped to a cluster
+				// For SAs warrants must be scoped to a cluster.
 				continue
+			}
+			// Add the system:cluster:<cluster> group if the warrant has
+			// an effective scope for the cluster the effective
+			// users are calculated for.
+			for _, g := range EffectiveScopes(wu.GetExtra()[ScopeExtraKey]) {
+				if strings.HasPrefix(g, clusterPrefix) {
+					wu.Groups = append(wu.Groups, "system:"+g)
+				}
 			}
 			recursive(wu)
 		}
@@ -156,11 +214,9 @@ func EffectiveUsers(clusterName logicalcluster.Name, u user.Info) []user.Info {
 			Name:   user.Anonymous,
 			Groups: []string{user.AllAuthenticated},
 		}
-		for _, g := range u.GetGroups() {
-			// system:cluster:* groups are used to allow controlling
-			// binding APIExports between workspaces via RBAC
-			if strings.HasPrefix(g, "system:cluster:") {
-				authed.Groups = append(authed.Groups, g)
+		for _, g := range EffectiveScopes(u.GetExtra()[ScopeExtraKey]) {
+			if strings.HasPrefix(g, clusterPrefix) {
+				authed.Groups = append(authed.Groups, "system:"+g)
 			}
 		}
 		ret = append(ret, authed)

--- a/pkg/registry/rbac/validation/kcp_test.go
+++ b/pkg/registry/rbac/validation/kcp_test.go
@@ -244,7 +244,7 @@ func TestAppliesToUserWithWarrantsAndScopes(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "non-cluster-aware service account as warrant", // TODO what is this supposed to test?
+			name: "non-cluster-aware service account as warrant",
 			user: &user.DefaultInfo{Name: "user-b", Extra: map[string][]string{WarrantExtraKey: {`{"user":"system:serviceaccount:ns:sa"}`}}},
 			sub:  rbacv1.Subject{Kind: "ServiceAccount", Namespace: "ns", Name: "sa"},
 			want: false,

--- a/pkg/registry/rbac/validation/kcp_test.go
+++ b/pkg/registry/rbac/validation/kcp_test.go
@@ -173,10 +173,28 @@ func TestAppliesToUserWithWarrantsAndScopes(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "simple matching user with warrants and from this cluster",
+			user: &user.DefaultInfo{Name: "user-a", Extra: map[string][]string{
+				WarrantExtraKey: {`{"user":"user-b"}`},
+				ClusterExtraKey: {"this"},
+			}},
+			sub:  rbacv1.Subject{Kind: "User", Name: "user-a"},
+			want: true, // user is subject
+		},
+		{
 			name: "simple non-matching user with matching warrants",
 			user: &user.DefaultInfo{Name: "user-b", Extra: map[string][]string{WarrantExtraKey: {`{"user":"user-a"}`}}},
 			sub:  rbacv1.Subject{Kind: "User", Name: "user-a"},
 			want: true,
+		},
+		{
+			name: "simple non-matching user with matching warrants but with cluster-name",
+			user: &user.DefaultInfo{Name: "user-b", Extra: map[string][]string{
+				WarrantExtraKey: {`{"user":"user-a"}`},
+				ClusterExtraKey: {"this"},
+			}},
+			sub:  rbacv1.Subject{Kind: "User", Name: "user-a"},
+			want: false, // Warrants are ineffective on users with cluster
 		},
 		{
 			name: "simple non-matching user with non-matching warrants",
@@ -189,6 +207,15 @@ func TestAppliesToUserWithWarrantsAndScopes(t *testing.T) {
 			user: &user.DefaultInfo{Name: "user-b", Extra: map[string][]string{WarrantExtraKey: {`{"user":"user-b"}`, `{"user":"user-a"}`, `{"user":"user-c"}`}}},
 			sub:  rbacv1.Subject{Kind: "User", Name: "user-a"},
 			want: true,
+		},
+		{
+			name: "simple non-matching user with multiple warrants and cluster-name",
+			user: &user.DefaultInfo{Name: "user-b", Extra: map[string][]string{
+				WarrantExtraKey: {`{"user":"user-b"}`, `{"user":"user-a"}`, `{"user":"user-c"}`},
+				ClusterExtraKey: {"this"},
+			}},
+			sub:  rbacv1.Subject{Kind: "User", Name: "user-a"},
+			want: false, // Warrants are ineffective on users with cluster
 		},
 		{
 			name: "simple non-matching user with nested warrants",
@@ -206,18 +233,18 @@ func TestAppliesToUserWithWarrantsAndScopes(t *testing.T) {
 		},
 		{
 			name: "non-cluster-aware service account with this scope",
-			user: &user.DefaultInfo{Name: "system:serviceaccount:ns:sa", Extra: map[string][]string{"authentication.kcp.io/scopes": {"cluster:this"}}},
+			user: &user.DefaultInfo{Name: "system:serviceaccount:ns:sa", Extra: map[string][]string{ScopeExtraKey: {"cluster:this"}}},
 			sub:  rbacv1.Subject{Kind: "ServiceAccount", Namespace: "ns", Name: "sa"},
 			want: true,
 		},
 		{
 			name: "non-cluster-aware service account with other scope",
-			user: &user.DefaultInfo{Name: "system:serviceaccount:ns:sa", Extra: map[string][]string{"authentication.kcp.io/scopes": {"cluster:other"}}},
+			user: &user.DefaultInfo{Name: "system:serviceaccount:ns:sa", Extra: map[string][]string{ScopeExtraKey: {"cluster:other"}}},
 			sub:  rbacv1.Subject{Kind: "ServiceAccount", Namespace: "ns", Name: "sa"},
 			want: false,
 		},
 		{
-			name: "non-cluster-aware service account as warrant",
+			name: "non-cluster-aware service account as warrant", // TODO what is this supposed to test?
 			user: &user.DefaultInfo{Name: "user-b", Extra: map[string][]string{WarrantExtraKey: {`{"user":"system:serviceaccount:ns:sa"}`}}},
 			sub:  rbacv1.Subject{Kind: "ServiceAccount", Namespace: "ns", Name: "sa"},
 			want: false,
@@ -226,37 +253,46 @@ func TestAppliesToUserWithWarrantsAndScopes(t *testing.T) {
 		// service accounts with cluster
 		{
 			name: "local service account",
-			user: &user.DefaultInfo{Name: "system:serviceaccount:ns:sa", Extra: map[string][]string{"authentication.kcp.io/cluster-name": {"this"}}},
+			user: &user.DefaultInfo{Name: "system:serviceaccount:ns:sa", Extra: map[string][]string{ClusterExtraKey: {"this"}}},
 			sub:  rbacv1.Subject{Kind: "ServiceAccount", Namespace: "ns", Name: "sa"},
 			want: true,
 		},
 		{
 			name: "foreign service account",
-			user: &user.DefaultInfo{Name: "system:serviceaccount:ns:sa", Extra: map[string][]string{"authentication.kcp.io/cluster-name": {"other"}}},
+			user: &user.DefaultInfo{Name: "system:serviceaccount:ns:sa", Extra: map[string][]string{ClusterExtraKey: {"other"}}},
 			sub:  rbacv1.Subject{Kind: "ServiceAccount", Namespace: "ns", Name: "sa"},
 			want: false,
 		},
 		{
 			name: "foreign service account with local warrant",
-			user: &user.DefaultInfo{Name: "system:serviceaccount:ns:sa", Extra: map[string][]string{"authentication.kcp.io/cluster-name": {"other"}, WarrantExtraKey: {`{"user":"system:serviceaccount:ns:sa","extra":{"authentication.kcp.io/cluster-name":["this"]}}`}}},
+			user: &user.DefaultInfo{Name: "system:serviceaccount:ns:sa", Extra: map[string][]string{
+				ClusterExtraKey: {"other"},
+				WarrantExtraKey: {`{"user":"system:serviceaccount:ns:sa","extra":{"authentication.kcp.io/cluster-name":["this"]}}`},
+			}},
 			sub:  rbacv1.Subject{Kind: "ServiceAccount", Namespace: "ns", Name: "sa"},
 			want: true,
 		},
 		{
 			name: "foreign service account with foreign warrant",
-			user: &user.DefaultInfo{Name: "system:serviceaccount:ns:sa", Extra: map[string][]string{"authentication.kcp.io/cluster-name": {"other"}, WarrantExtraKey: {`{"user":"system:serviceaccount:ns:sa","extra":{"authentication.kcp.io/cluster-name":["other"]}}`}}},
+			user: &user.DefaultInfo{Name: "system:serviceaccount:ns:sa", Extra: map[string][]string{
+				ClusterExtraKey: {"other"},
+				WarrantExtraKey: {`{"user":"system:serviceaccount:ns:sa","extra":{"authentication.kcp.io/cluster-name":["other"]}}`},
+			}},
 			sub:  rbacv1.Subject{Kind: "ServiceAccount", Namespace: "ns", Name: "sa"},
 			want: false,
 		},
 		{
 			name: "local service account with multiple clusters",
-			user: &user.DefaultInfo{Name: "system:serviceaccount:ns:sa", Extra: map[string][]string{"authentication.kcp.io/cluster-name": {"this", "this"}}},
+			user: &user.DefaultInfo{Name: "system:serviceaccount:ns:sa", Extra: map[string][]string{ClusterExtraKey: {"this", "this"}}},
 			sub:  rbacv1.Subject{Kind: "ServiceAccount", Namespace: "ns", Name: "sa"},
 			want: false,
 		},
 		{
 			name: "out-of-scope local service account",
-			user: &user.DefaultInfo{Name: "system:serviceaccount:ns:sa", Extra: map[string][]string{"authentication.kcp.io/cluster-name": {"this"}, "authentication.kcp.io/scopes": {"cluster:other"}}},
+			user: &user.DefaultInfo{Name: "system:serviceaccount:ns:sa", Extra: map[string][]string{
+				ClusterExtraKey: {"this"},
+				ScopeExtraKey:   {"cluster:other"},
+			}},
 			sub:  rbacv1.Subject{Kind: "ServiceAccount", Namespace: "ns", Name: "sa"},
 			want: false,
 		},
@@ -483,6 +519,71 @@ func TestPrefixUser(t *testing.T) {
 			got := PrefixUser(tt.u, tt.prefix)
 			if diff := cmp.Diff(tt.want, got); diff != "" {
 				t.Errorf("prefixUser() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestEffectiveUsers(t *testing.T) {
+	tests := map[string]struct {
+		in   []string
+		want []string
+	}{
+		"empty": {
+			in:   []string{},
+			want: []string{},
+		},
+		"one scope entry, one cluster": {
+			in:   []string{"cluster:this"},
+			want: []string{"cluster:this"},
+		},
+		"one scope entry, multiple clusters": {
+			in:   []string{"cluster:this,cluster:that"},
+			want: []string{"cluster:this", "cluster:that"},
+		},
+		"multiple scope entries, multiple clusters, empty result": {
+			in: []string{
+				"cluster:this,cluster:that",
+				"cluster:other",
+			},
+			want: []string{},
+		},
+		"multiple scope entries, multiple clusters, non-empty result": {
+			in: []string{
+				"cluster:this,cluster:that",
+				"cluster:other,cluster:this",
+			},
+			want: []string{"cluster:this"},
+		},
+		"multiple scopes entries, multiple clusters, multiple others": {
+			in: []string{
+				"cluster:this,foo:bar",
+				"cluster:this,cluster:other,foo:bar",
+				"cluster:third,foo:bar,foo:baz",
+			},
+			want: []string{
+				"foo:bar",
+			},
+		},
+		"multiple equal scopes entries": {
+			in: []string{
+				"cluster:this,cluster:other,foo:bar",
+				"cluster:this,cluster:other,foo:bar",
+				"cluster:this,cluster:other,foo:bar",
+			},
+			want: []string{
+				"cluster:this",
+				"cluster:other",
+				"foo:bar",
+			},
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			got := EffectiveScopes(tt.in)
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("EffectiveScopes() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/staging/src/k8s.io/apiserver/pkg/authentication/serviceaccount/util.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/serviceaccount/util.go
@@ -52,6 +52,8 @@ const (
 	NodeUIDKey = "authentication.kubernetes.io/node-uid"
 	// ClusterNameKey is the logical cluster name this service-account comes from.
 	ClusterNameKey = "authentication.kcp.io/cluster-name"
+	// ClusterScopeKey additionally sets the scope for the service-account to the cluster it belongs to.
+	ClusterScopeKey = "authentication.kcp.io/scopes"
 )
 
 // MakeUsername generates a username from the given namespace and ServiceAccount name.
@@ -170,6 +172,7 @@ func (sa *ServiceAccountInfo) UserInfo() user.Info {
 		info.Extra = map[string][]string{}
 	}
 	info.Extra[ClusterNameKey] = []string{sa.ClusterName.String()}
+	info.Extra[ClusterScopeKey] = []string{"cluster:" + sa.ClusterName.String()}
 	return info
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Adds the extra `authentication.kcp.io/scopes` to service accounts similar to per-workspace auth users.
Adds the group `system:cluster:...` to effective users based off of `authentication.kcp.io/scopes`.

Needed for github.com/kcp-dev/kcp/pull/3530

##### Problems

Users that do not originate from per-ws auth and do not have a warrant or scope cannot get a `system:cluster:...`.

Originally I had added the group explicitly for APIBinding requests and allowed the group through here. However that pattern would require adding the `system:cluster:` group wherever cross-ws requests can happen.

A potential solution could be what this PR proposes with building the groups based off of the scopes as well as allowing `system:clluster:` group through, adding those groups explicitly where necessary (e.g. in APIBinding) request.

Since per-ws auth does not allow setting `system:` groups coming from the auth provider that could be reasonably secure. Although it feels very hacky.

Alternatively we'd have to update EffectiveUsers/Groups to get the information on the source and target cluster so the correct info can be calculated more accurately.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
