### PR TITLE
UPSTREAM: <carry>: Use claster-aware key functions for ListWatch refl…

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/keyfunc.go
+++ b/staging/src/k8s.io/client-go/tools/cache/keyfunc.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2022 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+
+	"github.com/kcp-dev/logicalcluster/v3"
+)
+
+// TODO This file is copied from kcp's apimachinery to hotfix an issue
+// with the ListWatch reflector. The apimachinery namespacefunc cannot
+// be used because this causes an import-cycle.
+// At the latest for the next rebase this should be refactored so we can
+// pass the keyfunc into the reflector.
+
+// DeletionHandlingMetaClusterNamespaceKeyFunc checks for
+// DeletedFinalStateUnknown objects before calling
+// MetaClusterNamespaceKeyFunc.
+func DeletionHandlingMetaClusterNamespaceKeyFunc(obj interface{}) (string, error) {
+	if d, ok := obj.(DeletedFinalStateUnknown); ok {
+		return d.Key, nil
+	}
+	return MetaClusterNamespaceKeyFunc(obj)
+}
+
+// MetaClusterNamespaceKeyFunc is a convenient default KeyFunc which knows how to make
+// keys for API objects which implement meta.Interface.
+// The key uses the format <clusterName>|<namespace>/<name> unless <namespace> is empty, then
+// it's just <clusterName>|<name>, and if running in a single-cluster context where no explicit
+// cluster name is given, it's just <name>.
+func MetaClusterNamespaceKeyFunc(obj interface{}) (string, error) {
+	if key, ok := obj.(ExplicitKey); ok {
+		return string(key), nil
+	}
+	meta, err := meta.Accessor(obj)
+	if err != nil {
+		return "", fmt.Errorf("object has no meta: %v", err)
+	}
+	return ToClusterAwareKey(logicalcluster.From(meta).String(), meta.GetNamespace(), meta.GetName()), nil
+}
+
+// ToClusterAwareKey formats a cluster, namespace, and name as a key.
+func ToClusterAwareKey(cluster, namespace, name string) string {
+	var key string
+	if cluster != "" {
+		key += cluster + "|"
+	}
+	if namespace != "" {
+		key += namespace + "/"
+	}
+	key += name
+	return key
+}
+
+// SplitMetaClusterNamespaceKey returns the cluster name, namespace and
+// name that MetaClusterNamespaceKeyFunc encoded into key.
+func SplitMetaClusterNamespaceKey(key string) (clusterName logicalcluster.Name, namespace, name string, err error) {
+	invalidKey := fmt.Errorf("unexpected key format: %q", key)
+	outerParts := strings.Split(key, "|")
+	switch len(outerParts) {
+	case 1:
+		namespace, name, err := SplitMetaNamespaceKey(outerParts[0])
+		if err != nil {
+			err = invalidKey
+		}
+		return "", namespace, name, err
+	case 2:
+		namespace, name, err := SplitMetaNamespaceKey(outerParts[1])
+		if err != nil {
+			err = invalidKey
+		}
+		return logicalcluster.Name(outerParts[0]), namespace, name, err
+	default:
+		return "", "", "", invalidKey
+	}
+}

--- a/staging/src/k8s.io/client-go/tools/cache/reflector.go
+++ b/staging/src/k8s.io/client-go/tools/cache/reflector.go
@@ -208,7 +208,7 @@ func DefaultWatchErrorHandler(ctx context.Context, r *Reflector, err error) {
 // NewNamespaceKeyedIndexerAndReflector creates an Indexer and a Reflector
 // The indexer is configured to key on namespace
 func NewNamespaceKeyedIndexerAndReflector(lw ListerWatcher, expectedType interface{}, resyncPeriod time.Duration) (indexer Indexer, reflector *Reflector) {
-	indexer = NewIndexer(MetaNamespaceKeyFunc, Indexers{NamespaceIndex: MetaNamespaceIndexFunc})
+	indexer = NewIndexer(MetaClusterNamespaceKeyFunc, Indexers{NamespaceIndex: MetaNamespaceIndexFunc})
 	reflector = NewReflector(lw, expectedType, indexer, resyncPeriod)
 	return indexer, reflector
 }
@@ -754,7 +754,10 @@ func (r *Reflector) watchList(ctx context.Context) (watch.Interface, error) {
 
 		resourceVersion = ""
 		lastKnownRV := r.rewatchResourceVersion()
-		temporaryStore = NewStore(DeletionHandlingMetaNamespaceKeyFunc, storeOpts...)
+		// kcp modification: Use a cluster-aware key function. Without
+		// this, values from different clusters will just override each
+		// other.
+		temporaryStore = NewStore(DeletionHandlingMetaClusterNamespaceKeyFunc, storeOpts...)
 		// TODO(#115478): large "list", slow clients, slow network, p&f
 		//  might slow down streaming and eventually fail.
 		//  maybe in such a case we should retry with an increased timeout?


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Fix for https://github.com/kcp-dev/kcp/issues/3918 - basically kcp currently can't start from initialized etcd because the keyfunc in the reflector used for ListWatch just lets objects from different clusters override each other.

This is a quickfix to bring the keyfuncs from kcp apimachinery here to use - we cannot use them directly here because apimachinery's cache package imports this cache package.
So we'll have to fix that after KubeCon.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
