### PR TITLE
UPSTREAM: <carry>: Implement cluster-aware VAP parameter informers

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/generic/policy_source.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/generic/policy_source.go
@@ -419,13 +419,16 @@ func (s *policySource[P, B, E]) ensureParamsForPolicyLocked(paramSource *schema.
 	// Try to see if our provided informer factory has an informer for this type.
 	// We assume the informer is already started, and starts all types associated
 	// with it.
-	if genericInformer, err := s.informerFactory.ForResource(mapping.Resource); err == nil {
-		informer = genericInformer
+	if s.informerFactory != nil {
+		if genericInformer, err := s.informerFactory.ForResource(mapping.Resource); err == nil {
+			informer = genericInformer
 
-		// Start the informer
-		s.informerFactory.Start(instanceContext.Done())
+			// Start the informer
+			s.informerFactory.Start(instanceContext.Done())
+		}
+	}
 
-	} else {
+	if informer == nil {
 		// Dynamic JSON informer fallback.
 		// Cannot use shared dynamic informer since it would be impossible
 		// to clean CRD informers properly with multiple dependents

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/validating/plugin.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/validating/plugin.go
@@ -93,7 +93,7 @@ func NewPlugin(_ io.Reader) *Plugin {
 					NewValidatingAdmissionPolicyAccessor,
 					NewValidatingAdmissionPolicyBindingAccessor,
 					CompilePolicy,
-					nil, // TODO(embik): this was done in accordance with d0a7ccbaac22d32f219b4a2c4944e72e507c3d14.
+					f,
 					dynamicClient,
 					restMapper,
 					clusterName,


### PR DESCRIPTION
There is a feature in ValidatingAdmissionPolicies (VAPs) which allows you to specify arbitrary resources (e.g. configmaps) to be used as parameters. These resources need to be watched in a cluster aware manner.

This implementation uses by default cluster dynamic informers to watch the resources. Alternatively a specific SharedInformerFactory can be supplied.

This was the closest I was able to get it to match the upstream code.

In kcp itself no change should be done, as we want the cluster dynamic fallback/default. I would add in a separate PR though, that this triggers the fallback (just a little code comment).

https://github.com/kcp-dev/kcp/blob/8ef4002e6271898d2bab44010c801945c32138b6/pkg/admission/validatingadmissionpolicy/validating_admission_policy.go#L275

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
