### PR TITLE
forward current cluster context in TokenReviews

### DIFF
--- a/pkg/registry/authentication/tokenreview/storage.go
+++ b/pkg/registry/authentication/tokenreview/storage.go
@@ -94,6 +94,15 @@ func (r *REST) Create(ctx context.Context, obj runtime.Object, createValidation 
 	fakeReq := &http.Request{Header: http.Header{}}
 	fakeReq.Header.Add("Authorization", "Bearer "+tokenReview.Spec.Token)
 
+	// kcp
+	cluster := genericapirequest.ClusterFrom(ctx)
+	if cluster == nil {
+		return nil, apierrors.NewBadRequest("cannot handle TokenReviews wihout a cluster in the context")
+	}
+	// For the per-workspace-authentication in kcp to work, the authenticator needs access to the cluster name.
+	fakeReq = fakeReq.WithContext(genericapirequest.WithCluster(fakeReq.Context(), *cluster))
+	// end kcp
+
 	auds := tokenReview.Spec.Audiences
 	if len(auds) == 0 {
 		auds = r.apiAudiences


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
With the introduction of per-workspace authentication in kcp, the handler for TokenReviews needs to ensure that the current cluster context (the cluster in which the TokenReview is created) is included in the fake request, so that the authenticator can find the auth configuration.

This fix alone will not make TokenReviews work in kcp (with the WorkspaceAuthentication feature gate enabled). kcp still needs to be patched to provide a suitable authenticator to the storage provider which does not rely on other handlers in the handler mux chain to provide stuff to it. PR for that is in the works.

#### Which issue(s) this PR is related to:
https://github.com/kcp-dev/kcp/issues/3614

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
