### PR TITLE
Fix missing KcpStorageMetadata in consistencyChecker

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
@@ -346,6 +346,9 @@ type Cacher struct {
 	// expiredBookmarkWatchers is a list of watchers that were expired and need to be schedule for a next bookmark event
 	expiredBookmarkWatchers []*cacheWatcher
 	compactor               *compactor
+
+	// kcp
+	kcpExtraStorageMetadata *storagebackend.KcpStorageMetadata
 }
 
 // NewCacherFromConfig creates a new Cacher responsible for servicing WATCH and LIST requests from
@@ -449,6 +452,7 @@ func NewCacherFromConfig(config Config) (*Cacher, error) {
 	watchCache := newWatchCache(
 		config.KeyFunc, cacher.processEvent, config.GetAttrsFunc, config.Versioner, config.Indexers,
 		config.Clock, eventFreshDuration, config.GroupResource, progressRequester, config.Storage.GetCurrentResourceVersion)
+	cacher.kcpExtraStorageMetadata = config.KcpExtraStorageMetadata
 	listerWatcher := NewListerWatcher(config.Storage, resourcePrefix, config.NewListFunc, contextMetadata, config.KcpExtraStorageMetadata)
 	reflectorName := "storage/cacher.go:" + resourcePrefix
 

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/delegator.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/delegator.go
@@ -35,11 +35,11 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/apiserver/pkg/audit"
-	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/features"
 	"k8s.io/apiserver/pkg/storage"
 	"k8s.io/apiserver/pkg/storage/cacher/delegator"
 	"k8s.io/apiserver/pkg/storage/cacher/metrics"
+	"k8s.io/apiserver/pkg/storage/storagebackend"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/component-base/tracing"
 	"k8s.io/klog/v2"
@@ -66,7 +66,7 @@ func NewCacheDelegator(cacher *Cacher, storage storage.Interface) *CacheDelegato
 		stopCh:  make(chan struct{}),
 	}
 	if utilfeature.DefaultFeatureGate.Enabled(features.DetectCacheInconsistency) || panicOnCacheInconsistency {
-		d.checker = newConsistencyChecker(cacher.resourcePrefix, cacher.groupResource, cacher.newListFunc, cacher, storage)
+		d.checker = newConsistencyChecker(cacher.resourcePrefix, cacher.groupResource, cacher.newListFunc, cacher, storage, cacher.kcpExtraStorageMetadata)
 		d.wg.Add(1)
 		go func() {
 			defer d.wg.Done()
@@ -291,20 +291,22 @@ func (c *CacheDelegator) Stop() {
 	c.wg.Wait()
 }
 
-func newConsistencyChecker(resourcePrefix string, groupResource schema.GroupResource, newListFunc func() runtime.Object, cacher cacher, etcd getLister) *consistencyChecker {
+func newConsistencyChecker(resourcePrefix string, groupResource schema.GroupResource, newListFunc func() runtime.Object, cacher cacher, etcd getLister, kcpStorageMetadata *storagebackend.KcpStorageMetadata) *consistencyChecker {
 	return &consistencyChecker{
-		groupResource:  groupResource,
-		resourcePrefix: resourcePrefix,
-		newListFunc:    newListFunc,
-		cacher:         cacher,
-		etcd:           etcd,
+		groupResource:       groupResource,
+		resourcePrefix:      resourcePrefix,
+		newListFunc:         newListFunc,
+		cacher:              cacher,
+		etcd:                etcd,
+		kcpStorageMetadata:  kcpStorageMetadata,
 	}
 }
 
 type consistencyChecker struct {
-	resourcePrefix string
-	groupResource  schema.GroupResource
-	newListFunc    func() runtime.Object
+	resourcePrefix     string
+	groupResource      schema.GroupResource
+	newListFunc        func() runtime.Object
+	kcpStorageMetadata *storagebackend.KcpStorageMetadata
 
 	cacher cacher
 	etcd   getLister
@@ -333,7 +335,7 @@ func (c consistencyChecker) startChecking(stopCh <-chan struct{}) {
 }
 
 func (c *consistencyChecker) check(ctx context.Context) {
-	ctx = genericapirequest.WithCluster(ctx, genericapirequest.Cluster{Wildcard: true})
+	ctx = createKCPClusterAwareContext(ctx, c.kcpStorageMetadata)
 	digests, err := c.calculateDigests(ctx)
 	if err != nil {
 		klog.ErrorS(err, "Cache consistency check error", "group", c.groupResource.Group, "resource", c.groupResource.Resource)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

This PR wires in kcpExtraStorageMetadata into storage/cacher and then into consistencyChecker.

Without it, ctx was only  decorated with cluster, but other request info was incorrectly being omitted, which confuses [`adjustClusterNameIfWildcard`](https://github.com/kcp-dev/kubernetes/blob/kcp-1.35.1/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_kcp.go#L34C6-L34C33). Specifically, storage paths with `/customresources/` segment would be classified as `CRDRequest=false`.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
