### PR TITLE
Fix calculating kcp storage annotations

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
@@ -879,7 +879,7 @@ func (s *store) GetList(ctx context.Context, key string, opts storage.ListOption
 
 			// kcp
 			clusterName := adjustClusterNameIfWildcard(shard, cluster, crdIndicator, keyPrefix, string(kv.Key))
-			shardName := adjustShardNameIfWildcard(shard, keyPrefix, string(kv.Key))
+			shardName := adjustShardNameIfWildcard(shard, cluster, crdIndicator, keyPrefix, string(kv.Key))
 			obj, err := s.decodeListItem(ctx, data, kv.ModRevision, s.codec, s.versioner, newItemFunc, clusterName, shardName)
 			if err != nil {
 				recordDecodeError(s.groupResource, string(kv.Key))

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_kcp.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_kcp.go
@@ -26,44 +26,124 @@ import (
 	"k8s.io/klog/v2"
 )
 
+// adjustKeyForPrefix returns storage path key stripped of its prefix, with corrections that
+// account for wildcards and partial metadata if they are part of the request. We need that
+// so the resulting key has a stable form, from which the shard and cluster name can be parsed.
+//
+// The key is in the following format:
+//
+//	<Storage prefix> / <Group> / <Resource> / [ <Identity or "customresources"> / ] [ <Shard> / ] <Cluster> / [ <Namespace> / ] <Name>
+//
+// The prefix is variable, and may include segments ranging from:
+//
+//	<Storage prefix> / <Group> / <Resource> /
+//
+// And up to:
+//
+//	<Storage prefix> / <Group> / <Resource> / [ <Identity or "customresources"> / ] [ <Shard> / ] <Cluster> /
+//
+// The exact prefix length depends on how inclusive the request is:
+//
+//   - Partial metadata requests accept any key with matching group-resource, regardless of its identity or
+//     CustomResource origin. This makes the prefix stop right after .../<Resource>/. Only applies if CRDRequest=true.
+//   - Shard wildcard requests accept any key with matching fully-qualified resource,
+//     which makes the prefix stop right after .../<Identity or "customresources">/ in case of CRDRequest=true,
+//     or right after .../<Resource>/ in case of CRDRequest=false.
+//   - Cluster wildcard requests accept any key with matching fully-qualified resource, which makes the prefix
+//     stop right .../<Shard>/, or .../<Identity or "customresources">/, or .../<Resource>/, depending on which
+//     of those is part of the request.
+//
+// This function checks all these cases, and returns the key in format:
+//
+//   - If the shard in request is a wildcard: <Shard> / <Cluster> / [ <Namespace> / ] <Name>
+//   - If the shard in request is empty or concrete:    <Cluster> / [ <Namespace> / ] <Name>
+func adjustKeyForPrefix(prefix, key string, crdRequest bool, cluster *genericapirequest.Cluster, shard genericapirequest.Shard) string {
+	popSegment := func(s string) string {
+		segmentStart := strings.IndexByte(s, '/')
+		if segmentStart < 0 {
+			return s
+		}
+		if segmentStart == len(s) {
+			return s
+		}
+		return s[segmentStart+1:]
+	}
+
+	keyWithoutPrefix := strings.TrimPrefix(key, prefix)
+
+	// This is what keyWithoutPrefix can now contain, if:
+	//
+	//   [ <Identity or "customresources"> / ] [ <Shard> / ] <Cluster> / [ <Namespace> / ] <Name>
+	//   ^                                     ^             ^           ^----------------------^
+	//   |                                     |             |                    |             |
+	//   |                                     |             |          (4) !cluster.Wildcard   |
+	//   |                                     |             +----------------------------------+
+	//   |                                     |                   |                            |
+	//   |                                     |            (3) shard.Empty()                   |
+	//   |                                     +------------------------------------------------+
+	//   |                                                 |                                    |
+	//   |                                        (2) !shard.Empty()                            |
+	//   +--------------------------------------------------------------------------------------+
+	//                  |
+	//          (1) cluster.PartialMetadataRequest (assumes crdRequest)
+
+	if !crdRequest || !cluster.PartialMetadataRequest {
+		// The prefix already includes <Identity or "customresources"> segment,
+		// or this is not a CRD request, so keyWithoutPrefix is clean.
+		return keyWithoutPrefix
+	}
+
+	// With partial metadata, the prefix ends BEFORE the identity segment.
+	keyWithoutIdentity := popSegment(keyWithoutPrefix)
+
+	if shard.Empty() || shard.Wildcard() {
+		// Shard needs to be part of the key if it is wildcard.
+		return keyWithoutIdentity
+	}
+
+	// We are scoped to a shard, but the <Shard> segment wasn't part of the prefix
+	// because of partial metadata ending it early, so we need to strip it from the key now.
+	keyWithoutShard := popSegment(keyWithoutIdentity)
+
+	return keyWithoutShard
+}
+
 // adjustClusterNameIfWildcard determines the logical cluster name. If this is not a cluster-wildcard list/watch request,
-// the cluster name is returned unmodified. Otherwise, the cluster name is extracted from the key based on whether it is
-// - a shard-wildcard request: <prefix>/shardName/clusterName/<remainder>
-// - CR partial metadata request: <prefix>/identity/clusterName/<remainder>
-// - any other request: <prefix>/clusterName/<remainder>.
+// the cluster name is returned unmodified. Otherwise, the cluster name is extracted from the storage key.
 func adjustClusterNameIfWildcard(shard genericapirequest.Shard, cluster *genericapirequest.Cluster, crdRequest bool, keyPrefix, key string) logicalcluster.Name {
 	if !cluster.Wildcard {
 		return cluster.Name
 	}
 
-	keyWithoutPrefix := strings.TrimPrefix(key, keyPrefix)
+	keyWithoutPrefix := adjustKeyForPrefix(keyPrefix, key, crdRequest, cluster, shard)
 	parts := strings.SplitN(keyWithoutPrefix, "/", 3)
 
 	extract := func(minLen, i int) logicalcluster.Name {
 		if len(parts) < minLen {
-			klog.Warningf("shard=%s cluster=%s invalid key=%s had %d parts, not %d", shard, cluster, keyWithoutPrefix, len(parts), minLen)
+			klog.Warningf("shard=%s cluster=%v invalid key=%s had %d parts, wanted %d", shard, cluster, keyWithoutPrefix, len(parts), minLen)
 			return ""
 		}
 		return logicalcluster.Name(parts[i])
 	}
 
-	switch {
-	case cluster.PartialMetadataRequest && crdRequest:
-		// expecting 2699f4d273d342adccdc8a32663408226ecf66de7d191113ed3d4dc9bccec2f2/root:org:ws/<remainder>
-		// OR customresources/root:org:ws/<remainder>
-		return extract(3, 1)
-	case shard.Wildcard():
-		// expecting shardName/clusterName/<remainder>
-		return extract(3, 1)
-	default:
-		// expecting root:org:ws/<remainder>
+	if !shard.Wildcard() {
+		// Shard is either empty or concrete. In both cases, adjustKeyForPrefix
+		// has already stripped it (along with <Identity> segment, if applicable).
+		//
+		// The remaining key is in format:
+		//   <Cluster> / <Remainder...>
 		return extract(2, 0)
 	}
+	// Shard is wildcard, and still present in the key.
+	//
+	// The remaining key is in format:
+	//   <Shard> / <Cluster> / <Remainder...>
+	return extract(3, 1)
 }
 
 // adjustShardNameIfWildcard determines a shard name. If this is not a shard-wildcard request,
 // the shard name is returned unmodified. Otherwise, the shard name is extracted from the storage key.
-func adjustShardNameIfWildcard(shard genericapirequest.Shard, keyPrefix, key string) genericapirequest.Shard {
+func adjustShardNameIfWildcard(shard genericapirequest.Shard, cluster *genericapirequest.Cluster, crdRequest bool, keyPrefix, key string) genericapirequest.Shard {
 	if !shard.Empty() && !shard.Wildcard() {
 		return shard
 	}
@@ -74,10 +154,13 @@ func adjustShardNameIfWildcard(shard genericapirequest.Shard, keyPrefix, key str
 		return ""
 	}
 
-	keyWithoutPrefix := strings.TrimPrefix(key, keyPrefix)
+	keyWithoutPrefix := adjustKeyForPrefix(keyPrefix, key, crdRequest, cluster, shard)
+
+	// The remaining key is in format:
+	//   <Shard> / <Cluster> / <Remainder...>
 	parts := strings.SplitN(keyWithoutPrefix, "/", 3)
 	if len(parts) < 3 {
-		klog.Warningf("unable to extract a shard name, invalid key=%s had %d parts, not %d", keyWithoutPrefix, len(parts), 3)
+		klog.Warningf("unable to extract a shard name, invalid key=%s had %d parts, wanted %d", keyWithoutPrefix, len(parts), 3)
 		return ""
 	}
 	return genericapirequest.Shard(parts[0])

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_kcp_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_kcp_test.go
@@ -53,12 +53,12 @@ func TestAdjustClusterNameIfWildcard(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			cluster := &genericapirequest.Cluster{
-				Name:                   logicalcluster.New("root:org:ws"),
+				Name:                   logicalcluster.Name("root:org:ws"),
 				PartialMetadataRequest: tc.partialMetadata,
 			}
 
 			if tc.wildcard {
-				cluster.Name = logicalcluster.Wildcard
+				cluster.Wildcard = true
 			}
 
 			key := "/registry/group/resource/identity/root:org:ws/somename"
@@ -79,52 +79,214 @@ func TestAdjustClusterNameIfWildcardWithShardSupport(t *testing.T) {
 	tests := map[string]struct {
 		cluster             genericapirequest.Cluster
 		shard               genericapirequest.Shard
+		crdRequest          bool
 		key                 string
 		keyPrefix           string
 		expectedClusterName string
 	}{
-		"not wildcard": {
-			cluster:             genericapirequest.Cluster{Name: logicalcluster.New("root:org:ws")},
+
+		// Built-in types.
+
+		"not wildcard, built-in type": {
+			cluster:             genericapirequest.Cluster{Name: logicalcluster.Name("root:org:ws")},
 			shard:               "amber",
-			key:                 "/registry/group/resource:identity/amber/root:org:ws/somename",
-			keyPrefix:           "/registry/group/resource:identity/",
-			expectedClusterName: "root:org:ws",
-		},
-		"both wildcard": {
-			cluster:             genericapirequest.Cluster{Name: logicalcluster.Wildcard},
-			shard:               "*",
-			key:                 "/registry/group/resource:identity/amber/root:org:ws/somename",
-			keyPrefix:           "/registry/group/resource:identity/",
+			key:                 "/registry/core/configmaps/amber/root:org:ws/somename",
+			keyPrefix:           "/registry/core/configmaps/amber/root:org:ws/",
 			expectedClusterName: "root:org:ws",
 		},
 		"both wildcard, built-in type": {
-			cluster:             genericapirequest.Cluster{Name: logicalcluster.Wildcard},
+			cluster:             genericapirequest.Cluster{Wildcard: true},
 			shard:               "*",
 			key:                 "/registry/core/configmaps/amber/root:org:ws/somename",
 			keyPrefix:           "/registry/core/configmaps/",
 			expectedClusterName: "root:org:ws",
 		},
-		"only cluster wildcard": {
-			cluster:             genericapirequest.Cluster{Name: logicalcluster.Wildcard},
-			shard:               "amber",
-			key:                 "/registry/group/resource:identity/amber/root:org:ws/somename",
-			keyPrefix:           "/registry/group/resource:identity/amber/",
-			expectedClusterName: "root:org:ws",
-		},
-		"only shard wildcard": {
-			cluster:             genericapirequest.Cluster{Name: logicalcluster.New("root:org:ws")},
+		"both wildcard, built-in type, partial": {
+			cluster:             genericapirequest.Cluster{Wildcard: true, PartialMetadataRequest: true},
 			shard:               "*",
 			key:                 "/registry/core/configmaps/amber/root:org:ws/somename",
-			keyPrefix:           "/registry/group/resource:identity/",
+			keyPrefix:           "/registry/core/configmaps/",
+			expectedClusterName: "root:org:ws",
+		},
+		"only cluster wildcard, built-in type": {
+			cluster:             genericapirequest.Cluster{Wildcard: true},
+			shard:               "amber",
+			key:                 "/registry/core/configmaps/amber/root:org:ws/somename",
+			keyPrefix:           "/registry/core/configmaps/amber/",
+			expectedClusterName: "root:org:ws",
+		},
+		"only cluster wildcard, built-in type, partial": {
+			cluster:             genericapirequest.Cluster{Wildcard: true, PartialMetadataRequest: true},
+			shard:               "amber",
+			key:                 "/registry/core/configmaps/amber/root:org:ws/somename",
+			keyPrefix:           "/registry/core/configmaps/amber/",
+			expectedClusterName: "root:org:ws",
+		},
+		"only shard wildcard, built-in type": {
+			cluster:             genericapirequest.Cluster{Name: logicalcluster.Name("root:org:ws")},
+			shard:               "*",
+			key:                 "/registry/core/configmaps/amber/root:org:ws/somename",
+			keyPrefix:           "/registry/core/configmaps",
+			expectedClusterName: "root:org:ws",
+		},
+
+		// CRD types.
+
+		"both wildcard, CRD": {
+			cluster:             genericapirequest.Cluster{Wildcard: true},
+			shard:               "*",
+			crdRequest:          true,
+			key:                 "/registry/group/resource/identity/amber/root:org:ws/somename",
+			keyPrefix:           "/registry/group/resource/identity/",
+			expectedClusterName: "root:org:ws",
+		},
+		"both wildcard, CRD, partial metadata": {
+			cluster:             genericapirequest.Cluster{Wildcard: true, PartialMetadataRequest: true},
+			shard:               "*",
+			crdRequest:          true,
+			key:                 "/registry/group/resource/identity/amber/root:org:ws/somename",
+			keyPrefix:           "/registry/group/resource/",
+			expectedClusterName: "root:org:ws",
+		},
+
+		"only cluster wildcard, CRD": {
+			cluster:             genericapirequest.Cluster{Wildcard: true},
+			shard:               "amber",
+			crdRequest:          true,
+			key:                 "/registry/group/resource/identity/amber/root:org:ws/somename",
+			keyPrefix:           "/registry/group/resource/identity/amber/",
+			expectedClusterName: "root:org:ws",
+		},
+		"only cluster wildcard, CRD, partial metadata": {
+			cluster:             genericapirequest.Cluster{Wildcard: true, PartialMetadataRequest: true},
+			shard:               "amber",
+			crdRequest:          true,
+			key:                 "/registry/group/resource/identity/amber/root:org:ws/somename",
+			keyPrefix:           "/registry/group/resource/",
+			expectedClusterName: "root:org:ws",
+		},
+
+		"only shard wildcard, CRD": {
+			cluster:             genericapirequest.Cluster{Name: logicalcluster.Name("root:org:ws")},
+			shard:               "*",
+			crdRequest:          true,
+			key:                 "/registry/group/resource/identity/amber/root:org:ws/somename",
+			keyPrefix:           "/registry/group/resource/identity/",
 			expectedClusterName: "root:org:ws",
 		},
 	}
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			clusterName := adjustClusterNameIfWildcard(tc.shard, &tc.cluster, false, tc.keyPrefix, tc.key)
+			clusterName := adjustClusterNameIfWildcard(tc.shard, &tc.cluster, tc.crdRequest, tc.keyPrefix, tc.key)
 			if tc.expectedClusterName != clusterName.String() {
 				t.Errorf("expected: %q, actual %q", tc.expectedClusterName, clusterName)
+			}
+		})
+	}
+}
+
+func TestAdjustShardNameIfWildcard(t *testing.T) {
+	tests := map[string]struct {
+		cluster       genericapirequest.Cluster
+		shard         genericapirequest.Shard
+		crdRequest    bool
+		key           string
+		keyPrefix     string
+		expectedShard genericapirequest.Shard
+	}{
+
+		// Built-in types.
+
+		"not wildcard, built-in type": {
+			cluster:       genericapirequest.Cluster{Name: logicalcluster.Name("root:org:ws")},
+			shard:         "amber",
+			key:           "/registry/group/resource/amber/root:org:ws/somename",
+			keyPrefix:     "/registry/group/resource/amber/root:org:ws/",
+			expectedShard: "amber",
+		},
+		"shard wildcard, built-in type": {
+			cluster:       genericapirequest.Cluster{Name: logicalcluster.Name("root:org:ws")},
+			shard:         "*",
+			key:           "/registry/group/resource/amber/root:org:ws/somename",
+			keyPrefix:     "/registry/group/resource/",
+			expectedShard: "amber",
+		},
+		"cluster wildcard, built-in type": {
+			cluster:       genericapirequest.Cluster{Wildcard: true},
+			shard:         "amber",
+			key:           "/registry/group/resource/amber/root:org:ws/somename",
+			keyPrefix:     "/registry/group/resource/amber/",
+			expectedShard: "amber",
+		},
+		"both wildcard, built-in type": {
+			cluster:       genericapirequest.Cluster{Wildcard: true},
+			shard:         "*",
+			key:           "/registry/group/resource/amber/root:org:ws/somename",
+			keyPrefix:     "/registry/group/resource/",
+			expectedShard: "amber",
+		},
+
+		// CRD types.
+
+		"not wildcard, CRD": {
+			crdRequest:    true,
+			cluster:       genericapirequest.Cluster{Name: logicalcluster.Name("root:org:ws")},
+			shard:         "amber",
+			key:           "/registry/group/resource/identity/amber/root:org:ws/somename",
+			keyPrefix:     "/registry/group/resource/identity/amber/root:org:ws/",
+			expectedShard: "amber",
+		},
+
+		"both wildcard, CRD": {
+			crdRequest:    true,
+			cluster:       genericapirequest.Cluster{Wildcard: true},
+			shard:         "*",
+			key:           "/registry/group/resource/identity/amber/root:org:ws/somename",
+			keyPrefix:     "/registry/group/resource/identity/",
+			expectedShard: "amber",
+		},
+		"both wildcard, CRD, partial metadata request": {
+			crdRequest:    true,
+			cluster:       genericapirequest.Cluster{Wildcard: true, PartialMetadataRequest: true},
+			shard:         "*",
+			key:           "/registry/group/resource/identity/amber/root:org:ws/somename",
+			keyPrefix:     "/registry/group/resource/",
+			expectedShard: "amber",
+		},
+
+		"only cluster wildcard, CRD": {
+			cluster:       genericapirequest.Cluster{Wildcard: true},
+			shard:         "amber",
+			crdRequest:    true,
+			key:           "/registry/group/resource/identity/amber/root:org:ws/somename",
+			keyPrefix:     "/registry/group/resource/",
+			expectedShard: "amber",
+		},
+		"only cluster wildcard, CRD, partial metadata request": {
+			cluster:       genericapirequest.Cluster{Wildcard: true, PartialMetadataRequest: true},
+			shard:         "amber",
+			crdRequest:    true,
+			key:           "/registry/group/resource/identity/amber/root:org:ws/somename",
+			keyPrefix:     "/registry/group/resource/",
+			expectedShard: "amber",
+		},
+
+		"only shard wildcard, CRD": {
+			cluster:       genericapirequest.Cluster{Name: logicalcluster.Name("root:org:ws")},
+			shard:         "*",
+			crdRequest:    true,
+			key:           "/registry/group/resource/identity/amber/root:org:ws/somename",
+			keyPrefix:     "/registry/group/resource/identity/",
+			expectedShard: "amber",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			shardName := adjustShardNameIfWildcard(tc.shard, &tc.cluster, tc.crdRequest, tc.keyPrefix, tc.key)
+			if tc.expectedShard != shardName {
+				t.Errorf("expected: %q, actual %q", tc.expectedShard, shardName)
 			}
 		})
 	}

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher.go
@@ -733,7 +733,7 @@ func (wc *watchChan) prepareObjs(e *event) (curObj runtime.Object, oldObj runtim
 
 		// kcp: apply clusterName to the decoded object, as the name is not persisted in storage.
 		clusterName := adjustClusterNameIfWildcard(wc.shard, wc.cluster, wc.crdRequest, wc.key, e.key)
-		shardName := adjustShardNameIfWildcard(wc.shard, wc.key, e.key)
+		shardName := adjustShardNameIfWildcard(wc.shard, wc.cluster, wc.crdRequest, wc.key, e.key)
 		annotateDecodedObjectWith(curObj, clusterName, shardName)
 	}
 	// We need to decode prevValue, only if this is deletion event or
@@ -755,7 +755,7 @@ func (wc *watchChan) prepareObjs(e *event) (curObj runtime.Object, oldObj runtim
 
 		// kcp: apply clusterName to the decoded object, as the name is not persisted in storage.
 		clusterName := adjustClusterNameIfWildcard(wc.shard, wc.cluster, wc.crdRequest, wc.key, e.key)
-		shardName := adjustShardNameIfWildcard(wc.shard, wc.key, e.key)
+		shardName := adjustShardNameIfWildcard(wc.shard, wc.cluster, wc.crdRequest, wc.key, e.key)
 		annotateDecodedObjectWith(oldObj, clusterName, shardName)
 	}
 	return curObj, oldObj, nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

The [adjustClusterNameIfWildcard and adjustShardNameIfWildcard](https://github.com/kcp-dev/kubernetes/blob/kcp-1.35.1/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_kcp.go) funcs are confused when an etcd key contains shard name, an identity, and it's a partial metadata request.

Identities are used in https://github.com/kcp-dev/kcp/issues/3827 to distinguish between the different GVR owners of a cached resource.

This PR fixes that and updates the unit test.

Needs https://github.com/kcp-dev/kubernetes/pull/190

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
