### PR TITLE
registry: derive object key from its own scope, not the store's scope

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
@@ -1655,12 +1655,14 @@ func (e *Store) CompleteWithOptions(options *generic.StoreOptions) error {
 		if err != nil {
 			return "", err
 		}
+		name := accessor.GetName()
+		namespace := accessor.GetNamespace()
 
-		if isNamespaced {
-			return e.KeyFunc(genericapirequest.WithNamespace(ctx, accessor.GetNamespace()), accessor.GetName())
+		if isNamespaced && namespace != "" {
+			return e.KeyFunc(genericapirequest.WithNamespace(ctx, namespace), name)
 		}
 
-		return e.KeyFunc(ctx, accessor.GetName())
+		return NoNamespaceKeyFunc(ctx, prefix, name)
 	}
 
 	if e.DeleteCollectionWorkers == 0 {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
(arguably)

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

A wildcard partial-metadata watch cache can span several CRDs/identities of the same group-resource, mixing namespaced and cluster-scoped instances under one storage with a single fixed 'isNamespaced' flag. This can happen if a CRD scope changed but the GVR was kept - e.g. multiple ARS for the same GVR but different schemas and objects in etcd. Keying a cluster-scoped object through a namespaced can then fail with "Namespace parameter required".

Use the object as the source of truth - an empty namespace is keyed under no-namespace and namespaced objects still carry their namespace.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

xref
- https://github.com/kcp-dev/kcp/issues/4330

#### Special notes for your reviewer:

maybe this can be amended on top of 572d77d9de471. that commit clusterized the registry store and it shares the same complexity of being upstreamed.

the root of the problem lies in the linked issue. the user created one CRD that is cluster scoped, exported it, consumers bound to it and created instances. the user changed the CRD to namespaced, created new ARS, same GVR, users created more instances.

- multiple CRDs, same GVR, different scopes, multiple instances
- the indexer [here](https://github.com/kcp-dev/kcp/blob/release-0.32/pkg/informer/informer.go#L1047-L1048) is non-deterministicl; it picks the first one, but that comes from a `map[idx]...`, so they either get a fixed `isNamespaced` scoped indexer or not, which seems like a bug to me. also the comment there seems wrong given the multiple same GVRs can exist after a cross-WS list.
- fixing in downstream kcp's informer is not ideal as it means we need some sort of a bias there and also  likely wrongly key objects, IIUC.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
