### PR TITLE
UPSTREAM: <carry>: Use a shared cel environment for fitlerCompiler

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/generic/webhook.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/generic/webhook.go
@@ -21,9 +21,6 @@ import (
 	"fmt"
 	"io"
 
-	"k8s.io/apiserver/pkg/cel/environment"
-	"k8s.io/apiserver/pkg/features"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/klog/v2"
 
 	admissionv1 "k8s.io/api/admission/v1"
@@ -102,7 +99,7 @@ func NewWebhook(handler *admission.Handler, configFile io.Reader, sourceFactory 
 		namespaceMatcher: &namespace.Matcher{},
 		objectMatcher:    &object.Matcher{},
 		dispatcher:       dispatcherFactory(&cm),
-		filterCompiler:   cel.NewConditionCompiler(environment.MustBaseEnvSet(environment.DefaultCompatibilityVersion(), utilfeature.DefaultFeatureGate.Enabled(features.StrictCostEnforcementForWebhooks))),
+		filterCompiler:   sharedFilterCompiler,
 	}, nil
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/generic/webhook_kcp.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/generic/webhook_kcp.go
@@ -1,6 +1,10 @@
 package generic
 
 import (
+	"k8s.io/apiserver/pkg/admission/plugin/cel"
+	"k8s.io/apiserver/pkg/cel/environment"
+	"k8s.io/apiserver/pkg/features"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	coreinformers "k8s.io/client-go/informers/core/v1"
 )
 
@@ -17,3 +21,5 @@ func (a *Webhook) SetReadyFuncFromKCP(namespaceInformer coreinformers.NamespaceI
 		return namespaceInformer.Informer().HasSynced() && a.hookSource.HasSynced()
 	})
 }
+
+var sharedFilterCompiler = cel.NewConditionCompiler(environment.MustBaseEnvSet(environment.DefaultCompatibilityVersion(), utilfeature.DefaultFeatureGate.Enabled(features.StrictCostEnforcementForWebhooks)))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Majorly reduces the memory consumption per workspace.

For 100 workspaces pre patch:

```
File: kcp
Type: alloc_space
Time: 2025-12-16 15:18:20 CET
Showing nodes accounting for 40MB, 0.1% of 39150.08MB total
Dropped 4033 nodes (cum <= 195.75MB)
Showing top 10 nodes out of 374
      flat  flat%   sum%        cum   cum%
         0     0%     0% 29523.45MB 75.41%  k8s.io/apiserver/pkg/endpoints/handlers/finisher.finishRequest.func1
    4.50MB 0.011% 0.011% 25916.95MB 66.20%  k8s.io/apiserver/pkg/admission/plugin/webhook/generic.NewWebhook
       1MB 0.0026% 0.014% 25344.90MB 64.74%  k8s.io/apiserver/pkg/admission/plugin/cel.NewConditionCompiler (inline)
         0     0% 0.014% 25343.90MB 64.74%  k8s.io/apiserver/pkg/admission/plugin/cel.NewCompiler (inline)
    8.50MB 0.022% 0.036% 25343.90MB 64.74%  k8s.io/apiserver/pkg/admission/plugin/cel.mustBuildEnvs
      11MB 0.028% 0.064% 25126.37MB 64.18%  k8s.io/apiserver/pkg/admission/plugin/cel.createEnvForOpts
   10.50MB 0.027% 0.091% 25100.49MB 64.11%  k8s.io/apiserver/pkg/cel/environment.(*EnvSet).Extend
       2MB 0.0051% 0.096% 23525.86MB 60.09%  k8s.io/apiserver/pkg/registry/generic/registry.(*Store).Update
         0     0% 0.096% 23520.86MB 60.08%  k8s.io/apiserver/pkg/registry/generic/registry.(*DryRunnableStorage).GuaranteedUpdate
    2.50MB 0.0064%   0.1% 23473.35MB 59.96%  k8s.io/apiserver/pkg/storage/etcd3.(*store).GuaranteedUpdate
```

For 100 workspaces post patch:

```
Fetching profile over HTTP from http://localhost:6060/debug/pprof/allocs
Saved profile in /Users/I567861/pprof/pprof.kcp.alloc_objects.alloc_space.inuse_objects.inuse_space.027.pb.gz
File: kcp
Type: alloc_space
Time: 2025-12-16 15:13:24 CET
Showing nodes accounting for 21MB, 0.16% of 13033.01MB total
Dropped 3768 nodes (cum <= 65.17MB)
Showing top 10 nodes out of 660
      flat  flat%   sum%        cum   cum%
         0     0%     0%  4883.15MB 37.47%  net/http.HandlerFunc.ServeHTTP
    1.50MB 0.012% 0.012%  4561.45MB 35.00%  k8s.io/apiserver/pkg/server.DefaultBuildHandlerChainFromStartToBeforeImpersonation.WithWarningRecorder.func7
       2MB 0.015% 0.027%  4552.44MB 34.93%  k8s.io/apiserver/pkg/endpoints/filterlatency.trackStarted.func1
         0     0% 0.027%  4529.44MB 34.75%  k8s.io/apiserver/pkg/server.DefaultBuildHandlerChainFromStartToBeforeImpersonation.TrackCompleted.trackCompleted.func20
       4MB 0.031% 0.058%  4528.94MB 34.75%  go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp.(*middleware).serveHTTP
         0     0% 0.058%  4528.94MB 34.75%  go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp.NewMiddleware.func1.1
    4.50MB 0.035% 0.092%  4459.92MB 34.22%  k8s.io/apiserver/pkg/endpoints/filters.WithTracing.func2
         0     0% 0.092%  4437.41MB 34.05%  k8s.io/apiserver/pkg/server.DefaultBuildHandlerChainFromStartToBeforeImpersonation.TrackCompleted.trackCompleted.func18
         0     0% 0.092%  4434.92MB 34.03%  k8s.io/apiserver/pkg/endpoints/filters.withAuthentication.func1
       9MB 0.069%  0.16%  4418.91MB 33.91%  k8s.io/apiserver/pkg/server.DefaultBuildHandlerChainFromImpersonationToAuthz.WithImpersonation.func3
```

A reduction of in total 26MiB for 100 workspaces.

Note that these values are with the in-memory embeddedetcd. Real values with dedicated etcd will be better.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
